### PR TITLE
Throw error when bounds are set from Semi... bridges

### DIFF
--- a/src/Bridges/Constraint/semi_to_binary.jl
+++ b/src/Bridges/Constraint/semi_to_binary.jl
@@ -50,6 +50,15 @@ function bridge_constraint(::Type{SemiToBinaryBridge{T,S}}, model::MOI.ModelLike
     return SemiToBinaryBridge{T,S}(s, f.variable, binary, binary_con, lb_ci, ub_ci, int_ci)
 end
 
+MOIB.watched_variables(bridge::SemiToBinaryBridge) = [bridge.variable_index]
+function MOIB.notify_constraint(
+    bridge::SemiToBinaryBridge{T, S}, model::MOI.ModelLike,
+    func::MOI.SingleVariable, set::MOI.AbstractScalarSet
+) where {T, S}
+    mask = MOIU.single_variable_flag(S)
+    MOIU.throw_if_lower_bound_set(func.variable, typeof(set), mask, T)
+    MOIU.throw_if_upper_bound_set(func.variable, typeof(set), mask, T)
+end
 
 function MOIB.added_constrained_variable_types(::Type{<:SemiToBinaryBridge{T, S}}) where {T, S}
     return [(MOI.ZeroOne,)]

--- a/src/Bridges/Constraint/single_bridge_optimizer.jl
+++ b/src/Bridges/Constraint/single_bridge_optimizer.jl
@@ -8,13 +8,15 @@ even if they are supported by one of its bridges.
 """
 mutable struct SingleBridgeOptimizer{BT<:AbstractBridge, OT<:MOI.ModelLike} <: MOIB.AbstractBridgeOptimizer
     model::OT
+    watchers::Dict{MOI.VariableIndex, Set{MOIB.AbstractBridge}}
     map::Map # index of bridged constraint -> constraint bridge
     con_to_name::Dict{MOI.ConstraintIndex, String}
     name_to_con::Union{Dict{String, MOI.ConstraintIndex}, Nothing}
 end
 function SingleBridgeOptimizer{BT}(model::OT) where {BT, OT <: MOI.ModelLike}
     SingleBridgeOptimizer{BT, OT}(
-        model, Map(), Dict{MOI.ConstraintIndex, String}(), nothing)
+        model, Dict{MOI.VariableIndex, Set{MOIB.AbstractBridge}}(),
+        Map(), Dict{MOI.ConstraintIndex, String}(), nothing)
 end
 
 function bridges(bridge::MOI.Bridges.AbstractBridgeOptimizer)

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -78,7 +78,7 @@ function MOI.set(model::MOI.ModelLike, attr::MOI.AbstractConstraintAttribute,
 end
 
 """
-    added_constrained_variable_types(BT::Type{<:Variable.AbstractBridge})::Vector{Tuple{DataType}}
+    added_constrained_variable_types(BT::Type{<:AbstractBridge})::Vector{Tuple{DataType}}
 
 Return a list of the types of constrained variables that bridges of concrete
 type `BT` add. This is used by the [`LazyBridgeOptimizer`](@ref).
@@ -86,7 +86,7 @@ type `BT` add. This is used by the [`LazyBridgeOptimizer`](@ref).
 function added_constrained_variable_types end
 
 """
-    added_constraint_types(BT::Type{<:Constraint.AbstractBridge})::Vector{Tuple{DataType, DataType}}
+    added_constraint_types(BT::Type{<:AbstractBridge})::Vector{Tuple{DataType, DataType}}
 
 Return a list of the types of constraints that bridges of concrete type `BT`
 add. This is used by the [`LazyBridgeOptimizer`](@ref).
@@ -94,9 +94,31 @@ add. This is used by the [`LazyBridgeOptimizer`](@ref).
 function added_constraint_types end
 
 """
-    set_objective_function_type(BT::Type{<:Objective.AbstractBridge})::Type{<:MOI.AbstractScalarFunction}
+    set_objective_function_type(BT::Type{<:AbstractBridge})::Type{<:MOI.AbstractScalarFunction}
 
 Return the type of objective function that bridges of concrete type `BT`
 set. This is used by the [`LazyBridgeOptimizer`](@ref).
 """
 function set_objective_function_type end
+
+"""
+    watched_variables(::AbstractBridge)::AbstractVector{MOI.VariableIndex}
+
+Return a list of variable indices. For any `S<:MOI.AbstractScalarSet`, whenever
+a `MOI.SingleVariable`-in-`S` constraint is added to the model for one variable
+of this list, the bridge is notified with [`notify_constraint`]`(@ref) just before
+adding the constraint.
+If this method is not implemented, it fallbacks to returning
+`MOI.Utilities.EmptyVector{MOI.VariableIndex}()`.
+"""
+watched_variables(::AbstractBridge) = MOIU.EmptyVector{MOI.VariableIndex}()
+
+"""
+    notify_constraint(bridge::AbstractBridge, model::Model, func::SingleVariable, set::MOI.AbstractScalarSet)::AbstractVector{MOI.VariableIndex}
+
+Notifies `bridge` that the `func`-in-`set` constraint will be might be added to
+`model`. The bridge can throw an error if that should not be allowed or add
+variables or add/modify constraints due to this change.
+See [`watched_variables`](@ref) for being notified when variables are modified.
+"""
+function notify_constraint end

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -16,6 +16,7 @@ it will choose bridge 1 as it allows to bridge `F`-in-`S` using only one bridge 
 mutable struct LazyBridgeOptimizer{OT<:MOI.ModelLike} <: AbstractBridgeOptimizer
     # Internal model
     model::OT
+    watchers::Dict{MOI.VariableIndex, Set{AbstractBridge}}
     # Bridged variables
     variable_map::Variable.Map
     var_to_name::Dict{MOI.VariableIndex, String}
@@ -44,7 +45,7 @@ mutable struct LazyBridgeOptimizer{OT<:MOI.ModelLike} <: AbstractBridgeOptimizer
 end
 function LazyBridgeOptimizer(model::MOI.ModelLike)
     return LazyBridgeOptimizer{typeof(model)}(
-        model,
+        model, Dict{MOI.VariableIndex, Set{AbstractBridge}}(),
         Variable.Map(), Dict{MOI.VariableIndex, String}(), nothing,
         Constraint.Map(), Dict{MOI.ConstraintIndex, String}(), nothing,
         Objective.Map(),

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -614,16 +614,17 @@ function scalar_function_constant_not_zero(model::MOI.ModelLike)
     end
 end
 
-function set_lower_bound_twice(model::MOI.ModelLike, T::Type)
+function set_lower_bound_twice(
+    model::MOI.ModelLike, T::Type,
+    sets = [MOI.EqualTo(zero(T)), MOI.Interval(zero(T), zero(T)),
+            MOI.Semicontinuous(zero(T), zero(T)), MOI.Semiinteger(zero(T), zero(T))],
+    set2 = MOI.GreaterThan(zero(T))
+)
     MOI.empty!(model)
     @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     f = MOI.SingleVariable(x)
-    lb = zero(T)
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{T})
-    sets = [MOI.EqualTo(lb), MOI.Interval(lb, lb),
-             MOI.Semicontinuous(lb, lb), MOI.Semiinteger(lb, lb)]
-    set2 = MOI.GreaterThan(lb)
     for set1 in sets
         if !MOI.supports_constraint(model, MOI.SingleVariable, typeof(set1))
             continue
@@ -639,16 +640,17 @@ function set_lower_bound_twice(model::MOI.ModelLike, T::Type)
     end
 end
 
-function set_upper_bound_twice(model::MOI.ModelLike, T::Type)
+function set_upper_bound_twice(
+    model::MOI.ModelLike, T::Type,
+    sets = [MOI.EqualTo(zero(T)), MOI.Interval(zero(T), zero(T)),
+            MOI.Semicontinuous(zero(T), zero(T)), MOI.Semiinteger(zero(T), zero(T))],
+    set2 = MOI.GreaterThan(zero(T))
+)
     MOI.empty!(model)
     @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     f = MOI.SingleVariable(x)
-    ub = zero(T)
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.LessThan{T})
-    sets = [MOI.EqualTo(ub), MOI.Interval(ub, ub),
-             MOI.Semicontinuous(ub, ub), MOI.Semiinteger(ub, ub)]
-    set2 = MOI.LessThan(ub)
     for set1 in sets
         if !MOI.supports_constraint(model, MOI.SingleVariable, typeof(set1))
             continue

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -519,25 +519,21 @@ function MOI.supports_constraint(
     return true
 end
 function MOI.add_constraint(model::AbstractModel{T}, f::MOI.SingleVariable,
-                            s::MOI.AbstractScalarSet) where T
-    if MOI.supports_constraint(model, MOI.SingleVariable, typeof(s))
-        flag = single_variable_flag(typeof(s))
-        index = f.variable.value
-        mask = model.single_variable_mask[index]
-        throw_if_lower_bound_set(f.variable, typeof(s), mask, T)
-        throw_if_upper_bound_set(f.variable, typeof(s), mask, T)
-        # No error should be thrown now, we can modify `model`.
-        if !iszero(flag & LOWER_BOUND_MASK)
-            model.lower_bound[index] = extract_lower_bound(s)
-        end
-        if !iszero(flag & UPPER_BOUND_MASK)
-            model.upper_bound[index] = extract_upper_bound(s)
-        end
-        model.single_variable_mask[index] = mask | flag
-        return CI{MOI.SingleVariable, typeof(s)}(index)
-    else
-        throw(MOI.UnsupportedConstraint{MOI.SingleVariable, typeof(s)}())
+                            s::SUPPORTED_VARIABLE_SCALAR_SETS{T}) where T
+    flag = single_variable_flag(typeof(s))
+    index = f.variable.value
+    mask = model.single_variable_mask[index]
+    throw_if_lower_bound_set(f.variable, typeof(s), mask, T)
+    throw_if_upper_bound_set(f.variable, typeof(s), mask, T)
+    # No error should be thrown now, we can modify `model`.
+    if !iszero(flag & LOWER_BOUND_MASK)
+        model.lower_bound[index] = extract_lower_bound(s)
     end
+    if !iszero(flag & UPPER_BOUND_MASK)
+        model.upper_bound[index] = extract_upper_bound(s)
+    end
+    model.single_variable_mask[index] = mask | flag
+    return CI{MOI.SingleVariable, typeof(s)}(index)
 end
 function MOI.add_constraint(model::AbstractModel, f::F, s::S) where {F<:MOI.AbstractFunction, S<:MOI.AbstractSet}
     if MOI.supports_constraint(model, F, S)

--- a/test/Bridges/Constraint/semi_to_binary.jl
+++ b/test/Bridges/Constraint/semi_to_binary.jl
@@ -30,6 +30,11 @@ config = MOIT.TestConfig()
                    for F in [MOI.SingleVariable]
                    for S in [MOI.Semiinteger{Float64}, MOI.Semicontinuous{Float64}]])
 
+    T = Float64
+    MOIT.set_lower_bound_twice(bridged_mock, T, [MOI.Semicontinuous(zero(T), zero(T)), MOI.Semiinteger(zero(T), zero(T))])
+    @show MOI.get(bridged_mock, MOI.ListOfVariableIndices())
+    MOIT.set_upper_bound_twice(bridged_mock, T, [MOI.Semicontinuous(zero(T), zero(T)), MOI.Semiinteger(zero(T), zero(T))])
+
     MOIU.set_mock_optimize!(mock,
         (mock::MOIU.MockOptimizer) -> begin
             MOI.set(mock, MOI.ObjectiveBound(), 0.0)


### PR DESCRIPTION
This started as an alternative fix for https://github.com/JuliaOpt/GLPK.jl/pull/138.
This allows Semiinteger/Semicontinuous bridges to throw errors if LessThan/EqualTo/Interval/GreaterThan constraints are added on the variables. However, When LessThan/... are added to GLPK and then Semi... are bridged, we should then check in the bridge whether any bound has been set to the model, not sure we want to go in this direction. We should probably just make it optional to throw this error if multiple bounds are set.