### PR TITLE
add Hessian-vector product callback for HS071

### DIFF
--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -3,8 +3,10 @@ const VI = MOI.VariableIndex
 struct HS071 <: MOI.AbstractNLPEvaluator
     enable_hessian::Bool
     enable_hessian_vector_product::Bool
-    function HS071(enable_hessian::Bool,
-                   enable_hessian_vector_product::Bool=false)
+    function HS071(
+        enable_hessian::Bool,
+        enable_hessian_vector_product::Bool = false,
+    )
         return new(enable_hessian, enable_hessian_vector_product)
     end
 end
@@ -27,13 +29,14 @@ function MOI.initialize(d::HS071, requested_features::Vector{Symbol})
 end
 
 function MOI.features_available(d::HS071)
+    features = [:Grad, :Jac, :ExprGraph]
     if d.enable_hessian
-        return [:Grad, :Jac, :Hess, :ExprGraph]
-    elseif d.enable_hessian_vector_product
-        return [:Grad, :Jac, :HessVec, :ExprGraph]
-    else
-        return [:Grad, :Jac, :ExprGraph]
+        push!(features, :Hess)
     end
+    if d.enable_hessian_vector_product
+        return push!(features, :HessVec)
+    end
+    return features
 end
 
 function MOI.objective_expr(d::HS071)
@@ -252,7 +255,7 @@ function hs071_no_hessian_test(model, config)
     return hs071test_template(model, config, HS071(false))
 end
 
-function hs071_hessian_vector_product_test(model, config
+function hs071_hessian_vector_product_test(model, config)
     return hs071test_template(model, config, HS071(false, true))
 end
 

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -3,6 +3,10 @@ const VI = MOI.VariableIndex
 struct HS071 <: MOI.AbstractNLPEvaluator
     enable_hessian::Bool
     enable_hessian_vector_product::Bool
+    function HS071(enable_hessian::Bool,
+                   enable_hessian_vector_product::Bool=false)
+        return new(enable_hessian, enable_hessian_vector_product)
+    end
 end
 
 # hs071
@@ -241,7 +245,7 @@ function hs071test_template(
 end
 
 function hs071_test(model, config)
-    return hs071test_template(model, config, HS071(true, false))
+    return hs071test_template(model, config, HS071(true))
 end
 
 function hs071_no_hessian_test(model, config)

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -63,14 +63,16 @@ MOI.eval_objective(d::HS071, x) = x[1] * x[4] * (x[1] + x[2] + x[3]) + x[3]
 
 function MOI.eval_constraint(d::HS071, g, x)
     g[1] = x[1] * x[2] * x[3] * x[4]
-    return g[2] = x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2
+    g[2] = x[1]^2 + x[2]^2 + x[3]^2 + x[4]^2
+    return
 end
 
 function MOI.eval_objective_gradient(d::HS071, grad_f, x)
     grad_f[1] = x[1] * x[4] + x[4] * (x[1] + x[2] + x[3])
     grad_f[2] = x[1] * x[4]
     grad_f[3] = x[1] * x[4] + 1
-    return grad_f[4] = x[1] * (x[1] + x[2] + x[3])
+    grad_f[4] = x[1] * (x[1] + x[2] + x[3])
+    return
 end
 
 function MOI.jacobian_structure(d::HS071)
@@ -112,7 +114,8 @@ function MOI.eval_constraint_jacobian(d::HS071, J, x)
     J[5] = 2 * x[1]  # 2,1
     J[6] = 2 * x[2]  # 2,2
     J[7] = 2 * x[3]  # 2,3
-    return J[8] = 2 * x[4]  # 2,4
+    J[8] = 2 * x[4]  # 2,4
+    return
 end
 
 function MOI.eval_hessian_lagrangian(d::HS071, H, x, σ, μ)
@@ -142,7 +145,8 @@ function MOI.eval_hessian_lagrangian(d::HS071, H, x, σ, μ)
     H[1] += μ[2] * 2  # 1,1
     H[3] += μ[2] * 2  # 2,2
     H[6] += μ[2] * 2  # 3,3
-    return H[10] += μ[2] * 2
+    H[10] += μ[2] * 2
+    return
 end
 
 function MOI.eval_hessian_lagrangian_product(d::HS071, h, x, v, σ, μ)
@@ -152,7 +156,7 @@ function MOI.eval_hessian_lagrangian_product(d::HS071, h, x, v, σ, μ)
     h[2] = x[4] * v[1] + x[1] * v[4]
     h[3] = x[4] * v[1] + x[1] * v[4]
     h[4] = (2.0 * x[1] + x[2] + x[3]) * v[1] + x[1] * v[2] + x[1] * v[3]
-
+    h .*= σ
     # First constraint
     h[1] += μ[1] * (x[3] * x[4] * v[2] + x[2] * x[4] * v[3] + x[2] * x[3] * v[4])
     h[2] += μ[1] * (x[3] * x[4] * v[1] + x[1] * x[4] * v[3] + x[1] * x[3] * v[4])
@@ -164,7 +168,7 @@ function MOI.eval_hessian_lagrangian_product(d::HS071, h, x, v, σ, μ)
     h[2] += μ[2] * 2.0 * v[2]
     h[3] += μ[2] * 2.0 * v[3]
     h[4] += μ[2] * 2.0 * v[4]
-
+    return
 end
 
 function hs071test_template(

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -466,6 +466,7 @@ end
 const nlptests = Dict(
     "hs071" => hs071_test,
     "hs071_no_hessian" => hs071_no_hessian_test,
+    "hs071_hessian_vector_product_test" => hs071_hessian_vector_product_test,
     "feasibility_sense_with_objective_and_hessian" =>
         feasibility_sense_with_objective_and_hessian_test,
     "feasibility_sense_with_objective_and_no_hessian" =>

--- a/test/Test/nlp.jl
+++ b/test/Test/nlp.jl
@@ -23,7 +23,7 @@ const MOI = MathOptInterface
     MOI.Test.hs071_no_hessian_test(mock, config)
     MOI.Test.hs071_hessian_vector_product_test(mock, config)
 
-    d = MOI.Test.HS071(false, false)
+    d = MOI.Test.HS071(false)
     VI = MOI.VariableIndex
     @test MOI.objective_expr(d) == :(x[$(VI(1))] * x[$(VI(4))] * (x[$(VI(1))] +
                                      x[$(VI(2))] + x[$(VI(3))]) + x[$(VI(3))])

--- a/test/Test/nlp.jl
+++ b/test/Test/nlp.jl
@@ -21,8 +21,9 @@ const MOI = MathOptInterface
     )
     MOI.Test.hs071_test(mock, config)
     MOI.Test.hs071_no_hessian_test(mock, config)
+    MOI.Test.hs071_hessian_vector_product_test(mock, config)
 
-    d = MOI.Test.HS071(false)
+    d = MOI.Test.HS071(false, false)
     VI = MOI.VariableIndex
     @test MOI.objective_expr(d) == :(x[$(VI(1))] * x[$(VI(4))] * (x[$(VI(1))] +
                                      x[$(VI(2))] + x[$(VI(3))]) + x[$(VI(3))])


### PR DESCRIPTION
This PR implements a callback to compute Hessian vector product for the test HS071. 

It currrently runs fine with Knitro. I do not add this test to the [default NLP tests](https://github.com/JuliaOpt/MathOptInterface.jl/blob/master/src/Test/nlp.jl#L349-L361) as that would break the testing for all solvers not supporting Hessian-vector product (including Ipopt).

Implementing a callback for Jacobian vector-product would be straightforward, but I am not aware of any NLP solver supporting this feature.