### PR TITLE
RFC/WIP: add complex norm-1 and norm-infinity cones

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -211,6 +211,28 @@ end
 dual_set(s::NormOneCone) = NormInfinityCone(dimension(s))
 
 """
+    ComplexNormInfinityCone(dimension)
+
+The ``\\ell_\\infty``-norm of complex vectors cone ``\\{ (t,x) \\in \\mathbb{R}\\times\\mathbb{C}^{n} : t \\ge \\lVert x \\rVert_\\infty = \\max_i \\lvert x_i \\rvert \\}`` of real `dimension```{}=1+2n``.
+"""
+struct ComplexNormInfinityCone <: AbstractVectorSet
+    dimension::Int
+end
+
+dual_set(s::ComplexNormInfinityCone) = ComplexNormOneCone(dimension(s))
+
+"""
+    ComplexNormOneCone(dimension)
+
+The ``\\ell_1``-norm of complex vectors cone ``\\{ (t,x) \\in \\mathbb{R}\\times\\mathbb{C}^{n} : t \\ge \\lVert x \\rVert_\\infty_1 = \\sum_i \\lvert x_i \\rvert \\}`` of real `dimension```{}=1+2n``.
+"""
+struct ComplexNormOneCone <: AbstractVectorSet
+    dimension::Int
+end
+
+dual_set(s::ComplexNormOneCone) = ComplexNormInfinityCone(dimension(s))
+
+"""
     SecondOrderCone(dimension)
 
 The second-order cone (or Lorenz cone or ``\\ell_2``-norm cone) ``\\{ (t,x) \\in \\mathbb{R}^{dimension} : t \\ge \\lVert x \\rVert_2 \\}`` of dimension `dimension`.

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -214,6 +214,7 @@ dual_set(s::NormOneCone) = NormInfinityCone(dimension(s))
     ComplexNormInfinityCone(dimension)
 
 The ``\\ell_\\infty``-norm of complex vectors cone ``\\{ (t,x) \\in \\mathbb{R}\\times\\mathbb{C}^{n} : t \\ge \\lVert x \\rVert_\\infty = \\max_i \\lvert x_i \\rvert \\}`` of real `dimension```{}=1+2n``.
+The cone is represented as a real vector by stacking the real and imaginary parts of each complex element ``x_i`` consecutively, like ``(t, \\Re(x_1), \\Im(x_1), \\Re(x_2), \\Im(x_2), \\ldots, \\Re(x_n), \\Im(x_n)) \\in \\mathbb{R}^{dimension}``.
 """
 struct ComplexNormInfinityCone <: AbstractVectorSet
     dimension::Int
@@ -225,6 +226,7 @@ dual_set(s::ComplexNormInfinityCone) = ComplexNormOneCone(dimension(s))
     ComplexNormOneCone(dimension)
 
 The ``\\ell_1``-norm of complex vectors cone ``\\{ (t,x) \\in \\mathbb{R}\\times\\mathbb{C}^{n} : t \\ge \\lVert x \\rVert_\\infty_1 = \\sum_i \\lvert x_i \\rvert \\}`` of real `dimension```{}=1+2n``.
+The cone is represented as a real vector by stacking the real and imaginary parts of each complex element ``x_i`` consecutively, like ``(t, \\Re(x_1), \\Im(x_1), \\Re(x_2), \\Im(x_2), \\ldots, \\Re(x_n), \\Im(x_n)) \\in \\mathbb{R}^{dimension}``.
 """
 struct ComplexNormOneCone <: AbstractVectorSet
     dimension::Int


### PR DESCRIPTION
Hypatia supports real and complex norm-1 and norm-infinity cones (and real/complex versions of various other cones, such as spectral and PSD/rootdet/logdet). This is the least-complicated way to support these two cones, I think. If we agree on this soon then I can generalize the spectral/nuclear cones in a similar way after #976 is merged, and then we can discuss how to do it for Hermitian PSD/rootdet/logdet.