### PR TITLE
Various improvements to the FilesFormats.MOF subpackage.

### DIFF
--- a/src/FileFormats/MOF/MOF.jl
+++ b/src/FileFormats/MOF/MOF.jl
@@ -7,7 +7,6 @@ import JSONSchema
 import MathOptInterface
 
 const MOI = MathOptInterface
-const Object = OrderedCollections.OrderedDict{String, Any}
 const SCHEMA_PATH = joinpath(@__DIR__, "v0.4.0.json")
 const VERSION = let data = JSON.parsefile(SCHEMA_PATH, use_mmap=false)
     VersionNumber(
@@ -16,7 +15,11 @@ const VERSION = let data = JSON.parsefile(SCHEMA_PATH, use_mmap=false)
     )
 end
 
-function _parse_mof_version(version::Object)
+const OrderedObject = OrderedCollections.OrderedDict{String, Any}
+const UnorderedObject = Dict{String, Any}
+const Object = Union{OrderedObject, UnorderedObject}
+
+function _parse_mof_version(version)
     return VersionNumber(version["major"], version["minor"])
 end
 

--- a/src/FileFormats/MOF/MOF.jl
+++ b/src/FileFormats/MOF/MOF.jl
@@ -54,7 +54,7 @@ struct Options
 end
 
 function get_options(m::Model)
-    return get(m.model.ext, :MOF_OPTIONS, Options(false, true, false))
+    return get(m.model.ext, :MOF_OPTIONS, Options(false, false, false))
 end
 
 """
@@ -67,13 +67,14 @@ Keyword arguments are:
  - `print_compact::Bool=false`: print the JSON file in a compact format without
    spaces or newlines.
 
- - `validate::Bool=true`: validate each file prior to reading against the MOF
-   schema
+ - `validate::Bool=false`: validate each file prior to reading against the MOF
+   schema. Defaults to `false` because this can take a long time for large
+   models.
 
  - `warn::Bool=false`: print a warning when variables or constraints are renamed
 """
 function Model(;
-    print_compact::Bool = false, validate::Bool = true, warn::Bool = false
+    print_compact::Bool = false, validate::Bool = false, warn::Bool = false
 )
     model = MOI.Utilities.UniversalFallback(InnerModel{Float64}())
     model.model.ext[:MOF_OPTIONS] = Options(print_compact, validate, warn)

--- a/src/FileFormats/MOF/read.jl
+++ b/src/FileFormats/MOF/read.jl
@@ -272,9 +272,6 @@ end
 
 @head_to_val(
     head_to_set,
-    SOS1,
-    SOS2,
-    IndicatorSet,
     ZeroOne,
     Integer,
     LessThan,
@@ -305,6 +302,9 @@ end
     DualExponentialCone,
     PowerCone,
     DualPowerCone,
+    SOS1,
+    SOS2,
+    IndicatorSet,
 )
 
 """
@@ -314,28 +314,136 @@ Convert `x` from an OrderedDict representation into a MOI representation.
 """
 set_to_moi(x::Object) = set_to_moi(head_to_set(x["head"]::String), x)
 
-"""
-    set_info(::Val{HeadName}) where HeadName
+# ========== Non-typed scalar sets ==========
 
-Return a tuple of the corresponding MOI set and an ordered list of fieldnames.
-
-`HeadName` is a symbol of the string returned by `head_name(set)`.
-
-    HeadName = Symbol(head_name(set))
-    typeof(set_info(Val{HeadName}())[1]) == typeof(set)
-"""
-function set_info(::Val{S}) where {S}
-    error("Version $(VERSION) of MathOptFormat does not support the set: $S.")
+function set_to_moi(::Val{:ZeroOne}, ::Object)
+    return MOI.ZeroOne()
 end
 
-function set_to_moi(val::Val{S}, object::Object) where {S}
-    args = set_info(val)
-    SetType = args[1]
-    if length(args) > 1
-        return SetType([object[key] for key in args[2:end]]...)
-    else
-        return SetType()
-    end
+function set_to_moi(::Val{:Integer}, ::Object)
+    return MOI.Integer()
+end
+
+# ========== Typed scalar sets ==========
+
+function set_to_moi(::Val{:LessThan}, object::Object)
+    return MOI.LessThan(object["upper"])
+end
+
+function set_to_moi(::Val{:GreaterThan}, object::Object)
+    return MOI.GreaterThan(object["lower"])
+end
+
+function set_to_moi(::Val{:EqualTo}, object::Object)
+    return MOI.EqualTo(object["value"])
+end
+
+function set_to_moi(::Val{:Interval}, object::Object)
+    return MOI.Interval(object["lower"], object["upper"])
+end
+
+function set_to_moi(::Val{:Semiinteger}, object::Object)
+    return MOI.Semiinteger(object["lower"], object["upper"])
+end
+
+function set_to_moi(::Val{:Semicontinuous}, object::Object)
+    return MOI.Semicontinuous(object["lower"], object["upper"])
+end
+
+# ========== Non-typed vector sets ==========
+
+function set_to_moi(::Val{:Zeros}, object::Object)
+    return MOI.Zeros(object["dimension"]::Int)
+end
+
+function set_to_moi(::Val{:Reals}, object::Object)
+    return MOI.Reals(object["dimension"]::Int)
+end
+
+function set_to_moi(::Val{:Nonnegatives}, object::Object)
+    return MOI.Nonnegatives(object["dimension"]::Int)
+end
+
+function set_to_moi(::Val{:Nonpositives}, object::Object)
+    return MOI.Nonpositives(object["dimension"]::Int)
+end
+
+function set_to_moi(::Val{:SecondOrderCone}, object::Object)
+    return MOI.SecondOrderCone(object["dimension"]::Int)
+end
+
+function set_to_moi(::Val{:RotatedSecondOrderCone}, object::Object)
+    return MOI.RotatedSecondOrderCone(object["dimension"]::Int)
+end
+
+function set_to_moi(::Val{:GeometricMeanCone}, object::Object)
+    return MOI.GeometricMeanCone(object["dimension"]::Int)
+end
+
+function set_to_moi(::Val{:NormOneCone}, object::Object)
+    return MOI.NormOneCone(object["dimension"]::Int)
+end
+
+function set_to_moi(::Val{:NormInfinityCone}, object::Object)
+    return MOI.NormInfinityCone(object["dimension"]::Int)
+end
+
+function set_to_moi(::Val{:RelativeEntropyCone}, object::Object)
+    return MOI.RelativeEntropyCone(object["dimension"]::Int)
+end
+
+function set_to_moi(::Val{:NormSpectralCone}, object::Object)
+    return MOI.NormSpectralCone(
+        object["row_dim"]::Int, object["column_dim"]::Int
+    )
+end
+
+function set_to_moi(::Val{:NormNuclearCone}, object::Object)
+    return MOI.NormNuclearCone(
+        object["row_dim"]::Int, object["column_dim"]::Int
+    )
+end
+
+function set_to_moi(::Val{:RootDetConeTriangle}, object::Object)
+    return MOI.RootDetConeTriangle(object["side_dimension"]::Int)
+end
+
+function set_to_moi(::Val{:RootDetConeSquare}, object::Object)
+    return MOI.RootDetConeSquare(object["side_dimension"]::Int)
+end
+
+function set_to_moi(::Val{:LogDetConeTriangle}, object::Object)
+    return MOI.LogDetConeTriangle(object["side_dimension"]::Int)
+end
+
+function set_to_moi(::Val{:LogDetConeSquare}, object::Object)
+    return MOI.LogDetConeSquare(object["side_dimension"]::Int)
+end
+
+function set_to_moi(::Val{:PositiveSemidefiniteConeTriangle}, object::Object)
+    return MOI.PositiveSemidefiniteConeTriangle(object["side_dimension"]::Int)
+end
+
+function set_to_moi(::Val{:PositiveSemidefiniteConeSquare}, object::Object)
+    return MOI.PositiveSemidefiniteConeSquare(object["side_dimension"]::Int)
+end
+
+function set_to_moi(::Val{:ExponentialCone}, ::Object)
+    return MOI.ExponentialCone()
+end
+
+function set_to_moi(::Val{:DualExponentialCone}, ::Object)
+    return MOI.DualExponentialCone()
+end
+
+# ========== Typed vector sets ==========
+
+function set_to_moi(::Val{:PowerCone}, object::Object)
+    return MOI.PowerCone(object["exponent"]::Float64)
+end
+
+function set_to_moi(::Val{:DualPowerCone}, object::Object)
+    return MOI.DualPowerCone(object["exponent"]::Float64)
 end
 
 function set_to_moi(::Val{:SOS1}, object::Object)
@@ -356,55 +464,3 @@ function set_to_moi(::Val{:IndicatorSet}, object::Object)
     end
     return MOI.IndicatorSet{indicator}(set)
 end
-
-# ========== Non-typed scalar sets ==========
-set_info(::Val{:ZeroOne}) = (MOI.ZeroOne,)
-set_info(::Val{:Integer}) = (MOI.Integer,)
-
-# ========== Typed scalar sets ==========
-set_info(::Val{:LessThan}) = (MOI.LessThan, "upper")
-set_info(::Val{:GreaterThan}) = (MOI.GreaterThan, "lower")
-set_info(::Val{:EqualTo}) = (MOI.EqualTo, "value")
-set_info(::Val{:Interval}) = (MOI.Interval, "lower", "upper")
-set_info(::Val{:Semiinteger}) = (MOI.Semiinteger, "lower", "upper")
-set_info(::Val{:Semicontinuous}) = (MOI.Semicontinuous, "lower", "upper")
-
-# ========== Non-typed vector sets ==========
-set_info(::Val{:Zeros}) = (MOI.Zeros, "dimension")
-set_info(::Val{:Reals}) = (MOI.Reals, "dimension")
-set_info(::Val{:Nonnegatives}) = (MOI.Nonnegatives, "dimension")
-set_info(::Val{:Nonpositives}) = (MOI.Nonpositives, "dimension")
-set_info(::Val{:SecondOrderCone}) = (MOI.SecondOrderCone, "dimension")
-function set_info(::Val{:RotatedSecondOrderCone})
-    return MOI.RotatedSecondOrderCone, "dimension"
-end
-set_info(::Val{:GeometricMeanCone}) = (MOI.GeometricMeanCone, "dimension")
-set_info(::Val{:NormOneCone}) = (MOI.NormOneCone, "dimension")
-set_info(::Val{:NormInfinityCone}) = (MOI.NormInfinityCone, "dimension")
-set_info(::Val{:RelativeEntropyCone}) = (MOI.RelativeEntropyCone, "dimension")
-set_info(::Val{:NormSpectralCone}) = (MOI.NormSpectralCone, "row_dim", "column_dim")
-set_info(::Val{:NormNuclearCone}) = (MOI.NormNuclearCone, "row_dim", "column_dim")
-function set_info(::Val{:RootDetConeTriangle})
-    return MOI.RootDetConeTriangle, "side_dimension"
-end
-function set_info(::Val{:RootDetConeSquare})
-    return MOI.RootDetConeSquare, "side_dimension"
-end
-function set_info(::Val{:LogDetConeTriangle})
-    return MOI.LogDetConeTriangle, "side_dimension"
-end
-function set_info(::Val{:LogDetConeSquare})
-    return MOI.LogDetConeSquare, "side_dimension"
-end
-function set_info(::Val{:PositiveSemidefiniteConeTriangle})
-    return MOI.PositiveSemidefiniteConeTriangle, "side_dimension"
-end
-function set_info(::Val{:PositiveSemidefiniteConeSquare})
-    return MOI.PositiveSemidefiniteConeSquare, "side_dimension"
-end
-set_info(::Val{:ExponentialCone}) = (MOI.ExponentialCone, )
-set_info(::Val{:DualExponentialCone}) = (MOI.DualExponentialCone, )
-
-# ========== Typed vector sets ==========
-set_info(::Val{:PowerCone}) = (MOI.PowerCone, "exponent")
-set_info(::Val{:DualPowerCone}) = (MOI.DualPowerCone, "exponent")

--- a/src/FileFormats/MOF/write.jl
+++ b/src/FileFormats/MOF/write.jl
@@ -44,10 +44,11 @@ function write_objective(
     sense = MOI.get(model, MOI.ObjectiveSense())
     object["objective"] = Object("sense" => moi_to_object(sense))
     if sense != MOI.FEASIBILITY_SENSE
-        objective_type = MOI.get(model, MOI.ObjectiveFunctionType())
-        objective_function = MOI.get(model, MOI.ObjectiveFunction{objective_type}())
-        object["objective"]["function"] =
-            moi_to_object(objective_function, model, name_map)
+        F = MOI.get(model, MOI.ObjectiveFunctionType())
+        objective_function = MOI.get(model, MOI.ObjectiveFunction{F}())
+        object["objective"]["function"] = moi_to_object(
+            objective_function, name_map
+        )
     end
     return
 end
@@ -76,8 +77,11 @@ function moi_to_object(index::MOI.VariableIndex, model::Model)
     return Object("name" => name)
 end
 
-function moi_to_object(index::MOI.ConstraintIndex{F,S}, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String}) where {F, S}
+function moi_to_object(
+    index::MOI.ConstraintIndex{F,S},
+    model::Model,
+    name_map::Dict{MOI.VariableIndex, String}
+) where {F, S}
     func = MOI.get(model, MOI.ConstraintFunction(), index)
     set = MOI.get(model, MOI.ConstraintSet(), index)
     name = MOI.get(model, MOI.ConstraintName(), index)
@@ -85,8 +89,8 @@ function moi_to_object(index::MOI.ConstraintIndex{F,S}, model::Model,
     if name != ""
         object["name"] = name
     end
-    object["function"] = moi_to_object(func, model, name_map)
-    object["set"] = moi_to_object(set, model, name_map)
+    object["function"] = moi_to_object(func, name_map)
+    object["set"] = moi_to_object(set, name_map)
     return object
 end
 
@@ -103,8 +107,9 @@ end
 
 # ========== Non-typed scalar functions ==========
 
-function moi_to_object(foo::MOI.SingleVariable, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String})
+function moi_to_object(
+    foo::MOI.SingleVariable, name_map::Dict{MOI.VariableIndex, String}
+)
     return Object(
         "head" => "SingleVariable",
         "variable" => name_map[foo.variable]
@@ -113,25 +118,31 @@ end
 
 # ========== Typed scalar functions ==========
 
-function moi_to_object(foo::MOI.ScalarAffineTerm{Float64}, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String})
+function moi_to_object(
+    foo::MOI.ScalarAffineTerm{Float64},
+    name_map::Dict{MOI.VariableIndex, String},
+)
     return Object(
         "coefficient" => foo.coefficient,
         "variable" => name_map[foo.variable_index]
     )
 end
 
-function moi_to_object(foo::MOI.ScalarAffineFunction{Float64}, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String})
+function moi_to_object(
+    foo::MOI.ScalarAffineFunction{Float64},
+    name_map::Dict{MOI.VariableIndex, String},
+)
     return Object(
         "head" => "ScalarAffineFunction",
-        "terms" => moi_to_object.(foo.terms, Ref(model), Ref(name_map)),
-        "constant" => foo.constant
+        "terms" => moi_to_object.(foo.terms, Ref(name_map)),
+        "constant" => foo.constant,
     )
 end
 
-function moi_to_object(foo::MOI.ScalarQuadraticTerm{Float64}, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String})
+function moi_to_object(
+    foo::MOI.ScalarQuadraticTerm{Float64},
+    name_map::Dict{MOI.VariableIndex, String},
+)
     return Object(
         "coefficient" => foo.coefficient,
         "variable_1" => name_map[foo.variable_index_1],
@@ -139,60 +150,67 @@ function moi_to_object(foo::MOI.ScalarQuadraticTerm{Float64}, model::Model,
     )
 end
 
-function moi_to_object(foo::MOI.ScalarQuadraticFunction{Float64}, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String})
+function moi_to_object(
+    foo::MOI.ScalarQuadraticFunction{Float64},
+    name_map::Dict{MOI.VariableIndex, String},
+)
     return Object(
         "head" => "ScalarQuadraticFunction",
-        "affine_terms" => moi_to_object.(foo.affine_terms, Ref(model), Ref(name_map)),
-        "quadratic_terms" => moi_to_object.(foo.quadratic_terms, Ref(model), Ref(name_map)),
-        "constant" => foo.constant
+        "affine_terms" => moi_to_object.(foo.affine_terms, Ref(name_map)),
+        "quadratic_terms" => moi_to_object.(foo.quadratic_terms, Ref(name_map)),
+        "constant" => foo.constant,
     )
 end
 
 # ========== Non-typed vector functions ==========
 
-function moi_to_object(foo::MOI.VectorOfVariables, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String})
+function moi_to_object(
+    foo::MOI.VectorOfVariables, name_map::Dict{MOI.VariableIndex, String}
+)
     return Object(
         "head" => "VectorOfVariables",
-        "variables" => [name_map[variable] for variable in foo.variables]
+        "variables" => [name_map[variable] for variable in foo.variables],
     )
 end
 
 # ========== Typed vector functions ==========
 
-function moi_to_object(foo::MOI.VectorAffineTerm, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String})
+function moi_to_object(
+    foo::MOI.VectorAffineTerm, name_map::Dict{MOI.VariableIndex, String}
+)
     return Object(
         "output_index" => foo.output_index,
-        "scalar_term" => moi_to_object(foo.scalar_term, model, name_map)
+        "scalar_term" => moi_to_object(foo.scalar_term, name_map),
     )
 end
 
-function moi_to_object(foo::MOI.VectorAffineFunction, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String})
+function moi_to_object(
+    foo::MOI.VectorAffineFunction, name_map::Dict{MOI.VariableIndex, String}
+)
     return Object(
         "head" => "VectorAffineFunction",
-        "terms" => moi_to_object.(foo.terms, Ref(model), Ref(name_map)),
-        "constants" => foo.constants
+        "terms" => moi_to_object.(foo.terms, Ref(name_map)),
+        "constants" => foo.constants,
     )
 end
 
-function moi_to_object(foo::MOI.VectorQuadraticTerm, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String})
+function moi_to_object(
+    foo::MOI.VectorQuadraticTerm, name_map::Dict{MOI.VariableIndex, String}
+)
     return Object(
         "output_index" => foo.output_index,
-        "scalar_term" => moi_to_object(foo.scalar_term, model, name_map)
+        "scalar_term" => moi_to_object(foo.scalar_term, name_map),
     )
 end
 
-function moi_to_object(foo::MOI.VectorQuadraticFunction, model::Model,
-                   name_map::Dict{MOI.VariableIndex, String})
+function moi_to_object(
+    foo::MOI.VectorQuadraticFunction, name_map::Dict{MOI.VariableIndex, String}
+)
     return Object(
         "head" => "VectorQuadraticFunction",
-        "affine_terms" => moi_to_object.(foo.affine_terms, Ref(model), Ref(name_map)),
-        "quadratic_terms" => moi_to_object.(foo.quadratic_terms, Ref(model), Ref(name_map)),
-        "constants" => foo.constants
+        "affine_terms" => moi_to_object.(foo.affine_terms, Ref(name_map)),
+        "quadratic_terms" => moi_to_object.(foo.quadratic_terms, Ref(name_map)),
+        "constants" => foo.constants,
     )
 end
 
@@ -208,8 +226,9 @@ function head_name end
 # this to be called for a set that is not defined in the MOIU Model constructor.
 
 # Add every field as the field is named in MathOptInterface.
-function moi_to_object(set::SetType, model::Model,
-               name_map::Dict{MOI.VariableIndex, String}) where SetType
+function moi_to_object(
+    set::SetType, ::Dict{MOI.VariableIndex, String}
+) where {SetType}
     object = Object("head" => head_name(SetType))
     for key in fieldnames(SetType)
         object[string(key)] = getfield(set, key)
@@ -262,13 +281,12 @@ head_name(::Type{<:MOI.SOS1}) = "SOS1"
 head_name(::Type{<:MOI.SOS2}) = "SOS2"
 
 function moi_to_object(
-    set::MOI.IndicatorSet{I, S}, model::Model,
-    name_map::Dict{MOI.VariableIndex, String}
+    set::MOI.IndicatorSet{I, S}, name_map::Dict{MOI.VariableIndex, String}
 ) where {I, S}
     @assert I == MOI.ACTIVATE_ON_ONE || I == MOI.ACTIVATE_ON_ZERO
     return Object(
         "head" => "IndicatorSet",
-        "set" => moi_to_object(set.set, model, name_map),
+        "set" => moi_to_object(set.set, name_map),
         "activate_on" => (I == MOI.ACTIVATE_ON_ONE) ? "one" : "zero"
     )
 end

--- a/src/FileFormats/MOF/write.jl
+++ b/src/FileFormats/MOF/write.jl
@@ -5,14 +5,14 @@ Write `model` to `io` in the MathOptFormat file format.
 """
 function Base.write(io::IO, model::Model)
     options = get_options(model)
-    object = Object(
+    object = OrderedObject(
         "name"        => "MathOptFormat Model",
-        "version"     => Object(
+        "version"     => OrderedObject(
             "major" => Int(VERSION.major),
             "minor" => Int(VERSION.minor)
         ),
         "variables"   => Object[],
-        "objective"  => Object("sense" => "feasibility"),
+        "objective"  => OrderedObject("sense" => "feasibility"),
         "constraints" => Object[]
     )
     FileFormats.create_unique_names(model, warn=options.warn)
@@ -25,7 +25,7 @@ function Base.write(io::IO, model::Model)
     return
 end
 
-function write_variables(object::Object, model::Model)
+function write_variables(object, model::Model)
     name_map = Dict{MOI.VariableIndex, String}()
     for index in MOI.get(model, MOI.ListOfVariableIndices())
         variable = moi_to_object(index, model)
@@ -36,13 +36,13 @@ function write_variables(object::Object, model::Model)
 end
 
 function write_objective(
-    object::Object, model::Model, name_map::Dict{MOI.VariableIndex, String}
-)
+    object::T, model::Model, name_map::Dict{MOI.VariableIndex, String}
+) where {T <: Object}
     if object["objective"]["sense"] != "feasibility"
         return  # Objective must have been written from NLPBlock.
     end
     sense = MOI.get(model, MOI.ObjectiveSense())
-    object["objective"] = Object("sense" => moi_to_object(sense))
+    object["objective"] = T("sense" => moi_to_object(sense))
     if sense != MOI.FEASIBILITY_SENSE
         F = MOI.get(model, MOI.ObjectiveFunctionType())
         objective_function = MOI.get(model, MOI.ObjectiveFunction{F}())
@@ -53,8 +53,9 @@ function write_objective(
     return
 end
 
-function write_constraints(object::Object, model::Model,
-                           name_map::Dict{MOI.VariableIndex, String})
+function write_constraints(
+    object, model::Model, name_map::Dict{MOI.VariableIndex, String}
+)
     for (F, S) in MOI.get(model, MOI.ListOfConstraints())
         for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
             push!(object["constraints"], moi_to_object(index, model, name_map))
@@ -74,7 +75,7 @@ function moi_to_object(index::MOI.VariableIndex, model::Model)
     if name == ""
         error("Variable name for $(index) cannot be blank in an MOF file.")
     end
-    return Object("name" => name)
+    return OrderedObject("name" => name)
 end
 
 function moi_to_object(
@@ -85,7 +86,7 @@ function moi_to_object(
     func = MOI.get(model, MOI.ConstraintFunction(), index)
     set = MOI.get(model, MOI.ConstraintSet(), index)
     name = MOI.get(model, MOI.ConstraintName(), index)
-    object = Object()
+    object = OrderedObject()
     if name != ""
         object["name"] = name
     end
@@ -110,7 +111,7 @@ end
 function moi_to_object(
     foo::MOI.SingleVariable, name_map::Dict{MOI.VariableIndex, String}
 )
-    return Object(
+    return OrderedObject(
         "head" => "SingleVariable",
         "variable" => name_map[foo.variable]
     )
@@ -122,7 +123,7 @@ function moi_to_object(
     foo::MOI.ScalarAffineTerm{Float64},
     name_map::Dict{MOI.VariableIndex, String},
 )
-    return Object(
+    return OrderedObject(
         "coefficient" => foo.coefficient,
         "variable" => name_map[foo.variable_index]
     )
@@ -132,7 +133,7 @@ function moi_to_object(
     foo::MOI.ScalarAffineFunction{Float64},
     name_map::Dict{MOI.VariableIndex, String},
 )
-    return Object(
+    return OrderedObject(
         "head" => "ScalarAffineFunction",
         "terms" => moi_to_object.(foo.terms, Ref(name_map)),
         "constant" => foo.constant,
@@ -143,7 +144,7 @@ function moi_to_object(
     foo::MOI.ScalarQuadraticTerm{Float64},
     name_map::Dict{MOI.VariableIndex, String},
 )
-    return Object(
+    return OrderedObject(
         "coefficient" => foo.coefficient,
         "variable_1" => name_map[foo.variable_index_1],
         "variable_2" => name_map[foo.variable_index_2]
@@ -154,7 +155,7 @@ function moi_to_object(
     foo::MOI.ScalarQuadraticFunction{Float64},
     name_map::Dict{MOI.VariableIndex, String},
 )
-    return Object(
+    return OrderedObject(
         "head" => "ScalarQuadraticFunction",
         "affine_terms" => moi_to_object.(foo.affine_terms, Ref(name_map)),
         "quadratic_terms" => moi_to_object.(foo.quadratic_terms, Ref(name_map)),
@@ -167,7 +168,7 @@ end
 function moi_to_object(
     foo::MOI.VectorOfVariables, name_map::Dict{MOI.VariableIndex, String}
 )
-    return Object(
+    return OrderedObject(
         "head" => "VectorOfVariables",
         "variables" => [name_map[variable] for variable in foo.variables],
     )
@@ -178,7 +179,7 @@ end
 function moi_to_object(
     foo::MOI.VectorAffineTerm, name_map::Dict{MOI.VariableIndex, String}
 )
-    return Object(
+    return OrderedObject(
         "output_index" => foo.output_index,
         "scalar_term" => moi_to_object(foo.scalar_term, name_map),
     )
@@ -187,7 +188,7 @@ end
 function moi_to_object(
     foo::MOI.VectorAffineFunction, name_map::Dict{MOI.VariableIndex, String}
 )
-    return Object(
+    return OrderedObject(
         "head" => "VectorAffineFunction",
         "terms" => moi_to_object.(foo.terms, Ref(name_map)),
         "constants" => foo.constants,
@@ -197,7 +198,7 @@ end
 function moi_to_object(
     foo::MOI.VectorQuadraticTerm, name_map::Dict{MOI.VariableIndex, String}
 )
-    return Object(
+    return OrderedObject(
         "output_index" => foo.output_index,
         "scalar_term" => moi_to_object(foo.scalar_term, name_map),
     )
@@ -206,7 +207,7 @@ end
 function moi_to_object(
     foo::MOI.VectorQuadraticFunction, name_map::Dict{MOI.VariableIndex, String}
 )
-    return Object(
+    return OrderedObject(
         "head" => "VectorQuadraticFunction",
         "affine_terms" => moi_to_object.(foo.affine_terms, Ref(name_map)),
         "quadratic_terms" => moi_to_object.(foo.quadratic_terms, Ref(name_map)),
@@ -229,7 +230,7 @@ function head_name end
 function moi_to_object(
     set::SetType, ::Dict{MOI.VariableIndex, String}
 ) where {SetType}
-    object = Object("head" => head_name(SetType))
+    object = OrderedObject("head" => head_name(SetType))
     for key in fieldnames(SetType)
         object[string(key)] = getfield(set, key)
     end
@@ -284,7 +285,7 @@ function moi_to_object(
     set::MOI.IndicatorSet{I, S}, name_map::Dict{MOI.VariableIndex, String}
 ) where {I, S}
     @assert I == MOI.ACTIVATE_ON_ONE || I == MOI.ACTIVATE_ON_ZERO
-    return Object(
+    return OrderedObject(
         "head" => "IndicatorSet",
         "set" => moi_to_object(set.set, name_map),
         "activate_on" => (I == MOI.ACTIVATE_ON_ONE) ? "one" : "zero"

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -58,7 +58,7 @@ end
         @test_throws Exception MOF.moi_to_object(variable_index, model)
         MOI.FileFormats.create_unique_names(model, warn=true)
         @test MOF.moi_to_object(variable_index, model) ==
-            MOF.Object("name" => "x1")
+            MOF.OrderedObject("name" => "x1")
     end
     @testset "Duplicate variable name" begin
         model = MOF.Model()
@@ -66,11 +66,11 @@ end
         MOI.set(model, MOI.VariableName(), x, "x")
         y = MOI.add_variable(model)
         MOI.set(model, MOI.VariableName(), y, "x")
-        @test MOF.moi_to_object(x, model) == MOF.Object("name" => "x")
-        @test MOF.moi_to_object(y, model) == MOF.Object("name" => "x")
+        @test MOF.moi_to_object(x, model) == MOF.OrderedObject("name" => "x")
+        @test MOF.moi_to_object(y, model) == MOF.OrderedObject("name" => "x")
         MOI.FileFormats.create_unique_names(model, warn=true)
-        @test MOF.moi_to_object(x, model) == MOF.Object("name" => "x")
-        @test MOF.moi_to_object(y, model) == MOF.Object("name" => "x_1")
+        @test MOF.moi_to_object(x, model) == MOF.OrderedObject("name" => "x")
+        @test MOF.moi_to_object(y, model) == MOF.OrderedObject("name" => "x_1")
     end
     @testset "Blank constraint name" begin
         model = MOF.Model()

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -15,7 +15,7 @@ struct UnsupportedSet <: MOI.AbstractSet end
 struct UnsupportedFunction <: MOI.AbstractFunction end
 
 function test_model_equality(model_string, variables, constraints; suffix="")
-    model = MOF.Model()
+    model = MOF.Model(validate = true)
     MOIU.loadfromstring!(model, model_string)
     MOI.write_to_file(model, TEST_MOF_FILE * suffix)
     model_2 = MOF.Model()
@@ -99,24 +99,24 @@ end
 end
 @testset "round trips" begin
     @testset "Empty model" begin
-        model = MOF.Model()
+        model = MOF.Model(validate = true)
         MOI.write_to_file(model, TEST_MOF_FILE)
-        model_2 = MOF.Model()
+        model_2 = MOF.Model(validate = true)
         MOI.read_from_file(model_2, TEST_MOF_FILE)
         MOIU.test_models_equal(model, model_2, String[], String[])
     end
     @testset "FEASIBILITY_SENSE" begin
-        model = MOF.Model(validate=false)
+        model = MOF.Model(validate = true)
         x = MOI.add_variable(model)
         MOI.set(model, MOI.VariableName(), x, "x")
         MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
         MOI.write_to_file(model, TEST_MOF_FILE)
-        model_2 = MOF.Model(validate=false)
+        model_2 = MOF.Model(validate = true)
         MOI.read_from_file(model_2, TEST_MOF_FILE)
         MOIU.test_models_equal(model, model_2, ["x"], String[])
     end
     @testset "Empty function term" begin
-        model = MOF.Model()
+        model = MOF.Model(validate = true)
         x = MOI.add_variable(model)
         MOI.set(model, MOI.VariableName(), x, "x")
         c = MOI.add_constraint(model,
@@ -125,7 +125,7 @@ end
         )
         MOI.set(model, MOI.ConstraintName(), c, "c")
         MOI.write_to_file(model, TEST_MOF_FILE)
-        model_2 = MOF.Model()
+        model_2 = MOF.Model(validate = true)
         MOI.read_from_file(model_2, TEST_MOF_FILE)
         MOIU.test_models_equal(model, model_2, ["x"], ["c"])
     end

--- a/test/FileFormats/MOF/nonlinear.jl
+++ b/test/FileFormats/MOF/nonlinear.jl
@@ -1,7 +1,7 @@
 function roundtrip_nonlinear_expression(
     expr, variable_to_string, string_to_variable
 )
-    node_list = MOF.Object[]
+    node_list = MOF.OrderedObject[]
     object = MOF.convert_expr_to_mof(expr, node_list, variable_to_string)
     @test MOF.convert_mof_to_expr(object, node_list, string_to_variable) == expr
 end
@@ -60,7 +60,7 @@ end
             :(not_supported_function(x)), node_list, variable_to_string)
         # Test unsupported function for MOF -> Expr.
         @test_throws Exception MOF.convert_mof_to_expr(
-            MOF.Object("head"=>"not_supported_function", "value"=>1),
+            MOF.OrderedObject("head"=>"not_supported_function", "value"=>1),
             node_list, string_to_variable)
         # Test n-ary function with no arguments.
         @test_throws Exception MOF.convert_expr_to_mof(


### PR DESCRIPTION
- Disable validation by default. Large models are excessively slow
- Only pass `model` argument if necessary
- Style fixes

Here are the same benchmarks as https://github.com/jump-dev/MathOptInterface.jl/pull/1109#issuecomment-651190353. Almost all the time is in the JSON reader/writer, so I am investigating alternative packages, e.g., <s>https://github.com/quinnj/JSON2.jl</s>https://github.com/quinnj/JSON3.jl.
```
Benchmarking bab2.mof.json.gz
 28.975040 seconds (93.25 M allocations: 5.337 GiB, 28.06% gc time)
  7.827851 seconds (28.08 M allocations: 1.426 GiB, 7.81% gc time)
 17.103940 seconds (62.18 M allocations: 3.096 GiB, 29.77% gc time)
Benchmarking irish-electricity.mof.json.gz
  8.547113 seconds (29.20 M allocations: 1.702 GiB, 26.35% gc time)
  1.840084 seconds (6.03 M allocations: 326.758 MiB, 21.29% gc time)
  5.476004 seconds (21.25 M allocations: 1.092 GiB, 26.15% gc time)
Benchmarking n2seq36q.mof.json.gz
  1.753196 seconds (8.82 M allocations: 539.913 MiB)
  0.068960 seconds (528.03 k allocations: 37.539 MiB)
  1.624115 seconds (6.60 M allocations: 348.492 MiB, 23.21% gc time)
Benchmarking rocI-4-11.mof.json.gz
  0.713158 seconds (2.99 M allocations: 176.544 MiB)
  0.454900 seconds (1.51 M allocations: 75.668 MiB, 19.89% gc time)
  0.464614 seconds (2.10 M allocations: 106.495 MiB, 15.96% gc time)
Benchmarking rocII-5-11.mof.json.gz
  2.909575 seconds (11.66 M allocations: 709.547 MiB, 23.60% gc time)
  0.082422 seconds (600.17 k allocations: 44.882 MiB)
  2.372844 seconds (8.78 M allocations: 475.844 MiB, 29.05% gc time)
Benchmarking roi5alpha10n8.mof.json.gz
 21.743750 seconds (76.43 M allocations: 4.500 GiB, 36.25% gc time)
  0.393966 seconds (2.39 M allocations: 187.840 MiB)
 15.990958 seconds (59.22 M allocations: 3.112 GiB, 24.10% gc time)
Benchmarking supportcase42.mof.json.gz
  3.210505 seconds (14.29 M allocations: 871.042 MiB, 17.99% gc time)
  0.054430 seconds (299.17 k allocations: 33.244 MiB)
  2.650974 seconds (10.82 M allocations: 567.588 MiB, 19.72% gc time)
Benchmarking timtab1.mof.json.gz
  0.024931 seconds (94.75 k allocations: 5.772 MiB)
  0.001201 seconds (7.61 k allocations: 566.109 KiB)
  0.012308 seconds (68.88 k allocations: 3.700 MiB)
Benchmarking triptim1.mof.json.gz
  4.908370 seconds (18.91 M allocations: 1.129 GiB, 22.19% gc time)
  0.327538 seconds (865.58 k allocations: 58.395 MiB, 63.77% gc time)
  3.569853 seconds (14.32 M allocations: 735.137 MiB, 21.07% gc time)
Benchmarking uccase12.mof.json.gz
  8.423044 seconds (29.24 M allocations: 1.701 GiB, 20.47% gc time)
  0.724674 seconds (1.98 M allocations: 128.351 MiB, 48.15% gc time)
  5.658028 seconds (21.37 M allocations: 1.099 GiB, 26.49% gc time)
```