### PR TITLE
When copying a model, propose to only keep conflict constraints.

### DIFF
--- a/src/Benchmarks/Benchmarks.jl
+++ b/src/Benchmarks/Benchmarks.jl
@@ -232,4 +232,25 @@ end
     return model
 end
 
+@add_benchmark function copy_model(new_model)
+    model = new_model()
+    index = MOI.add_variables(model, 1_000)
+    cons = Vector{
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}}
+    }(undef, 1_000)
+    for (i, x) in enumerate(index)
+        cons[i] = MOI.add_constraint(
+            model,
+            MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0),
+            MOI.LessThan(1.0 * i)
+        )
+    end
+    
+    model2 = new_model()
+    MOI.copy_to(model2, model)
+    # MOI.copy_to(model2, model, filter_constraints=(x) -> x in cons[1:500])
+
+    return model2
+end
+
 end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -266,7 +266,7 @@ function copy_constraints(dest::MOI.ModelLike, src::MOI.ModelLike,
     # Retrieve the constraints to copy.
     f_src = MOI.get(src, MOI.ConstraintFunction(), cis_src)
 
-    # Filter this set of constraints if need before.
+    # Filter this set of constraints if needed before.
     if filter_constraints !== nothing
         filter!(filter_constraints, cis_src)
     end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -287,6 +287,9 @@ function pass_constraints(
     pass_cons=copy_constraints, pass_attr=MOI.set;
     filter_constraints::Union{Nothing, Function}=nothing
 )
+    # copy_constraints can also take a filter_constraints argument; however, filtering
+    # is performed within this function (because it also calls MOI.set on the constraints). 
+    # Don't pass this argument to copy_constraints/pass_cons to avoid a double filtering.
     for (S, cis_src) in zip(single_variable_types,
                             single_variable_indices)
         if filter_constraints !== nothing

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -249,7 +249,7 @@ end
     copy_constraints(dest::MOI.ModelLike, src::MOI.ModelLike,
                      idxmap::IndexMap,
                      cis_src::Vector{<:MOI.ConstraintIndex},
-                     filter_constraints::Function=(() -> true))
+                     filter_constraints::Union{Nothing, Function}=nothing)
 
 Copy the constraints `cis_src` from the model `src` to the model `dest` and fill
 `idxmap` accordingly. Note that the attributes are not copied; call

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -278,24 +278,28 @@ function pass_constraints(
     dest::MOI.ModelLike, src::MOI.ModelLike, copy_names::Bool, idxmap::IndexMap,
     single_variable_types, single_variable_indices,
     vector_of_variables_types, vector_of_variables_indices,
-    pass_cons=copy_constraints, pass_attr=MOI.set,
+    pass_cons=copy_constraints, pass_attr=MOI.set;
     filter_constraints::Function=((x) -> true)
 )
     for (S, cis_src) in zip(single_variable_types,
                             single_variable_indices)
+        filter!(filter_constraints, cis_src)
         # do the rest in `pass_cons` which is type stable
         pass_cons(dest, src, idxmap, cis_src)
         cis_src = MOI.get(src, MOI.ListOfConstraintIndices{
             MOI.SingleVariable, S}())
+        filter!(filter_constraints, cis_src)
         pass_attributes(dest, src, copy_names, idxmap, cis_src, pass_attr)
     end
 
     for (S, cis_src) in zip(vector_of_variables_types,
                             vector_of_variables_indices)
+        filter!(filter_constraints, cis_src)
         # do the rest in `pass_cons` which is type stable
         pass_cons(dest, src, idxmap, cis_src)
         cis_src = MOI.get(src, MOI.ListOfConstraintIndices{
             MOI.VectorOfVariables, S}())
+        filter!(filter_constraints, cis_src)
         pass_attributes(dest, src, copy_names, idxmap, cis_src, pass_attr)
     end
 
@@ -305,8 +309,9 @@ function pass_constraints(
     ]
     for (F, S) in nonvariable_constraint_types
         cis_src = MOI.get(src, MOI.ListOfConstraintIndices{F, S}())
+        filter!(filter_constraints, cis_src)
         # do the rest in `pass_cons` which is type stable
-        pass_cons(dest, src, idxmap, cis_src, filter_constraints=filter_constraints)
+        pass_cons(dest, src, idxmap, cis_src)#, filter_constraints=filter_constraints)
         pass_attributes(dest, src, copy_names, idxmap, cis_src, pass_attr)
     end
 end

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -256,3 +256,23 @@ MOI.supports_add_constrained_variable(::ReverseOrderConstrainedVariablesModel, :
     @test typeof(c1) == typeof(dest.constraintIndices[1])
     @test typeof(c2) == typeof(dest.constraintIndices[2])
 end
+
+@testset "Filtering copy" begin
+    # Create a basic model. 
+    src = MOIU.Model{Float64}()
+    x = MOI.add_variable(src)
+    c1 = MOI.add_constraint(src, x, MOI.LessThan{Float64}(1.0))
+    c2 = MOI.add_constraint(src, x, MOI.GreaterThan{Float64}(0.0))
+
+    # Filtering function: the default case where this function always returns
+    # true is already well-tested by the above cases.
+    # Only keep the constraint c1.
+    f = (cidx) -> cidx == c1
+    
+    # Perform the copy.
+    dst = OrderConstrainedVariablesModel()
+    index_map = MOI.copy_to(dst, src, filter_constraints=f)
+
+    @test typeof(c1) == typeof(dst.constraintIndices[1])
+    @test length(dst.constraintIndices) == 1
+end


### PR DESCRIPTION
In line with #1035, a first step to allow a common interface for conflicts (exporting just these constraints). Copying the relevant constraints is a more flexible way to get to that point. 