### PR TITLE
RFC/WIP: add weighted power mean cone

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -235,11 +235,22 @@ dual_set(s::RotatedSecondOrderCone) = copy(s)
 """
     GeometricMeanCone(dimension)
 
-The geometric mean cone ``\\{ (t,x) \\in \\mathbb{R}^{n+1} : x \\ge 0, t \\le \\sqrt[n]{x_1 x_2 \\cdots x_n} \\}`` of dimension `dimension```{}=n+1``.
+The geometric mean cone ``\\{ (t,x) \\in \\mathbb{R}^{1+n} : x \\ge 0, t \\le \\sqrt[n]{x_1 x_2 \\cdots x_n} \\}`` of dimension `dimension```{}=1+n``.
 """
 struct GeometricMeanCone <: AbstractVectorSet
     dimension::Int
 end
+
+"""
+    GeneralizedGeometricMeanCone{T <: Real}(exponents::Vector{T})
+
+The generalized geometric mean cone ``\\{ (t,x) \\in \\mathbb{R}^{1+n} : x \\ge 0, t^{sum(exponents)} \\le \\prod_i x_i^{exponents_i} \\}`` of dimension ``1+n`` with parameter vector `exponents```{}\\in \\mathbb{R}_{++}^{n}``.
+"""
+struct GeneralizedGeometricMeanCone{T <: Real} <: AbstractVectorSet
+    exponents::Vector{T}
+end
+
+dimension(s::GeneralizedGeometricMeanCone) = 1 + length(s.exponents)
 
 """
     ExponentialCone()

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -242,15 +242,15 @@ struct GeometricMeanCone <: AbstractVectorSet
 end
 
 """
-    GeneralizedGeometricMeanCone{T <: Real}(exponents::Vector{T})
+    WeightedPowerMeanCone(exponents::Vector{<:Real})
 
-The generalized geometric mean cone ``\\{ (t,x) \\in \\mathbb{R}^{1+n} : x \\ge 0, t^{sum(exponents)} \\le \\prod_i x_i^{exponents_i} \\}`` of dimension ``1+n`` with parameter vector `exponents```{}\\in \\mathbb{R}_{++}^{n}``.
+The generalized geometric mean cone ``\\{ (t,x) \\in \\mathbb{R}^{1+n} : x \\ge 0, t^{sum(exponents)} \\le \\prod_i x_i^{exponents_i} \\}`` of dimension ``1+n`` with positive parameter vector `exponents```{}\\in \\mathbb{R}_{>0}^n``.
 """
-struct GeneralizedGeometricMeanCone{T <: Real} <: AbstractVectorSet
-    exponents::Vector{T}
+struct WeightedPowerMeanCone{T <: Real} <: AbstractVectorSet
+    exponents::Vector{<:Real}
 end
 
-dimension(s::GeneralizedGeometricMeanCone) = 1 + length(s.exponents)
+dimension(s::WeightedPowerMeanCone) = 1 + length(s.exponents)
 
 """
     ExponentialCone()


### PR DESCRIPTION
This is a generalization of the geometric mean cone for any vector of positive exponents (rather than just [1/n, 1/n, ..., 1/n]). It gives pretty close to all the utility (that I can see) of n-dimensional power cones. Hypatia supports this cone thanks to the existence of a SC barrier. When the definition is decided, I can add bridges, either to 3D exponential cone constraints or to 3D MOI power cone constraints.