### PR TITLE
Add variable constraint watcher bridges

### DIFF
--- a/src/Bridges/Constraint/single_bridge_optimizer.jl
+++ b/src/Bridges/Constraint/single_bridge_optimizer.jl
@@ -46,6 +46,7 @@ with inner model MOIU.Model{Float64}
 mutable struct SingleBridgeOptimizer{BT<:AbstractBridge,OT<:MOI.ModelLike} <:
                MOI.Bridges.AbstractBridgeOptimizer
     model::OT
+    watchers::Dict{MOI.VariableIndex,Set{MOIB.AbstractBridge}}
     map::Map # index of bridged constraint -> constraint bridge
     con_to_name::Dict{MOI.ConstraintIndex,String}
     name_to_con::Union{Dict{String,MOI.ConstraintIndex},Nothing}
@@ -54,6 +55,7 @@ end
 function SingleBridgeOptimizer{BT}(model::OT) where {BT,OT<:MOI.ModelLike}
     return SingleBridgeOptimizer{BT,OT}(
         model,
+        Dict{MOI.VariableIndex,Set{MOIB.AbstractBridge}}(),
         Map(),
         Dict{MOI.ConstraintIndex,String}(),
         nothing,

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -253,3 +253,25 @@ MathOptInterface.ScalarAffineFunction{Float64}
 ```
 """
 function set_objective_function_type end
+
+"""
+    watched_variables(::AbstractBridge)::AbstractVector{MOI.VariableIndex}
+
+Return a list of variable indices. For any `S<:MOI.AbstractScalarSet`, whenever
+a `MOI.SingleVariable`-in-`S` constraint is added to the model for one variable
+of this list, the bridge is notified with [`notify_constraint`]`(@ref) just before
+adding the constraint.
+If this method is not implemented, it fallbacks to returning
+`MOI.Utilities.EmptyVector{MOI.VariableIndex}()`.
+"""
+watched_variables(::AbstractBridge) = MOIU.EmptyVector{MOI.VariableIndex}()
+
+"""
+    notify_constraint(bridge::AbstractBridge, model::Model, func::SingleVariable, set::MOI.AbstractScalarSet)::AbstractVector{MOI.VariableIndex}
+
+Notifies `bridge` that the `func`-in-`set` constraint will be might be added to
+`model`. The bridge can throw an error if that should not be allowed or add
+variables or add/modify constraints due to this change.
+See [`watched_variables`](@ref) for being notified when variables are modified.
+"""
+function notify_constraint end

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -41,6 +41,7 @@ true
 mutable struct LazyBridgeOptimizer{OT<:MOI.ModelLike} <: AbstractBridgeOptimizer
     # Internal model
     model::OT
+    watchers::Dict{MOI.VariableIndex,Set{AbstractBridge}}
     # Bridged variables
     variable_map::Variable.Map
     var_to_name::Dict{MOI.VariableIndex,String}
@@ -72,6 +73,7 @@ mutable struct LazyBridgeOptimizer{OT<:MOI.ModelLike} <: AbstractBridgeOptimizer
     function LazyBridgeOptimizer(model::MOI.ModelLike)
         return new{typeof(model)}(
             model,
+            Dict{MOI.VariableIndex,Set{AbstractBridge}}(),
             Variable.Map(),
             Dict{MOI.VariableIndex,String}(),
             nothing,


### PR DESCRIPTION
The key feature of bridges is that they are applied to each constraint independently.
This allows to defined numerous different model transformations just by defining a few bridges.
However, there are a few exceptions, that we have ignored from now:
1) Quadratic constraints `x^2 + y^2 <= z^2` can be bridged to `[z, x, y] in SOC` if `z >= 0`. So the transformations depends on a bound on `y`.
2) Complementarity constraints depends on the bounds on the variable.

So in the bridge, we would need to check what are the bounds on the variables (and assume the bound was set first), this is currently possible.
However, if the bounds on the variable are changed, the bridge should be notified as it may need to modify the constraints it added or it may throw an error.
In example 1) above, if the nonnegativity constraint is removed on `z`, the bridge should throw an error.
To allow this, this PR adds a mechanism for bridge to inform that they want to be notified whenever a `SingleVariable` constraint is added on a variable.

Requires https://github.com/JuliaOpt/MathOptInterface.jl/pull/1095