### PR TITLE
Improve performance of LazyBridgeOptimizer

### DIFF
--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -42,7 +42,7 @@ mutable struct LazyBridgeOptimizer{OT<:MOI.ModelLike} <: AbstractBridgeOptimizer
     objective_node::OrderedDict{Tuple{DataType}, ObjectiveNode}
     objective_types::Vector{Tuple{DataType}}
     # Cache for (F, S) -> BridgeType. Avoids having to look up
-    # `concrete_bridge_type`, which is slow.
+    # `concrete_bridge_type` at runtime, which is slow.
     cached_bridge_type::Dict{Any, DataType}
 end
 function LazyBridgeOptimizer(model::MOI.ModelLike)

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -41,8 +41,8 @@ mutable struct LazyBridgeOptimizer{OT<:MOI.ModelLike} <: AbstractBridgeOptimizer
     objective_bridge_types::Vector{Any}
     objective_node::OrderedDict{Tuple{DataType}, ObjectiveNode}
     objective_types::Vector{Tuple{DataType}}
-    # Cache for (F, S) -> BridgeType. Avoids having to look up the node in the
-    # graph, which is slow.
+    # Cache for (F, S) -> BridgeType. Avoids having to look up 
+    # `concrete_bridge_type`, which is slow.
     cached_bridge_type::Dict{Any, Any}
 end
 function LazyBridgeOptimizer(model::MOI.ModelLike)


### PR DESCRIPTION
Extracted from #1130

Key line is the `generate` in `SCS MOI scalar`. Drops from 130 ms to 85 ms.

## Before 

```
──────────────────────────────────────────────────────────────────────────
                                   Time                   Allocations      
                           ──────────────────────   ───────────────────────
     Tot / % measured:          1.48s / 44.8%            269MiB / 100%     

 Section           ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────────
 SCS MOI scalar         1    355ms  53.4%   355ms    140MiB  51.9%   140MiB
   solve                1    224ms  33.8%   224ms   85.9MiB  31.9%  85.9MiB
   generate             1    130ms  19.6%   130ms   53.9MiB  20.0%  53.9MiB
 GLPK MOI vector        1    106ms  16.0%   106ms   44.3MiB  16.4%  44.3MiB
   solve                1   90.2ms  13.6%  90.2ms   21.8MiB  8.09%  21.8MiB
   generate             1   15.7ms  2.37%  15.7ms   22.4MiB  8.33%  22.4MiB
 SCS MOI vector         1   77.4ms  11.7%  77.4ms   39.2MiB  14.6%  39.2MiB
   solve                1   70.4ms  10.6%  70.4ms   31.2MiB  11.6%  31.2MiB
   generate             1   6.78ms  1.02%  6.78ms   7.92MiB  2.94%  7.92MiB
 GLPK MOI scalar        1   71.6ms  10.8%  71.6ms   28.7MiB  10.7%  28.7MiB
   solve                1   62.5ms  9.40%  62.5ms   18.0MiB  6.70%  18.0MiB
   generate             1   8.81ms  1.33%  8.81ms   10.7MiB  3.96%  10.7MiB
 SCS direct             1   35.3ms  5.31%  35.3ms   15.2MiB  5.66%  15.2MiB
   solve                1   22.0ms  3.32%  22.0ms   2.15MiB  0.80%  2.15MiB
   generate             1   13.3ms  2.00%  13.3ms   13.1MiB  4.86%  13.1MiB
 GLPK direct            1   19.1ms  2.87%  19.1ms   2.08MiB  0.77%  2.08MiB
   solve                1   12.2ms  1.83%  12.2ms     0.00B  0.00%    0.00B
   generate             1   6.44ms  0.97%  6.44ms   2.08MiB  0.77%  2.08MiB
 ──────────────────────────────────────────────────────────────────────────
 ```

## After

```
 ──────────────────────────────────────────────────────────────────────────
                                   Time                   Allocations      
                           ──────────────────────   ───────────────────────
     Tot / % measured:          1.43s / 43.3%            269MiB / 100%     

 Section           ncalls     time   %tot     avg     alloc   %tot      avg
 ──────────────────────────────────────────────────────────────────────────
 SCS MOI scalar         1    310ms  50.0%   310ms    140MiB  51.9%   140MiB
   solve                1    224ms  36.1%   224ms   85.9MiB  31.9%  85.9MiB
   generate             1   85.7ms  13.8%  85.7ms   53.9MiB  20.0%  53.9MiB
 GLPK MOI vector        1    107ms  17.3%   107ms   44.3MiB  16.4%  44.3MiB
   solve                1   91.1ms  14.7%  91.1ms   21.8MiB  8.09%  21.8MiB
   generate             1   16.0ms  2.58%  16.0ms   22.4MiB  8.33%  22.4MiB
 SCS MOI vector         1   78.1ms  12.6%  78.1ms   39.2MiB  14.6%  39.2MiB
   solve                1   71.4ms  11.5%  71.4ms   31.2MiB  11.6%  31.2MiB
   generate             1   6.43ms  1.04%  6.43ms   7.92MiB  2.94%  7.92MiB
 GLPK MOI scalar        1   70.3ms  11.3%  70.3ms   28.7MiB  10.7%  28.7MiB
   solve                1   62.2ms  10.0%  62.2ms   18.0MiB  6.70%  18.0MiB
   generate             1   7.82ms  1.26%  7.82ms   10.7MiB  3.96%  10.7MiB
 SCS direct             1   32.7ms  5.28%  32.7ms   15.2MiB  5.66%  15.2MiB
   solve                1   20.1ms  3.24%  20.1ms   2.15MiB  0.80%  2.15MiB
   generate             1   12.6ms  2.03%  12.6ms   13.1MiB  4.86%  13.1MiB
 GLPK direct            1   21.3ms  3.44%  21.3ms   2.08MiB  0.77%  2.08MiB
   solve                1   12.2ms  1.97%  12.2ms     0.00B  0.00%    0.00B
   generate             1   8.32ms  1.34%  8.32ms   2.08MiB  0.77%  2.08MiB
 ──────────────────────────────────────────────────────────────────────────
 ```