### PR TITLE
Populate NEWS for v0.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 MathOptInterface (MOI) release notes
 ====================================
 
-v0.6.0 (August 25, 2018)
+v0.6.0 (August ??, 2018)
 -----------------------
 
 - Rename functions according to the [JuMP's style guide](http://www.juliaopt.org/JuMP.jl/latest/style.html):


### PR DESCRIPTION
Assuming #496, #497 and #498 get merged, this PR adds the changes since https://github.com/JuliaOpt/MathOptInterface.jl/pull/471.
Any objection to tag MOI v0.6 once #496, #497 and #498 are merged ?