### PR TITLE
Add allow_modify_function to add_constraint

### DIFF
--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -839,10 +839,10 @@ will additionally support `ScalarAffineFunction`-in-`Interval`.
 
 Solver-specific attributes should either be passed to the optimizer on creation,
 e.g., `MyPackage.Optimizer(PrintLevel = 0)`, or through a sub-type of
-[`AbstractSolverAttribute`](@ref). For example, inside `MyPackage`, we could add
+[`AbstractOptimizerAttribute`](@ref). For example, inside `MyPackage`, we could add
 the following:
 ```julia
-struct PrintLevel <: MOI.AbstractSolverAttribute end
+struct PrintLevel <: MOI.AbstractOptimizerAttribute end
 function MOI.set(model::Optimizer, ::PrintLevel, level::Int)
     # ... set the print level ...
 end

--- a/src/Bridges/bridgeoptimizer.jl
+++ b/src/Bridges/bridgeoptimizer.jl
@@ -290,13 +290,16 @@ function MOI.supports_constraint(b::AbstractBridgeOptimizer,
     end
 end
 function MOI.add_constraint(b::AbstractBridgeOptimizer, f::MOI.AbstractFunction,
-                            s::MOI.AbstractSet)
+                            s::MOI.AbstractSet;
+                            allow_modify_function::Bool=false)
     if is_bridged(b, typeof(f), typeof(s))
-        ci = MOI.add_constraint(b.bridged, f, s)
+        ci = MOI.add_constraint(b.bridged, f, s;
+                                allow_modify_function=allow_modify_function)
         @assert !haskey(b.bridges, ci)
         b.bridges[ci] = concrete_bridge_type(b, typeof(f), typeof(s))(b, f, s)
         return ci
     else
+        # TODO pass `allow_modify_function` in MOI v0.7
         return MOI.add_constraint(b.model, f, s)
     end
 end

--- a/src/Utilities/constraints.jl
+++ b/src/Utilities/constraints.jl
@@ -13,6 +13,7 @@ function add_scalar_constraint end
 function add_scalar_constraint(model::MOI.ModelLike, func::MOI.SingleVariable,
                                set::MOI.AbstractScalarSet;
                                allow_modify_function::Bool=false)
+    # TODO pass allow_modify_function in MOI v0.7
     return MOI.add_constraint(model, func, set)
 end
 function add_scalar_constraint(model::MOI.ModelLike,
@@ -25,5 +26,6 @@ function add_scalar_constraint(model::MOI.ModelLike,
         func = copy(func)
     end
     func.constant = zero(T)
+    # TODO pass allow_modify_function in MOI v0.7
     return MOI.add_constraint(model, func, set)
 end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -142,6 +142,7 @@ function copyconstraints!(dest::MOI.ModelLike, src::MOI.ModelLike, copy_names::B
         f_src = MOI.get(src, MOI.ConstraintFunction(), ci_src)
         f_dest = mapvariables(idxmap, f_src)
         s = MOI.get(src, MOI.ConstraintSet(), ci_src)
+        # TODO explicitely pass `allow_modify_function=false` in MOI v0.7
         ci_dest = MOI.add_constraint(dest, f_dest, s)
         idxmap.conmap[ci_src] = ci_dest
     end

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -93,9 +93,13 @@ function MOI.add_variables(mock::MockOptimizer, n::Int)
 end
 function MOI.add_constraint(mock::MockOptimizer,
                             func::MOI.AbstractFunction,
-                            set::MOI.AbstractSet)
+                            set::MOI.AbstractSet;
+                            allow_modify_function::Bool=false)
     if mock.add_con_allowed
-        ci = MOI.add_constraint(mock.inner_model, xor_variables(func), set)
+        # `xor_variables` returns a copy so the inner model is allowed to modify
+        # it
+        ci = MOI.add_constraint(mock.inner_model, xor_variables(func), set,
+                                allow_modify_function=true)
         return xor_index(ci)
     else
         throw(MOI.AddConstraintNotAllowed{typeof(func), typeof(set)}())

--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -250,6 +250,7 @@ function loadfromstring!(model, s)
             else
                 error("Unrecognized expression $ex")
             end
+            # TODO pass `allow_modify_function=true` in MOI v0.7
             cindex = MOI.add_constraint(model, f, set)
             MOI.set(model, MOI.ConstraintName(), cindex, String(label))
         end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -40,22 +40,28 @@ AddConstraintNotAllowed{F, S}() where {F, S} = AddConstraintNotAllowed{F, S}("")
 operation_name(::AddConstraintNotAllowed{F, S}) where {F, S} = "Adding `$F`-in-`$S` constraints"
 
 """
-    add_constraint(model::ModelLike, func::F, set::S)::ConstraintIndex{F,S} where {F,S}
+    add_constraint(model::ModelLike, func::F, set::S;
+                   allow_modify_function::Bool=false)::ConstraintIndex{F,S}
 
-Add the constraint ``f(x) \\in \\mathcal{S}`` where ``f`` is defined by `func`, and ``\\mathcal{S}`` is defined by `set`.
+Add the constraint ``f(x) \\in \\mathcal{S}`` where ``f`` is defined by `func`,
+and ``\\mathcal{S}`` is defined by `set`. If `allow_modify_function` is `true`
+then the function `func`, can be modified.
 
-    add_constraint(model::ModelLike, v::VariableIndex, set::S)::ConstraintIndex{SingleVariable,S} where {S}
-    add_constraint(model::ModelLike, vec::Vector{VariableIndex}, set::S)::ConstraintIndex{VectorOfVariables,S} where {S}
+    add_constraint(model::ModelLike, v::VariableIndex,
+                   set::S)::ConstraintIndex{SingleVariable,S} where {S}
+    add_constraint(model::ModelLike, vec::Vector{VariableIndex},
+                   set::S)::ConstraintIndex{VectorOfVariables,S} where {S}
 
-Add the constraint ``v \\in \\mathcal{S}`` where ``v`` is the variable (or vector of variables) referenced by `v` and ``\\mathcal{S}`` is defined by `set`.
+Add the constraint ``v \\in \\mathcal{S}`` where ``v`` is the variable (or
+vector of variables) referenced by `v` and ``\\mathcal{S}`` is defined by `set`.
 
 An [`UnsupportedConstraint`](@ref) error is thrown if `model` does not support
-`F`-in-`S` constraints and a [`AddConstraintNotAllowed`](@ref) error is thrown if
-it supports `F`-in-`S` constraints but it cannot add the constraint(s) in its
+`F`-in-`S` constraints and a [`AddConstraintNotAllowed`](@ref) error is thrown
+if it supports `F`-in-`S` constraints but it cannot add the constraint(s) in its
 current state.
 """
 function add_constraint(model::ModelLike, func::AbstractFunction,
-                        set::AbstractSet)
+                        set::AbstractSet; allow_modify_function::Bool=false)
     throw_add_constraint_error_fallback(model, func, set)
 end
 

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -282,3 +282,9 @@ for state in (MOIU.NoOptimizer, MOIU.EmptyOptimizer, MOIU.AttachedOptimizer)
         end
     end
 end
+
+@testset "add_constraint copy function test" begin
+    model = MOIU.CachingOptimizer(ModelForCachingOptimizer{Float64}(),
+                                  MOIU.Manual)
+    MOIT.add_constraint_copy_function_test(model)
+end

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -9,6 +9,11 @@ end
     MOIT.default_status_test(model)
 end
 
+@testset "add_constraint copy function test" begin
+    model = MOIU.MockOptimizer(ModelForMock{Float64}())
+    MOIT.add_constraint_copy_function_test(model)
+end
+
 @testset "Mock optimizer name test" begin
     MOIT.nametest(MOIU.MockOptimizer(ModelForMock{Float64}()))
 end

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -17,6 +17,10 @@ end
     MOIT.supports_constrainttest(Model{Int}(), Int, Float64)
 end
 
+@testset "add_constraint copy function test" begin
+    MOIT.add_constraint_copy_function_test(Model{Float64}())
+end
+
 @testset "OrderedIndices" begin
     MOIT.orderedindicestest(Model{Float64}())
 end

--- a/test/Utilities/universalfallback.jl
+++ b/test/Utilities/universalfallback.jl
@@ -73,6 +73,12 @@ struct UnknownOptimizerAttribute <: MOI.AbstractOptimizerAttribute end
         MOI.empty!(uf)
         @test MOI.is_empty(uf)
     end
+    @testset "add_constraint copy function test" begin
+        # `EqualTo` is not supported by `ModelForUniversalFallback` but
+        # `LessThan` is supported
+        MOIT.add_constraint_copy_function_test(uf, set=MOI.EqualTo(0.0))
+        MOIT.add_constraint_copy_function_test(uf, set=MOI.LessThan(0.0))
+    end
     @testset "Start Values Test" begin
         src = MOIU.UniversalFallback(Model{Float64}())
         dest = MOIU.UniversalFallback(Model{Float64}())


### PR DESCRIPTION
When this keyword argument is set, the model does not have to copy the function in argument if it want to store it or modify it. It is similar to
https://github.com/JuliaOpt/MathOptInterface.jl/blob/6dcee0bda0c870380576ddd56194dbd21efe3798/src/Utilities/constraints.jl#L5
For instance, in `JuMP.add_constraint`, an MOI function is created, sent to the model which copies it but then JuMP discards the original function. The function is therefore copied for nothing!
`MOIU.AbstractModel` implements `add_constraint` with this keyword argument but the rest of `MOIU` avoids using it at places where the solver is used to avoid breakage.
I have left TODO for these spots so that we can change it before we release MOI v0.7.

Here is a benchmark which shows the speedup.
```julia
function time_add(model, f, s, c)
    @btime MOI.add_constraint($model, $f, $s, allow_modify_function=$c)
end
function bench()
    model = Model()
    x = @variable(model)
    y = @variable(model)
    f = JuMP.moi_function(x + y)
    s = MOI.EqualTo(0.0)
    time_add(JuMP.backend(model), f, s, true)
    time_add(JuMP.backend(model), f, s, false)
    return
end
bench()

# output
  67.566 ns (3 allocations: 64 bytes)
  159.491 ns (5 allocations: 208 bytes)
```