### PR TITLE
Double dict reversion

### DIFF
--- a/src/Utilities/DoubleDicts.jl
+++ b/src/Utilities/DoubleDicts.jl
@@ -73,24 +73,17 @@ end
     v
 end
 
-function MOIU._reverse_dict(dest::IndexDoubleDict, src::IndexDoubleDict)
+# reversing IndexDoubleDict is ok because they map CI to CI
+function MOIU._reverse_dict(
+    dest::IndexDoubleDict{DI}, src::IndexDoubleDict{DI}
+) where DI
     for (k, v) in src.dict
-        dest.dict[k] = MOIU._reverse_dict(v)
+        dest.dict[k] = DI(values(v) .=> keys(v))
     end
-    # error("skeurghrgtseuihrglkjsehjkserhglih")
 end
-function MOIU._reverse_dict(src::D) where {D<:AbstractDict}
-    # dest = D()
-    # sizehint!(dest, length(src))
-    # MOIU._reverse_dict(dest, src)
-    D(values(src) .=> keys(src))
-    # Dict(v => k for (k,v) in src)::D
-end
-# function MOIU._reverse_dict(dest::Dict{Int64,Inf64}, src::Dict{Int64,Inf64})
-#     for (k,v) in src
-#         dest[v] = k
-#     end
-# end
+# reversing other double dict types is not ok because the map CI fo K
+# so it wont be a double dict anymore, double dict keys are always CIs.
+# We keep the default fallback
 
 function Base.sizehint!(::AbstractDoubleDict, ::Integer)
     throw(ErrorException("sizehint!(d::DoubleDict, ::Integer) has no proper" *

--- a/src/Utilities/DoubleDicts.jl
+++ b/src/Utilities/DoubleDicts.jl
@@ -3,6 +3,7 @@ module DoubleDicts
 import MathOptInterface
 
 const MOI = MathOptInterface
+const MOIU = MOI.Utilities
 const CI = MOI.ConstraintIndex
 const AD = AbstractDict
 
@@ -71,6 +72,25 @@ end
 @inline function typed_value(::FunctionSetDoubleDict, v::Tuple{F,S}, ::Type{F}, ::Type{S})::Tuple{F,S} where {F, S}
     v
 end
+
+function MOIU._reverse_dict(dest::IndexDoubleDict, src::IndexDoubleDict)
+    for (k, v) in src.dict
+        dest.dict[k] = MOIU._reverse_dict(v)
+    end
+    # error("skeurghrgtseuihrglkjsehjkserhglih")
+end
+function MOIU._reverse_dict(src::D) where {D<:AbstractDict}
+    # dest = D()
+    # sizehint!(dest, length(src))
+    # MOIU._reverse_dict(dest, src)
+    D(values(src) .=> keys(src))
+    # Dict(v => k for (k,v) in src)::D
+end
+# function MOIU._reverse_dict(dest::Dict{Int64,Inf64}, src::Dict{Int64,Inf64})
+#     for (k,v) in src
+#         dest[v] = k
+#     end
+# end
 
 function Base.sizehint!(::AbstractDoubleDict, ::Integer)
     throw(ErrorException("sizehint!(d::DoubleDict, ::Integer) has no proper" *

--- a/src/Utilities/DoubleDicts.jl
+++ b/src/Utilities/DoubleDicts.jl
@@ -78,7 +78,7 @@ function MOIU._reverse_dict(
     dest::IndexDoubleDict{DI}, src::IndexDoubleDict{DI}
 ) where DI
     for (k, v) in src.dict
-        dest.dict[k] = DI(values(v) .=> keys(v))
+        dest.dict[k] = MOIU._reverse_dict(v)
     end
 end
 # reversing other double dict types is not ok because the map CI fo K

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -26,6 +26,9 @@ function print_with_acronym(io::IO, s::AbstractString)
     print(io, s)
 end
 
+
+function _reverse_dict end
+
 include("CleverDicts.jl")
 include("DoubleDicts.jl")
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -26,7 +26,17 @@ function print_with_acronym(io::IO, s::AbstractString)
     print(io, s)
 end
 
+"""
+    _reverse_dict(src::AbstractDict)
 
+Reverse dictionary `src` so that values of the new dictionary are keys of `src`
+and vice-versa. Also the values of `src` are assumed to be unique.
+
+    _reverse_dict(dest::AbstractDict, src::AbstractDict)
+
+Reverse dictionary so that values of `src` are key of `dest` and vice-versa.
+`dest` must be empty. Also the values of `src` are assumed to be unique.
+"""
 function _reverse_dict end
 
 include("CleverDicts.jl")

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -184,12 +184,10 @@ function _standardize(d::AbstractDict)
     return map
 end
 function _standardize(d::IndexMap)
-    # return d
     # if we return d as is, its not possible to add variables
     # if there was a dense dict inside
     # the solution would be to allow automatically swtiching
     # a ClevelDenseDict...
-    # return IndexMap(d.varmap, d.conmap)
     return IndexMap(_standard_dict(d.varmap), d.conmap)
 end
 function _standard_dict(
@@ -202,8 +200,7 @@ function _standard_dict(
 )::Dict{MOI.VariableIndex, MOI.VariableIndex} where {
     D<:AbstractDict{MOI.VariableIndex, MOI.VariableIndex}
 }
-    ret = Dict{MOI.VariableIndex, MOI.VariableIndex}(keys(d) .=> values(d))
-    return ret
+    return Dict{MOI.VariableIndex, MOI.VariableIndex}(keys(d) .=> values(d))
 end
 
 function MOI.copy_to(m::CachingOptimizer, src::MOI.ModelLike; kws...)

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -164,12 +164,6 @@ function _reverse_index_map(src::IndexMap)
     return dest
 end
 
-"""
-    _reverse_dict(dest::AbstractDict, src::AbstractDict)
-
-Reverse dictionary so that values of `src` are key of `dest` and vice-versa.
-`dest` must be empty. Also the values of `src` are assumed to be unique.
-"""
 function _reverse_dict(dest::AbstractDict, src::AbstractDict)
     for (k,v) in src
         dest[v] = k

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -151,12 +151,12 @@ function attach_optimizer(model::CachingOptimizer)
     model.state = ATTACHED_OPTIMIZER
     # MOI does not define the type of index_map, so we have to convert it
     # into an actual IndexMap. Also load the reverse IndexMap.
-    model.model_to_optimizer_map = convert(IndexMap, indexmap)
-    model.optimizer_to_model_map = reverse_index_map(indexmap)
+    model.model_to_optimizer_map = _standardize(indexmap)
+    model.optimizer_to_model_map = _reverse_index_map(indexmap)
     return nothing
 end
 
-function reverse_index_map(src::IndexMap)
+function _reverse_index_map(src::IndexMap)
     dest = IndexMap()
     sizehint!(dest.varmap, length(src.varmap))
     _reverse_dict(dest.varmap, src.varmap)
@@ -176,14 +176,14 @@ function _reverse_dict(dest::AbstractDict, src::AbstractDict)
     end
 end
 
-function Base.convert(::Type{IndexMap}, d::AbstractDict{MOI.Index, MOI.Index})
+function _standardize(d::AbstractDict{MOI.Index, MOI.Index})
     map = IndexMap()
     for (k,v) in d
         map[k] = v
     end
     return map
 end
-function Base.convert(::Type{IndexMap}, d::IndexMap)
+function _standardize(d::IndexMap)
     # return d
     # if we return d as is, its not possible to add variables
     # if there was a dense dict inside

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -175,6 +175,9 @@ function _reverse_dict(dest::AbstractDict, src::AbstractDict)
         dest[v] = k
     end
 end
+function _reverse_dict(src::D) where {D<:Dict}
+    return D(values(src) .=> keys(src))
+end
 
 function _standardize(d::AbstractDict)
     map = IndexMap()

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -176,7 +176,7 @@ function _reverse_dict(dest::AbstractDict, src::AbstractDict)
     end
 end
 
-function _standardize(d::AbstractDict{MOI.Index, MOI.Index})
+function _standardize(d::AbstractDict)
     map = IndexMap()
     for (k,v) in d
         map[k] = v
@@ -189,6 +189,7 @@ function _standardize(d::IndexMap)
     # if there was a dense dict inside
     # the solution would be to allow automatically swtiching
     # a ClevelDenseDict...
+    # return IndexMap(d.varmap, d.conmap)
     return IndexMap(_standard_dict(d.varmap), d.conmap)
 end
 function _standard_dict(
@@ -201,12 +202,8 @@ function _standard_dict(
 )::Dict{MOI.VariableIndex, MOI.VariableIndex} where {
     D<:AbstractDict{MOI.VariableIndex, MOI.VariableIndex}
 }
-    ret = Dict{MOI.VariableIndex, MOI.VariableIndex}()
-    sizehint!(ret, length(d))
-    for (k,v) in d
-        ret[k] = v
-    end
-    return d
+    ret = Dict{MOI.VariableIndex, MOI.VariableIndex}(keys(d) .=> values(d))
+    return ret
 end
 
 function MOI.copy_to(m::CachingOptimizer, src::MOI.ModelLike; kws...)

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -148,14 +148,55 @@ function attach_optimizer(model::CachingOptimizer)
     # We do not need to copy names because name-related operations are handled by `m.model_cache`
     indexmap = MOI.copy_to(model.optimizer, model.model_cache, copy_names=false)
     model.state = ATTACHED_OPTIMIZER
-    # MOI does not define the type of index_map, so we have to copy it into a
-    # concrete container. Also load the reverse map.
-    model.model_to_optimizer_map = IndexMap()
-    model.optimizer_to_model_map = IndexMap()
-    for k in keys(indexmap)
-        model.model_to_optimizer_map[k] = indexmap[k]
-        model.optimizer_to_model_map[indexmap[k]] = k
+    # MOI does not define the type of index_map, so we might have to copy it
+    # into a concrete container. Also load the reverse map.
+    model.model_to_optimizer_map = convert(IndexMap, indexmap)#IndexMap()
+    model.optimizer_to_model_map = reverse_index_map(indexmap)#IndexMap()
+    nothing
+end
+
+function reverse_index_map(src::IndexMap)
+    dest = IndexMap()
+    sizehint!(dest.varmap, length(src.varmap))
+    # sizehint!(dest.conmap, length(src.conmap))
+    reverse_dict(dest.varmap, src.varmap)
+    reverse_dict(dest.conmap, src.conmap)
+    return dest
+end
+function reverse_dict(dest::AbstractDict, src::AbstractDict)
+    for (k,v) in src
+        dest[v] = k
     end
+end
+
+function Base.convert(::Type{IndexMap}, d::AbstractDict{MOI.Index, MOI.Index})
+    map = IndexMap()
+    for (k,v) in d
+        map[k] = v
+    end
+    return map
+end
+function Base.convert(::Type{IndexMap}, d::IndexMap)
+    # return d
+    # if we return d as is, its not possible to add variables
+    # if there was a dense dict inside
+    # the solution would be to allow automatically swtiching
+    # a ClevelDenseDict...
+    return IndexMap(standard_dict(d.varmap), d.conmap)
+end
+function standard_dict(d::D)::D where
+    {D<:AbstractDict{MOI.VariableIndex, MOI.VariableIndex}}
+    return d
+end
+function standard_dict(d::D
+    )::Dict{MOI.VariableIndex, MOI.VariableIndex} where
+    {D<:AbstractDict{MOI.VariableIndex, MOI.VariableIndex}}
+    ret = Dict{MOI.VariableIndex, MOI.VariableIndex}()
+    sizehint!(ret, length(d))
+    for (k,v) in d
+        ret[k] = v
+    end
+    return d
 end
 
 function MOI.copy_to(m::CachingOptimizer, src::MOI.ModelLike; kws...)

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -63,9 +63,10 @@ error in case `copy_to` is called with `copy_names` equal to `true`.
 """
 supports_default_copy_to(model::MOI.ModelLike, copy_names::Bool) = false
 
-const DenseVariableDict{V} = DenseDict{MOI.VariableIndex, V, typeof(MOI.index_value), typeof(MOI.VariableIndex)}
+_index_to_variable(i) = MOI.VariableIndex(i)
+const DenseVariableDict{V} = DenseDict{MOI.VariableIndex, V, typeof(MOI.index_value), typeof(_index_to_variable)}
 function dense_variable_dict(::Type{V}, n) where V
-    return DenseDict{MOI.VariableIndex, V}(MOI.index_value, MOI.VariableIndex, n)
+    return DenseDict{MOI.VariableIndex, V}(MOI.index_value, _index_to_variable, n)
 end
 
 struct IndexMap <: AbstractDict{MOI.Index, MOI.Index}

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -63,6 +63,14 @@ error in case `copy_to` is called with `copy_names` equal to `true`.
 """
 supports_default_copy_to(model::MOI.ModelLike, copy_names::Bool) = false
 
+"""
+    _index_to_variable(i::Int)
+
+Simply returns `MOI.VariableIndex(i)`. This is necessary to pass a function that
+creates the `VariableIndex` from an integer. If we pass `MOI.VariableIndex`
+julia understands is as a `DataType` and not a function, this leads to type
+instability issues.
+"""
 _index_to_variable(i) = MOI.VariableIndex(i)
 const DenseVariableDict{V} = DenseDict{MOI.VariableIndex, V, typeof(MOI.index_value), typeof(_index_to_variable)}
 function dense_variable_dict(::Type{V}, n) where V

--- a/src/Utilities/dense_dict.jl
+++ b/src/Utilities/dense_dict.jl
@@ -28,13 +28,8 @@ function Base.iterate(d::DenseDict{K,V}, args...) where {K,V}
         return nothing
     else
         el, i = itr
-        return inverse_hash(d, el)::K => d.map[el]::V, i
+        return d.inverse_hash(el)::K => d.map[el]::V, i
     end
-end
-
-function inverse_hash(d::DenseDict{K, V, F, I}, el)::K where {K,V,F,I}
-    f = d.inverse_hash::I
-    return f(el)::K
 end
 
 Base.length(d::DenseDict) = length(d.set)

--- a/src/Utilities/dense_dict.jl
+++ b/src/Utilities/dense_dict.jl
@@ -22,15 +22,21 @@ end
 
 # Implementation of the `AbstractDict` API.
 # Base.empty(::DenseDict, ::Type{K}, ::Type{V}) not implemented
-function Base.iterate(d::DenseDict, args...)
+function Base.iterate(d::DenseDict{K,V}, args...) where {K,V}
     itr = iterate(d.set, args...)
     if itr === nothing
         return nothing
     else
         el, i = itr
-        return d.inverse_hash(el) => d.map[el], i
+        return inverse_hash(d, el)::K => d.map[el]::V, i
     end
 end
+
+function inverse_hash(d::DenseDict{K, V, F, I}, el)::K where {K,V,F,I}
+    f = d.inverse_hash::I
+    return f(el)::K
+end
+
 Base.length(d::DenseDict) = length(d.set)
 Base.haskey(dict::DenseDict, key) = dict.hash(key) in dict.set
 Base.getindex(dict::DenseDict, key) = dict.map[dict.hash(key)]

--- a/src/Utilities/dense_dict.jl
+++ b/src/Utilities/dense_dict.jl
@@ -7,6 +7,7 @@
     end
 
 Same as `Dict{K, V}` but `hash(key)` is assumed to belong to `eachindex(map)`.
+`inverse_hash` maps `Int`s to `V`
 """
 struct DenseDict{K, V, F, I} <: AbstractDict{K, V}
     hash::F
@@ -16,7 +17,8 @@ struct DenseDict{K, V, F, I} <: AbstractDict{K, V}
     function DenseDict{K, V}(hash, inverse_hash, n) where {K, V}
         set = BitSet()
         sizehint!(set, n)
-        return new{K, V, typeof(hash), typeof(inverse_hash)}(hash, inverse_hash, set, Vector{K}(undef, n))
+        return new{K, V, typeof(hash), typeof(inverse_hash)}(
+            hash, inverse_hash, set, Vector{K}(undef, n))
     end
 end
 

--- a/test/Utilities/DoubleDicts.jl
+++ b/test/Utilities/DoubleDicts.jl
@@ -136,6 +136,16 @@ end
     ]
     vals = keys
     basic_functionality(dict, keys, vals)
+
+    src = DoubleDicts.IndexDoubleDict()
+    for (k,v) in zip(keys, vals)
+        dict[k] = v
+    end
+    dest = DoubleDicts.IndexDoubleDict()
+    MOIU._reverse_dict(dest, src)
+    for (k, v) in src
+        @test dest[v] == k
+    end
 end
 
 @testset "FunctionSetDoubleDict" begin


### PR DESCRIPTION
Following #1129

This PR applies dictionary reversion directly do double dicts.
Now it is type stable and more performant.