### PR TITLE
Update URLs to jump-dev

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,7 @@ makedocs(
         prettyurls = get(ENV, "CI", nothing) == "true",
         mathengine = Documenter.MathJax()
     ),
-    # See https://github.com/JuliaOpt/JuMP.jl/issues/1576
+    # See https://github.com/jump-dev/JuMP.jl/issues/1576
     strict = true,
     pages = [
         "Introduction" => "index.md",
@@ -17,5 +17,5 @@ makedocs(
 )
 
 deploydocs(
-    repo   = "github.com/JuliaOpt/MathOptInterface.jl.git",
+    repo   = "github.com/jump-dev/MathOptInterface.jl.git",
 )

--- a/docs/src/apimanual.md
+++ b/docs/src/apimanual.md
@@ -14,9 +14,9 @@ DocTestFilters = [r"MathOptInterface|MOI"]
 Each mathematical optimization solver API has its own concepts and data structures for representing optimization models and obtaining results.
 However, it is often desirable to represent an instance of an optimization problem at a higher level so that it is easy to try using different solvers.
 MathOptInterface (MOI) is an abstraction layer designed to provide a unified interface to mathematical optimization solvers so that users do not need to understand multiple solver-specific APIs.
-MOI can be used directly, or through a higher-level modeling interface like [JuMP](https://github.com/JuliaOpt/JuMP.jl).
+MOI can be used directly, or through a higher-level modeling interface like [JuMP](https://github.com/jump-dev/JuMP.jl).
 
-MOI has been designed to replace [MathProgBase](https://github.com/JuliaOpt/MathProgBase.jl), which has been used by modeling packages such as [JuMP](https://github.com/JuliaOpt/JuMP.jl) and [Convex.jl](https://github.com/JuliaOpt/Convex.jl).
+MOI has been designed to replace [MathProgBase](https://github.com/JuliaOpt/MathProgBase.jl), which has been used by modeling packages such as [JuMP](https://github.com/jump-dev/JuMP.jl) and [Convex.jl](https://github.com/jump-dev/Convex.jl).
 This second-generation abstraction layer addresses a number of limitations of MathProgBase.
 MOI is designed to:
 - Be simple and extensible, unifying linear, quadratic, and conic optimization, and seamlessly facilitate extensions to essentially arbitrary constraints and functions (e.g., indicator constraints, complementarity constraints, and piecewise linear functions)
@@ -1223,7 +1223,7 @@ wrapper type is called `Optimizer`):
   model from a cache, the [Allocate-Load API](@ref) allows MOI layers to be
   added between the cache and the solver which allows transformations to be
   applied without the need for additional caching. For instance, with the
-  proposed [Light bridges](https://github.com/JuliaOpt/MathOptInterface.jl/issues/523),
+  proposed [Light bridges](https://github.com/jump-dev/MathOptInterface.jl/issues/523),
   no cache will be needed to store the bridged model when bridges are used by
   JuMP so implementing the [Allocate-Load API](@ref) will allow JuMP to use only
   one cache instead of two.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # MathOptInterface
 
-[MathOptInterface.jl](https://github.com/JuliaOpt/MathOptInterface.jl) is a standardized API for mathematical optimization solvers.
+[MathOptInterface.jl](https://github.com/jump-dev/MathOptInterface.jl) is a standardized API for mathematical optimization solvers.
 
 ```@contents
 Pages = ["apimanual.md", "apireference.md"]

--- a/perf/cachingoptimizer.jl
+++ b/perf/cachingoptimizer.jl
@@ -1,6 +1,6 @@
-# See https://github.com/JuliaOpt/MathOptInterface.jl/issues/321,
-#     https://github.com/JuliaOpt/MathOptInterface.jl/pull/323 and
-#     https://github.com/JuliaOpt/MathOptInterface.jl/pull/390
+# See https://github.com/jump-dev/MathOptInterface.jl/issues/321,
+#     https://github.com/jump-dev/MathOptInterface.jl/pull/323 and
+#     https://github.com/jump-dev/MathOptInterface.jl/pull/390
 
 using BenchmarkTools
 using MathOptInterface

--- a/src/Bridges/Constraint/geomean.jl
+++ b/src/Bridges/Constraint/geomean.jl
@@ -55,7 +55,7 @@ function bridge_constraint(::Type{GeoMeanBridge{T, F, G, H}}, model,
                            s::MOI.GeometricMeanCone) where {T, F, G, H}
     d = s.dimension
     if d <= 1
-        # TODO change to a standard error: https://github.com/JuliaOpt/MathOptInterface.jl/issues/967
+        # TODO change to a standard error: https://github.com/jump-dev/MathOptInterface.jl/issues/967
         error("Dimension of GeometricMeanCone must be greater than 1.")
     end
     n = d - 1

--- a/src/Bridges/Constraint/square.jl
+++ b/src/Bridges/Constraint/square.jl
@@ -93,7 +93,7 @@ function bridge_constraint(::Type{SquareBridge{T, F, G, TT, ST}},
             lower = f_scalars[j + (i - 1) * dim]
             diff = MOIU.operate!(-, T, upper, lower)
             MOIU.canonicalize!(diff)
-            # The value 1e-10 was decided in https://github.com/JuliaOpt/JuMP.jl/pull/976
+            # The value 1e-10 was decided in https://github.com/jump-dev/JuMP.jl/pull/976
             # This avoid generating symmetrization constraints when the
             # functions at entries (i, j) and (j, i) are almost identical
             if !MOIU.isapprox_zero(diff, 1e-10)

--- a/src/Bridges/Constraint/vectorize.jl
+++ b/src/Bridges/Constraint/vectorize.jl
@@ -112,7 +112,7 @@ function MOI.get(
     @assert length(x) == 1
     if MOIU.is_ray(MOI.get(model, MOI.PrimalStatus(attr.N)))
        # If it is an infeasibility certificate, it is a ray and satisfies the
-       # homogenized problem, see https://github.com/JuliaOpt/MathOptInterface.jl/issues/433
+       # homogenized problem, see https://github.com/jump-dev/MathOptInterface.jl/issues/433
        return x[1]
     else
        # Otherwise, we need to add the set constant since the ConstraintPrimal

--- a/src/Bridges/Variable/vectorize.jl
+++ b/src/Bridges/Variable/vectorize.jl
@@ -78,7 +78,7 @@ function MOI.get(model::MOI.ModelLike, attr::MOI.ConstraintPrimal,
     y = x[1]
     if !MOIU.is_ray(MOI.get(model, MOI.PrimalStatus(attr.N)))
        # If it is an infeasibility certificate, it is a ray and satisfies the
-       # homogenized problem, see https://github.com/JuliaOpt/MathOptInterface.jl/issues/433
+       # homogenized problem, see https://github.com/jump-dev/MathOptInterface.jl/issues/433
        # Otherwise, we need to add the set constant since the ConstraintPrimal
        # is defined as the value of the function and the set_constant was
        # removed from the original function

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -1412,7 +1412,7 @@ end
 geomean1vtest(model::MOI.ModelLike, config::TestConfig) = _geomean1test(model, config, true)
 geomean1ftest(model::MOI.ModelLike, config::TestConfig) = _geomean1test(model, config, false)
 
-# addresses bug https://github.com/JuliaOpt/MathOptInterface.jl/pull/962
+# addresses bug https://github.com/jump-dev/MathOptInterface.jl/pull/962
 function _geomean2test(model::MOI.ModelLike, config::TestConfig, vecofvars)
     atol = config.atol
     rtol = config.rtol

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -289,7 +289,7 @@ function nametest(model::MOI.ModelLike)
     end
 end
 
-# Taken from https://github.com/JuliaOpt/MathOptInterfaceUtilities.jl/issues/41
+# Taken from https://github.com/jump-dev/MathOptInterfaceUtilities.jl/issues/41
 function validtest(model::MOI.ModelLike)
     MOI.empty!(model)
     @test MOIU.supports_default_copy_to(model, #=copy_names=# false)

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -851,7 +851,7 @@ end
 function operate_term(::typeof(*), α::T, t::MOI.ScalarAffineTerm{T}) where T
     MOI.ScalarAffineTerm(α * t.coefficient, t.variable_index)
 end
-# `<:Number` is a workaround for https://github.com/JuliaOpt/MathOptInterface.jl/issues/980
+# `<:Number` is a workaround for https://github.com/jump-dev/MathOptInterface.jl/issues/980
 function operate_term(::typeof(*), t::MOI.ScalarAffineTerm{T}, β::T) where T<:Number
     MOI.ScalarAffineTerm(t.coefficient * β, t.variable_index)
 end
@@ -1462,7 +1462,7 @@ function operate(::typeof(*), ::Type{T},
     return operate(*, T, α, f)
 end
 
-# `<:Number` is a workaround for https://github.com/JuliaOpt/MathOptInterface.jl/issues/980
+# `<:Number` is a workaround for https://github.com/jump-dev/MathOptInterface.jl/issues/980
 function operate!(::typeof(*), ::Type{T},
                   f::Union{MOI.ScalarAffineFunction{T},
                            MOI.ScalarQuadraticFunction{T}}, α::T) where T<:Number
@@ -1915,7 +1915,7 @@ end
 
 
 # Similar to `eachscalar` but faster, see
-# https://github.com/JuliaOpt/MathOptInterface.jl/issues/418
+# https://github.com/jump-dev/MathOptInterface.jl/issues/418
 function scalarize(f::MOI.VectorOfVariables, ignore_constants::Bool = false)
     MOI.SingleVariable.(f.variables)
 end

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -14,7 +14,7 @@ optimizer bridges should be used instead.
 mutable struct UniversalFallback{MT} <: MOI.ModelLike
     model::MT
     objective::Union{MOI.AbstractScalarFunction, Nothing}
-    constraints::OrderedDict{Tuple{DataType, DataType}, OrderedDict} # See https://github.com/JuliaOpt/JuMP.jl/issues/1152 and https://github.com/JuliaOpt/JuMP.jl/issues/2238
+    constraints::OrderedDict{Tuple{DataType, DataType}, OrderedDict} # See https://github.com/jump-dev/JuMP.jl/issues/1152 and https://github.com/jump-dev/JuMP.jl/issues/2238
     nextconstraintid::Int64
     con_to_name::Dict{CI, String}
     name_to_con::Union{Dict{String, MOI.ConstraintIndex}, Nothing}

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -74,7 +74,7 @@ end
 # Note: ScalarAffineFunction is mutable because its `constant` field is likely of an immutable
 # type, while its `terms` field is of a mutable type, meaning that creating a `ScalarAffineFunction`
 # allocates, and it is desirable to provide a zero-allocation option for working with
-# ScalarAffineFunctions. See https://github.com/JuliaOpt/MathOptInterface.jl/pull/343.
+# ScalarAffineFunctions. See https://github.com/jump-dev/MathOptInterface.jl/pull/343.
 """
     ScalarAffineFunction{T}(terms, constant)
 
@@ -147,7 +147,7 @@ end
 # Note: ScalarQuadraticFunction is mutable because its `constant` field is likely of an immutable
 # type, while its other fields are of mutable types, meaning that creating a `ScalarQuadraticFunction`
 # allocates, and it is desirable to provide a zero-allocation option for working with
-# ScalarQuadraticFunctions. See https://github.com/JuliaOpt/MathOptInterface.jl/pull/343.
+# ScalarQuadraticFunctions. See https://github.com/jump-dev/MathOptInterface.jl/pull/343.
 """
     ScalarQuadraticFunction{T}(affine_terms, quadratic_terms, constant)
 
@@ -260,7 +260,7 @@ end
 # Note: MultiRowChange is mutable because its `variable` field of an immutable
 # type, while `new_coefficients` is of a mutable type, meaning that creating a `MultiRowChange`
 # allocates, and it is desirable to provide a zero-allocation option for working with
-# MultiRowChanges. See https://github.com/JuliaOpt/MathOptInterface.jl/pull/343.
+# MultiRowChanges. See https://github.com/jump-dev/MathOptInterface.jl/pull/343.
 """
     MultirowChange{T}(variable::VariableIndex, new_coefficients::Vector{Tuple{Int64, T}})
 


### PR DESCRIPTION
Some links to `JuliaOpt` domains have not been changed, namely:

* [`News.md`](https://github.com/jump-dev/MathOptInterface.jl/blame/372cb21432c80e932a2c2323a23e6bd55c26f648/NEWS.md#L426): the [original link](http://www.juliaopt.org/JuMP.jl/latest/style.html) is broken
* All references to `JuliaOpt/MathProgBase.jl`: it looks like MPB is not in the jump-dev GitHub organization
* Gitter URLs in README: they are still of the form `JuliaOpt/jump-dev`
* URLs that appear in [`src/FileFormats/MOF/v0.4.0.json`](https://github.com/jump-dev/MathOptInterface.jl/blob/372cb21432c80e932a2c2323a23e6bd55c26f648/src/FileFormats/MOF/v0.4.0.json): I don't know what this file is for, and I was afraid I would break something