### PR TITLE
Add Interval(::Interval) constructor.

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -134,6 +134,7 @@ end
 Interval(s::GreaterThan{<:AbstractFloat}) = Interval(s.lower, typemax(s.lower))
 Interval(s::LessThan{<:AbstractFloat}) = Interval(typemin(s.upper), s.upper)
 Interval(s::EqualTo{<:Real}) = Interval(s.value, s.value)
+Interval(s::Interval) = s
 
 """
     SecondOrderCone(dimension)

--- a/test/interval.jl
+++ b/test/interval.jl
@@ -14,4 +14,6 @@
     @test_throws MethodError MOI.Interval(MOI.GreaterThan(1))
     @test_throws MethodError MOI.Interval(MOI.LessThan(2))
     @test MOI.Interval(MOI.EqualTo(3)) === MOI.Interval(3, 3)
+
+    @test MOI.Interval(MOI.Interval(1, 2)) == MOI.Interval(1, 2)
 end


### PR DESCRIPTION
For convenience. This worked already on 0.6, but produces a depwarn on 0.7 due to the constructor/convert changes.