### PR TITLE
Add Bridges.ListOfNonstandardBridges attribute

### DIFF
--- a/docs/src/submodules/Bridges/reference.md
+++ b/docs/src/submodules/Bridges/reference.md
@@ -60,9 +60,10 @@ Bridges.inverse_adjoint_map_function
 
 ```@docs
 Bridges.Constraint.FlipSignBridge
+Bridges.Constraint.AbstractToIntervalBridge
 Bridges.Constraint.GreaterToIntervalBridge
-Bridges.Constraint.GreaterToLessBridge
 Bridges.Constraint.LessToIntervalBridge
+Bridges.Constraint.GreaterToLessBridge
 Bridges.Constraint.LessToGreaterBridge
 Bridges.Constraint.NonnegToNonposBridge
 Bridges.Constraint.NonposToNonnegBridge

--- a/docs/src/submodules/Bridges/reference.md
+++ b/docs/src/submodules/Bridges/reference.md
@@ -25,7 +25,7 @@ Bridges.add_bridge
 Bridges.remove_bridge
 Bridges.has_bridge
 Bridges.full_bridge_optimizer
-Bridges.ToAdd
+Bridges.ListOfNonstandardBridges
 Bridges.debug_supports_constraint
 Bridges.debug_supports
 Bridges.bridged_variable_function

--- a/docs/src/submodules/Bridges/reference.md
+++ b/docs/src/submodules/Bridges/reference.md
@@ -25,6 +25,7 @@ Bridges.add_bridge
 Bridges.remove_bridge
 Bridges.has_bridge
 Bridges.full_bridge_optimizer
+Bridges.ToAdd
 Bridges.debug_supports_constraint
 Bridges.debug_supports
 Bridges.bridged_variable_function

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -23,16 +23,69 @@ include("debug.jl")
 """
     full_bridge_optimizer(model::MOI.ModelLike, ::Type{T}) where {T}
 
-Returns a `LazyBridgeOptimizer` bridging `model` for every bridge defined in
-this package and for the coefficient type `T`.
+Returns a [`LazyBridgeOptimizer`](@ref) bridging `model` for every bridge
+defined in this package (see below for the few exceptions) and for the
+coefficient type `T` in addition to the bridges in the list returned by
+`MOI.get(model, MOI.Bridges.ToAdd{T}())`.
+
+See also [`ToAdd`](@ref).
+
+!!! note
+    The following bridges are not added by `full_bridge_optimizer` except if
+    they are in the list returned by `MOI.get(model, MOI.Bridges.ToAdd{T}())`
+    (see the docstrings of the corresponding bridge for the reason they are not
+    added):
+    * [`Constraint.SOCtoNonConvexQuad`](@ref),
+      [`Constraint.RSOCtoNonConvexQuad`](@ref) and
+      [`Constraint.SOCtoPSDBridge`](@ref).
+    * The subtypes of [`Constraint.AbstractToIntervalBridge`](@ref) (i.e.
+      [`Constraint.GreaterToIntervalBridge`](@ref) and
+      [`Constraint.LessToIntervalBridge`](@ref)) if `T` is not a subtype of
+      `AbstractFloat`.
 """
 function full_bridge_optimizer(model::MOI.ModelLike, ::Type{T}) where {T}
     bridged_model = LazyBridgeOptimizer(model)
+    for BT in MOI.get(model, ToAdd{T}())
+        MOIB.add_bridge(bridged_model, BT)
+    end
     Variable.add_all_bridges(bridged_model, T)
     Constraint.add_all_bridges(bridged_model, T)
     Objective.add_all_bridges(bridged_model, T)
     return bridged_model
 end
+
+"""
+    ToAdd{T}()
+
+A list of additional bridges that should be added to the
+[`LazyBridgeOptimizer`](@ref) in `full_bridge_optimizer(optimizer, T)`.
+
+See also [`full_bridge_optimizer`](@ref).
+
+## Examples
+
+Suppose an optimizer can exploit specific structure of a constraint.
+For instance, suppose it can exploit the structure of the matrix `A`
+in the linear system of equations `A * x = b`.
+The optimizer can create a function:
+```julia
+struct MatrixAffineFunction{T,M<:AbstractMatrix{T}} <: MOI.AbstractVectorFunction
+    A::M
+    b::Vector{T}
+end
+```
+and then a bridge from `VectorAffineFunction{T}` to
+`MatrixAffineFunction{T,SparseMatrixCSC{T,Int}}`.
+The bridge is then included in the list returned as the value of the
+`ToAdd` attribute. That way, the optimizer can exploit a specific matrix
+structure if the user uses a `MatrixAffineFunction` and in case the user uses
+`VectorAffineFunction` then it's automatically bridged.
+"""
+struct ToAdd{T} <: MOI.AbstractOptimizerAttribute end
+
+MOI.is_copyable(::ToAdd) = false
+
+MOI.get(model::MOI.ModelLike, ::ToAdd) = []
 
 print_num_bridges(io::IO, ::Variable.EmptyMap) = nothing
 

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -46,7 +46,7 @@ See also [`ListOfNonstandardBridges`](@ref).
 function full_bridge_optimizer(model::MOI.ModelLike, ::Type{T}) where {T}
     bridged_model = LazyBridgeOptimizer(model)
     for BT in MOI.get(model, ListOfNonstandardBridges{T}())
-        MOIB.add_bridge(bridged_model, BT)
+        add_bridge(bridged_model, BT)
     end
     Variable.add_all_bridges(bridged_model, T)
     Constraint.add_all_bridges(bridged_model, T)

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -26,17 +26,17 @@ include("debug.jl")
 Returns a [`LazyBridgeOptimizer`](@ref) bridging `model` for every bridge
 defined in this package (see below for the few exceptions) and for the
 coefficient type `T` in addition to the bridges in the list returned by
-`MOI.get(model, MOI.Bridges.ToAdd{T}())`.
+`MOI.get(model, MOI.Bridges.ListOfNonstandardBridges{T}())`.
 
-See also [`ToAdd`](@ref).
+See also [`ListOfNonstandardBridges`](@ref).
 
 !!! note
     The following bridges are not added by `full_bridge_optimizer` except if
-    they are in the list returned by `MOI.get(model, MOI.Bridges.ToAdd{T}())`
+    they are in the list returned by `MOI.get(model, MOI.Bridges.ListOfNonstandardBridges{T}())`
     (see the docstrings of the corresponding bridge for the reason they are not
     added):
-    * [`Constraint.SOCtoNonConvexQuad`](@ref),
-      [`Constraint.RSOCtoNonConvexQuad`](@ref) and
+    * [`Constraint.SOCtoNonConvexQuadBridge`](@ref),
+      [`Constraint.RSOCtoNonConvexQuadBridge`](@ref) and
       [`Constraint.SOCtoPSDBridge`](@ref).
     * The subtypes of [`Constraint.AbstractToIntervalBridge`](@ref) (i.e.
       [`Constraint.GreaterToIntervalBridge`](@ref) and
@@ -45,7 +45,7 @@ See also [`ToAdd`](@ref).
 """
 function full_bridge_optimizer(model::MOI.ModelLike, ::Type{T}) where {T}
     bridged_model = LazyBridgeOptimizer(model)
-    for BT in MOI.get(model, ToAdd{T}())
+    for BT in MOI.get(model, ListOfNonstandardBridges{T}())
         MOIB.add_bridge(bridged_model, BT)
     end
     Variable.add_all_bridges(bridged_model, T)
@@ -55,37 +55,78 @@ function full_bridge_optimizer(model::MOI.ModelLike, ::Type{T}) where {T}
 end
 
 """
-    ToAdd{T}()
+    ListOfNonstandardBridges{T}() <: MOI.AbstractOptimizerAttribute
 
-A list of additional bridges that should be added to the
-[`LazyBridgeOptimizer`](@ref) in `full_bridge_optimizer(optimizer, T)`.
+Any optimizer can be wrapped in a [`LazyBridgeOptimizer`](@ref) using
+[`full_bridge_optimizer`](@ref). However, by default [`LazyBridgeOptimizer`](@ref)
+uses a limited set of bridges that are:
 
-See also [`full_bridge_optimizer`](@ref).
+  1. implemented in `MOI.Bridges`
+  2. generally applicable for all optimizers.
+
+For some optimizers however, it is useful to add additional bridges, such as
+those that are implemented in external packages (e.g., within the solver package
+itself) or only apply in certain circumstances (e.g.,
+[`Constraint.SOCtoNonConvexQuadBridge`](@ref)).
+
+Such optimizers should implement the `ListOfNonstandardBridges` attribute to
+return a vector of bridge types that are added by [`full_bridge_optimizer`](@ref)
+in addition to the list of default bridges.
+
+Note that optimizers implementing `ListOfNonstandardBridges` may be unusable
+if the non-standard bridges are not added.
 
 ## Examples
 
-Suppose an optimizer can exploit specific structure of a constraint.
-For instance, suppose it can exploit the structure of the matrix `A`
-in the linear system of equations `A * x = b`.
-The optimizer can create a function:
+### An optimizer using a non-default bridge in `MOI.Bridges`
+
+Solvers supporting [`MOI.ScalarQuadraticFunction`](@ref) can support
+[`MOI.SecondOrderCone`](@ref) and [`MOI.RotatedSecondOrderCone`](@ref) by
+defining:
 ```julia
-struct MatrixAffineFunction{T,M<:AbstractMatrix{T}} <: MOI.AbstractVectorFunction
-    A::M
+function MOI.get(::MyQuadraticOptimizer, ::ListOfNonstandardBridges{Float64})
+    return Type[
+        MOI.Bridges.Constraint.SOCtoNonConvexQuadBridge{Float64},
+        MOI.Bridges.Constraint.RSOCtoNonConvexQuadBridge{Float64},
+    ]
+end
+```
+
+### An optimizer defining an internal bridge
+
+Suppose an optimizer can exploit specific structure of a constraint, e.g., it
+can exploit the structure of the matrix `A` in the linear system of equations
+`A * x = b`.
+
+The optimizer can define the function:
+```julia
+struct MatrixAffineFunction{T} <: MOI.AbstractVectorFunction
+    A::SomeStructuredMatrixType{T}
     b::Vector{T}
 end
 ```
-and then a bridge from `VectorAffineFunction{T}` to
-`MatrixAffineFunction{T,SparseMatrixCSC{T,Int}}`.
-The bridge is then included in the list returned as the value of the
-`ToAdd` attribute. That way, the optimizer can exploit a specific matrix
-structure if the user uses a `MatrixAffineFunction` and in case the user uses
-`VectorAffineFunction` then it's automatically bridged.
+and then a bridge
+```julia
+struct MatrixAffineFunctionBridge{T} <: MOI.Constraint.AbstractBridge
+    # ...
+end
+# ...
+```
+from `VectorAffineFunction{T}` to the `MatrixAffineFunction`. Finally, it
+defines:
+```julia
+function MOI.get(::Optimizer{T}, ::ListOfNonstandardBridges{T}) where {T}
+    return Type[MatrixAffineFunctionBridge{T}]
+end
+```
 """
-struct ToAdd{T} <: MOI.AbstractOptimizerAttribute end
+struct ListOfNonstandardBridges{T} <: MOI.AbstractOptimizerAttribute end
 
-MOI.is_copyable(::ToAdd) = false
+attribute_value_type(::ListOfNonstandardBridges) = Vector{Type}
 
-MOI.get(model::MOI.ModelLike, ::ToAdd) = []
+MOI.is_copyable(::ListOfNonstandardBridges) = false
+
+MOI.get_fallback(model::MOI.ModelLike, ::ListOfNonstandardBridges) = Type[]
 
 print_num_bridges(io::IO, ::Variable.EmptyMap) = nothing
 

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -73,8 +73,12 @@ Such optimizers should implement the `ListOfNonstandardBridges` attribute to
 return a vector of bridge types that are added by [`full_bridge_optimizer`](@ref)
 in addition to the list of default bridges.
 
-Note that optimizers implementing `ListOfNonstandardBridges` may be unusable
-if the non-standard bridges are not added.
+Note that optimizers implementing `ListOfNonstandardBridges` may require
+package-specific functions or sets to be used if the non-standard bridges
+are not added. Therefore, you are recommended to use
+`model = MOI.instantiate(Package.Optimizer; with_bridge_type = T)` instead of
+`model = MOI.instantiate(Package.Optimizer)`. See
+[`MathOptInterface.instantiate`](@ref).
 
 ## Examples
 

--- a/src/Bridges/Constraint/ltgt_to_interval.jl
+++ b/src/Bridges/Constraint/ltgt_to_interval.jl
@@ -9,9 +9,14 @@ Bridge a `F`-in-`Interval` constraint into an `F`-in-`Interval{T}` constraint wh
 
 The `F`-in-`Interval{T}` constraint is stored in the `constraint`
 field by convention.
-It is required that T be a AbstractFloat type because otherwise
-typemin and typemax would either be not implemented (e.g. BigInt)
-or would not give infinite value (e.g. Int).
+
+!!! warning
+    It is required that `T` be a `AbstractFloat` type because otherwise
+    typemin and typemax would either be not implemented (e.g. BigInt)
+    or would not give infinite value (e.g. Int). For this reason,
+    this bridge is only added to [`full_bridge_optimizer`](@ref)
+
+    when `T` is a subtype of `AbstractFloat`.
 """
 abstract type AbstractToIntervalBridge{
     T<:AbstractFloat,

--- a/src/Bridges/Constraint/ltgt_to_interval.jl
+++ b/src/Bridges/Constraint/ltgt_to_interval.jl
@@ -14,7 +14,8 @@ field by convention.
     It is required that `T` be a `AbstractFloat` type because otherwise
     typemin and typemax would either be not implemented (e.g. BigInt)
     or would not give infinite value (e.g. Int). For this reason,
-    this bridge is only added to [`full_bridge_optimizer`](@ref)
+    this bridge is only added to
+    [`MathOptInterface.Bridges.full_bridge_optimizer`](@ref).
 
     when `T` is a subtype of `AbstractFloat`.
 """

--- a/src/Bridges/Constraint/soc_to_nonconvex_quad.jl
+++ b/src/Bridges/Constraint/soc_to_nonconvex_quad.jl
@@ -16,13 +16,14 @@ is equivalent to
 ```
 with ``t \\ge 0``.  (3)
 
-*WARNING* This transformation starts from a convex constraint (1) and creates a
-non-convex constraint (2), because the Q matrix associated with the constraint 2
-has one negative eigenvalue. This might be wrongly interpreted by a solver.
-Some solvers can look at (2) and understand that it is a second order cone, but
-this is not a general rule.
-For these reasons this bridge is not automatically added by [`MOI.Bridges.full_bridge_optimizer`](@ref).
-Care is recommended when adding this bridge to a optimizer.
+!!! warning
+    This transformation starts from a convex constraint (1) and creates a
+    non-convex constraint (2), because the Q matrix associated with the constraint (2)
+    has one negative eigenvalue. This might be wrongly interpreted by a solver.
+    Some solvers can look at (2) and understand that it is a second order cone, but
+    this is not a general rule.
+    For these reasons this bridge is not automatically added by [`MOI.Bridges.full_bridge_optimizer`](@ref).
+    Care is recommended when adding this bridge to a optimizer.
 """
 struct SOCtoNonConvexQuadBridge{T} <: AbstractSOCtoNonConvexQuadBridge{T}
     quad::CI{MOI.ScalarQuadraticFunction{T},MOI.LessThan{T}}

--- a/src/Bridges/Constraint/soc_to_psd.jl
+++ b/src/Bridges/Constraint/soc_to_psd.jl
@@ -45,10 +45,12 @@ which is equivalent to
   t^2 & > x^\\top x
 \\end{align*}
 ```
-This bridge is not added by default by [`MOI.Bridges.full_bridge_optimizer`](@ref)
-as bridging second order cone constraints to semidefinite constraints can be
-achieved by the [`SOCtoRSOCBridge`](@ref) followed by the [`RSOCtoPSDBridge`](@ref)
-while creating a smaller semidefinite constraint.
+
+!!! warning
+    This bridge is not added by default by [`MOI.Bridges.full_bridge_optimizer`](@ref)
+    as bridging second order cone constraints to semidefinite constraints can be
+    achieved by the [`SOCtoRSOCBridge`](@ref) followed by the [`RSOCtoPSDBridge`](@ref)
+    while creating a smaller semidefinite constraint.
 """
 struct SOCtoPSDBridge{T,F,G} <: SetMapBridge{
     T,

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -1956,16 +1956,23 @@ function test_wrong_coefficient()
     return
 end
 
-struct OptimizerWithBridgeToAdd <: MOI.AbstractOptimizer end
-struct BridgeToAdd{T} <: MOI.Bridges.Constraint.AbstractBridge end
-function MOI.get(::OptimizerWithBridgeToAdd, ::MOI.Bridges.ToAdd{T}) where {T}
-    return [BridgeToAdd{T}]
+struct OptimizerWithBridgeListOfNonstandardBridges <: MOI.AbstractOptimizer end
+struct BridgeListOfNonstandardBridges{T} <:
+       MOI.Bridges.Constraint.AbstractBridge end
+function MOI.get(
+    ::OptimizerWithBridgeListOfNonstandardBridges,
+    ::MOI.Bridges.ListOfNonstandardBridges{T},
+) where {T}
+    return [BridgeListOfNonstandardBridges{T}]
 end
 
 function test_toadd()
-    b = MOI.Bridges.full_bridge_optimizer(OptimizerWithBridgeToAdd(), Int)
-    @test MOI.Bridges.has_bridge(b, BridgeToAdd{Int})
-    @test !MOI.Bridges.has_bridge(b, BridgeToAdd{Float64})
+    b = MOI.Bridges.full_bridge_optimizer(
+        OptimizerWithBridgeListOfNonstandardBridges(),
+        Int,
+    )
+    @test MOI.Bridges.has_bridge(b, BridgeListOfNonstandardBridges{Int})
+    @test !MOI.Bridges.has_bridge(b, BridgeListOfNonstandardBridges{Float64})
 end
 
 end  # module

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -1956,6 +1956,18 @@ function test_wrong_coefficient()
     return
 end
 
+struct OptimizerWithBridgeToAdd <: MOI.AbstractOptimizer end
+struct BridgeToAdd{T} <: MOI.Bridges.Constraint.AbstractBridge end
+function MOI.get(::OptimizerWithBridgeToAdd, ::MOI.Bridges.ToAdd{T}) where {T}
+    return [BridgeToAdd{T}]
+end
+
+function test_toadd()
+    b = MOI.Bridges.full_bridge_optimizer(OptimizerWithBridgeToAdd(), Int)
+    @test MOI.Bridges.has_bridge(b, BridgeToAdd{Int})
+    @test !MOI.Bridges.has_bridge(b, BridgeToAdd{Float64})
+end
+
 end  # module
 
 TestBridgesLazyBridgeOptimizer.runtests()


### PR DESCRIPTION
This attributes allow an optimizer to list a few bridges that should automatically be used by JuMP.
Here are a few use cases:
* Solvers that requires SOC constraint to be provided as ScalarQuadraticFunction-in-LessThan can add the SOCtoQuad bridge in this list in the prefered form (either supporting VectorOfVariables-in-SOC or VectorAffineFunction-in-SOC, since for some solver, the quadratic function obtained is recognized only if it is computated from the correct one, and we can go from one form to another with the [Slack and VectorOfVariables bridges](https://github.com/JuliaOpt/MathOptInterface.jl/issues/528)), see https://github.com/JuliaOpt/MathOptInterface.jl/pull/478#discussion_r211120417 (@ccoffrin this would resolve the issue we discussed with @mlubin )
* Solvers that use non-standard form for a set can create a custom set and a bridge inside the wrapper:
    - [ECOS](https://github.com/JuliaOpt/ECOS.jl) exponential cone which does not has the same order
    - [SeDuMi](https://github.com/blegat/SeDuMi.jl) PSDSquare-like cone
    - [CDCS](https://github.com/blegat/CDCS.jl) PSDSquare-like cone (not clear if it exactly the PSDSquare yet, see https://github.com/oxfordcontrol/CDCS/issues/13)

- [x] Needs tests