### PR TITLE
Fixing `set_start_value` only accept numbers (#2237)

### DIFF
--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -451,7 +451,7 @@ function start_values_unset_test(model::MOI.ModelLike, config)
         # determined behaviour, there are two possibilities about the behaviour
         # of ListOfConstraintAttributesSet and ListOfVariableAttributesSet:
         #
-        # 1) They list all attributes ever set, even after unsetted.
+        # 1) They list all attributes ever set, even after attributes are unset.
         # 2) They list only the attributes that, at the moment, are set.
         #
         # The current behavior is (1), but we are not sure if this will not

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -386,7 +386,13 @@ function failcopytestca(dest::MOI.ModelLike)
     @test_throws MOI.UnsupportedAttribute MOI.copy_to(dest, BadConstraintAttributeModel())
 end
 
-function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
+function start_values_test(
+    dest::MOI.ModelLike, src::MOI.ModelLike;
+    skip_variable_primal = false,
+    skip_vp_unsetting = false,
+    skip_constraint_primal = false,
+    skip_constraint_dual = false
+)
     MOI.empty!(dest)
     @test MOIU.supports_default_copy_to(src, #=copy_names=# false)
     x, y, z = MOI.add_variables(src, 3)
@@ -403,56 +409,92 @@ function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
     cpattr = MOI.ConstraintPrimalStart()
     cdattr = MOI.ConstraintDualStart()
 
+    # shorten names
+    test_vp = !skip_variable_primal
+    test_cp = !skip_constraint_primal
+    test_cd = !skip_constraint_dual
+
     @testset "Supports" begin
-        @test MOI.supports(dest, vpattr, MOI.VariableIndex)
-        @test MOI.supports(dest, cpattr, MOI.ConstraintIndex{F1, S1})
-        @test MOI.supports(dest, cpattr, MOI.ConstraintIndex{F2, S2})
-        @test MOI.supports(dest, cdattr, MOI.ConstraintIndex{F1, S1})
-        @test MOI.supports(dest, cdattr, MOI.ConstraintIndex{F2, S2})
+        test_vp && @test MOI.supports(dest, vpattr, MOI.VariableIndex)
+        if test_cp
+            @test MOI.supports(dest, cpattr, MOI.ConstraintIndex{F1, S1})
+            @test MOI.supports(dest, cpattr, MOI.ConstraintIndex{F2, S2})
+        end
+        if test_cd
+            @test MOI.supports(dest, cdattr, MOI.ConstraintIndex{F1, S1})
+            @test MOI.supports(dest, cdattr, MOI.ConstraintIndex{F2, S2})
+        end
+    end
+
+    if skip_vp_unsetting
+        @testset "Allows unsetting by nothing" begin
+            MOI.set(model, vpattr, x, 1.0)
+            MOI.set(model, vpattr, y, 0.0)
+            MOI.set(model, vpattr, z, 2.0)
+            @test MOI.get.(model, vpattr, (x, y, z)) == (1.0, 0.0, 2.0)
+            MOI.set(model, vpattr, y, nothing)
+            @test MOI.get.(model, vpattr, (x, y, z)) == (1.0, nothing, 2.0)
+            MOI.set.(model, vpattr, (x, z), (nothing, nothing))
+            @test MOI.get.(model, vpattr, (x, y, z)) ==
+                (nothing, nothing, nothing)
+        end
     end
 
     @testset "Attribute set to no indices" begin
         dict = MOI.copy_to(dest, src, copy_names=false)
 
-        @test !(vpattr in MOI.get(dest, MOI.ListOfVariableAttributesSet()))
-        @test MOI.get(dest, vpattr, dict[x]) === nothing
-        @test MOI.get(dest, vpattr, dict[y]) === nothing
-        @test MOI.get(dest, vpattr, dict[z]) === nothing
-        @test !(cpattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F1, S1}()))
-        @test MOI.get(dest, cpattr, dict[a]) === nothing
-        @test MOI.get(dest, cpattr, dict[b]) === nothing
-        @test !(cpattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F2, S2}()))
-        @test MOI.get(dest, cpattr, dict[c]) === nothing
-        @test !(cdattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F1, S1}()))
-        @test MOI.get(dest, cdattr, dict[a]) === nothing
-        @test MOI.get(dest, cdattr, dict[b]) === nothing
-        @test !(cdattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F2, S2}()))
-        @test MOI.get(dest, cdattr, dict[c]) === nothing
+        if test_vp
+            @test !(vpattr in MOI.get(dest, MOI.ListOfVariableAttributesSet()))
+            @test MOI.get(dest, vpattr, dict[x]) === nothing
+            @test MOI.get(dest, vpattr, dict[y]) === nothing
+            @test MOI.get(dest, vpattr, dict[z]) === nothing
+        end
+
+        if test_cp
+            @test !(cpattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F1, S1}()))
+            @test MOI.get(dest, cpattr, dict[a]) === nothing
+            @test MOI.get(dest, cpattr, dict[b]) === nothing
+            @test !(cpattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F2, S2}()))
+            @test MOI.get(dest, cpattr, dict[c]) === nothing
+        end
+        if test_cd
+            @test !(cdattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F1, S1}()))
+            @test MOI.get(dest, cdattr, dict[a]) === nothing
+            @test MOI.get(dest, cdattr, dict[b]) === nothing
+            @test !(cdattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F2, S2}()))
+            @test MOI.get(dest, cdattr, dict[c]) === nothing
+        end
     end
 
     @testset "Attribute set to some indices" begin
-        MOI.set(src, vpattr, x, 1.0)
-        MOI.set(src, vpattr, z, 3.0)
-        MOI.set(src, cpattr, a, 1.0)
-        MOI.set(src, cpattr, b, 2.0)
-        MOI.set(src, cdattr, b, 2.0)
-        MOI.set(src, cdattr, c, [3.0])
+        test_vp && MOI.set(src, vpattr, x, 1.0)
+        test_vp && MOI.set(src, vpattr, z, 3.0)
+        test_cp && MOI.set(src, cpattr, a, 1.0)
+        test_cp && MOI.set(src, cpattr, b, 2.0)
+        test_cd && MOI.set(src, cdattr, b, 2.0)
+        test_cd && MOI.set(src, cdattr, c, [3.0])
 
         dict = MOI.copy_to(dest, src, copy_names=false)
 
-        @test vpattr in MOI.get(dest, MOI.ListOfVariableAttributesSet())
-        @test MOI.get(dest, vpattr, dict[x]) == 1.0
-        @test MOI.get(dest, vpattr, dict[y]) === nothing
-        @test MOI.get(dest, vpattr, dict[z]) == 3.0
-        @test cpattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F1, S1}())
-        @test MOI.get(dest, cpattr, dict[a]) == 1.0
-        @test MOI.get(dest, cpattr, dict[b]) == 2.0
-        @test MOI.get(dest, cpattr, dict[c]) === nothing
-        @test cdattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F1, S1}())
-        @test MOI.get(dest, cdattr, dict[a]) === nothing
-        @test MOI.get(dest, cdattr, dict[b]) == 2.0
-        @test cdattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F2, S2}())
-        @test MOI.get(dest, cdattr, dict[c]) == [3.0]
+        if test_vp
+            @test vpattr in MOI.get(dest, MOI.ListOfVariableAttributesSet())
+            @test MOI.get(dest, vpattr, dict[x]) == 1.0
+            @test MOI.get(dest, vpattr, dict[y]) === nothing
+            @test MOI.get(dest, vpattr, dict[z]) == 3.0
+        end
+        if test_cp
+            @test cpattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F1, S1}())
+            @test MOI.get(dest, cpattr, dict[a]) == 1.0
+            @test MOI.get(dest, cpattr, dict[b]) == 2.0
+            @test MOI.get(dest, cpattr, dict[c]) === nothing
+        end
+        if test_cd
+            @test cdattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F1, S1}())
+            @test MOI.get(dest, cdattr, dict[a]) === nothing
+            @test MOI.get(dest, cdattr, dict[b]) == 2.0
+            @test cdattr in MOI.get(dest, MOI.ListOfConstraintAttributesSet{F2, S2}())
+            @test MOI.get(dest, cdattr, dict[c]) == [3.0]
+        end
     end
 end
 

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -408,16 +408,16 @@ function start_values_unset_test(model::MOI.ModelLike, config)
         @test MOI.get(model, vpattr, y) === nothing
         @test MOI.get(model, vpattr, z) === nothing
 
-        @test !(cpattr in MOI.get(model, MOI.ListOfConstraintAttributesSet{F1, S1}()))
+        @test cpattr ∉ MOI.get(model, MOI.ListOfConstraintAttributesSet{F1, S1}())
         @test MOI.get(model, cpattr, a) === nothing
         @test MOI.get(model, cpattr, b) === nothing
-        @test !(cpattr in MOI.get(model, MOI.ListOfConstraintAttributesSet{F2, S2}()))
+        @test cpattr ∉ MOI.get(model, MOI.ListOfConstraintAttributesSet{F2, S2}())
         @test MOI.get(model, cpattr, c) === nothing
 
-        @test !(cdattr in MOI.get(model, MOI.ListOfConstraintAttributesSet{F1, S1}()))
+        @test cdattr ∉ MOI.get(model, MOI.ListOfConstraintAttributesSet{F1, S1}())
         @test MOI.get(model, cdattr, a) === nothing
         @test MOI.get(model, cdattr, b) === nothing
-        @test !(cdattr in MOI.get(model, MOI.ListOfConstraintAttributesSet{F2, S2}()))
+        @test cdattr ∉ MOI.get(model, MOI.ListOfConstraintAttributesSet{F2, S2}())
         @test MOI.get(model, cdattr, c) === nothing
     end
 
@@ -444,23 +444,36 @@ function start_values_unset_test(model::MOI.ModelLike, config)
         MOI.set(model, vpattr, y, nothing)
         MOI.set(model, cpattr, a, nothing)
         MOI.set(model, cdattr, a, nothing)
-        MOI.set(model, cpattr, c, [nothing])
-        MOI.set(model, cdattr, c, [nothing])
+        MOI.set(model, cpattr, c, nothing)
+        MOI.set(model, cdattr, c, nothing)
 
+        # The tests below are commented because it was decided to not pin a
+        # determined behaviour, there are two possibilities about the behaviour
+        # of ListOfConstraintAttributesSet and ListOfVariableAttributesSet:
+        #
+        # 1) They list all attributes ever set, even after unsetted.
+        # 2) They list only the attributes that, at the moment, are set.
+        #
+        # The current behavior is (1), but we are not sure if this will not
+        # be changed in the future, so we do not include any tests for it.
+        # The commented tests assume (2) and if uncommented will fail.
+        # Ref.: https://github.com/jump-dev/MathOptInterface.jl/pull/1136#discussion_r496466058
         #@test cpattr ∉ MOI.get(model, MOI.ListOfConstraintAttributesSet{F2, S2}())
         #@test cdattr ∉ MOI.get(model, MOI.ListOfConstraintAttributesSet{F2, S2}())
 
-        @test all(MOI.get.((model,), (vpattr,), (x, y, z)) .== (0.0, nothing, 2.0))
-        @test all(MOI.get.((model,), (cpattr,), (a, b)) .== (nothing, 1.0))
-        @test all(MOI.get.((model,), (cdattr,), (a, b)) .== (nothing, 1.0))
-        @test MOI.get(model, cpattr, c) == [nothing]
-        @test MOI.get(model, cdattr, c) == [nothing]
+        @test all(MOI.get.((model,), (vpattr,), (x, y, z)) .=== (0.0, nothing, 2.0))
+        @test all(MOI.get.((model,), (cpattr,), (a, b)) .=== (nothing, 1.0))
+        @test all(MOI.get.((model,), (cdattr,), (a, b)) .=== (nothing, 1.0))
+        @test MOI.get(model, cpattr, c) === nothing
+        @test MOI.get(model, cdattr, c) === nothing
 
         MOI.set(model, vpattr, x, nothing)
         MOI.set(model, vpattr, z, nothing)
         MOI.set(model, cpattr, b, nothing)
         MOI.set(model, cdattr, b, nothing)
 
+        # The three tests below are commented for the same reason the two
+        # commented tests above.
         #@test vpattr ∉ MOI.get(model, MOI.ListOfVariableAttributesSet())
         #@test cpattr ∉ MOI.get(model, MOI.ListOfConstraintAttributesSet{F1, S1}())
         #@test cdattr ∉ MOI.get(model, MOI.ListOfConstraintAttributesSet{F1, S1}())

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -964,7 +964,7 @@ struct VariableName <: AbstractVariableAttribute end
 """
     VariablePrimalStart()
 
-A variable attribute for the initial assignment to some primal variable's value that the optimizer may use to warm-start the solve. May be a number or nothing (unset).
+A variable attribute for the initial assignment to some primal variable's value that the optimizer may use to warm-start the solve. May be a number or `nothing` (unset).
 """
 struct VariablePrimalStart <: AbstractVariableAttribute end
 
@@ -1043,14 +1043,14 @@ struct ConstraintName <: AbstractConstraintAttribute end
 """
     ConstraintPrimalStart()
 
-A constraint attribute for the initial assignment to some constraint's primal value(s) that the optimizer may use to warm-start the solve. May be a number or nothing (unset).
+A constraint attribute for the initial assignment to some constraint's primal value(s) that the optimizer may use to warm-start the solve. May be a number or `nothing` (unset).
 """
 struct ConstraintPrimalStart <: AbstractConstraintAttribute end
 
 """
     ConstraintDualStart()
 
-A constraint attribute for the initial assignment to some constraint's dual value(s) that the optimizer may use to warm-start the solve. May be a number or nothing (unset).
+A constraint attribute for the initial assignment to some constraint's dual value(s) that the optimizer may use to warm-start the solve. May be a number or `nothing` (unset).
 """
 struct ConstraintDualStart <: AbstractConstraintAttribute end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -69,7 +69,7 @@ An error indicating that the attribute `attr` is supported (see
 """
 struct SetAttributeNotAllowed{AttrType<:AnyAttribute} <: NotAllowedError
     attr::AttrType
-	message::String # Human-friendly explanation why the attribute cannot be set
+    message::String # Human-friendly explanation why the attribute cannot be set
 end
 SetAttributeNotAllowed(attr::AnyAttribute) = SetAttributeNotAllowed(attr, "")
 
@@ -965,6 +965,8 @@ struct VariableName <: AbstractVariableAttribute end
     VariablePrimalStart()
 
 A variable attribute for the initial assignment to some primal variable's value that the optimizer may use to warm-start the solve.
+
+The value `nothing` means the solver is free to decide which value to use. This attribute can be set back to `nothing` after being set to a numerical value.
 """
 struct VariablePrimalStart <: AbstractVariableAttribute end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -964,9 +964,7 @@ struct VariableName <: AbstractVariableAttribute end
 """
     VariablePrimalStart()
 
-A variable attribute for the initial assignment to some primal variable's value that the optimizer may use to warm-start the solve.
-
-The value `nothing` means the solver is free to decide which value to use. This attribute can be set back to `nothing` after being set to a numerical value.
+A variable attribute for the initial assignment to some primal variable's value that the optimizer may use to warm-start the solve. May be a number or nothing (unset).
 """
 struct VariablePrimalStart <: AbstractVariableAttribute end
 
@@ -1045,14 +1043,14 @@ struct ConstraintName <: AbstractConstraintAttribute end
 """
     ConstraintPrimalStart()
 
-A constraint attribute for the initial assignment to some constraint's primal value(s) that the optimizer may use to warm-start the solve.
+A constraint attribute for the initial assignment to some constraint's primal value(s) that the optimizer may use to warm-start the solve. May be a number or nothing (unset).
 """
 struct ConstraintPrimalStart <: AbstractConstraintAttribute end
 
 """
     ConstraintDualStart()
 
-A constraint attribute for the initial assignment to some constraint's dual value(s) that the optimizer may use to warm-start the solve.
+A constraint attribute for the initial assignment to some constraint's dual value(s) that the optimizer may use to warm-start the solve. May be a number or nothing (unset).
 """
 struct ConstraintDualStart <: AbstractConstraintAttribute end
 

--- a/test/Test/modellike.jl
+++ b/test/Test/modellike.jl
@@ -2,6 +2,12 @@ using Test
 import MathOptInterface
 const MOI = MathOptInterface
 const MOIT = MOI.Test
+const MOU = MOI.Utilities
+
+@testset "Start value attributes and nothing" begin
+    model = MOIU.MockOptimizer(MOIU.UniversalFallback(MOIU.Model{Float64}()))
+    MOI.Test.start_values_unset_test(model, MOI.Test.TestConfig())
+end
 
 @testset "Failed copy" begin
     include("../dummy.jl")


### PR DESCRIPTION
Intends to close #2237 and some related open issues (#649, #794, #853).

Some guidance is needed. For now, I just edited what I found to be the relevant piece of documentation, and added a new tests as well flags to an old test (allowing more granular selection of which attributes are tested). I would like to know:

1. There are other places where the documentation needs to be changed? `JuMP` probably will need a change, but there are other points inside MOI?
2. Seems to me that allowing `nothing` to be passed is something done at the wrapper level, and the generic methods in MOI already allow it. The test will probably force the wrappers to allow this behavior.
3. How is the best way to check if the test is working? Should I download a bunch of wrappers and make they use my version of MOI, and then call their tests?

No hurry, @odow, I do not know if I will work during the week, but I will try finish it next weekend if I am sure of what needs to be done yet. 