### PR TITLE
Fix dual check for norminf3 test

### DIFF
--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -493,8 +493,10 @@ function norminf3test(model::MOI.ModelLike, config::TestConfig)
         @test MOI.get(model, MOI.ConstraintPrimal(), nonneg) ≈ zeros(3) atol=atol rtol=rtol
 
         if config.duals
-            @test MOI.get(model, MOI.ConstraintDual(), norminf) ≈ vcat(1, fill(-inv(3), 3)) atol=atol rtol=rtol
-            @test MOI.get(model, MOI.ConstraintDual(), nonneg) ≈ fill(inv(3), 3) atol=atol rtol=rtol
+            dual_nonneg = MOI.get(model, MOI.ConstraintDual(), nonneg)
+            @test minimum(dual_nonneg) >= -atol
+            @test sum(dual_nonneg) ≈ 1.0 atol=atol rtol=rtol
+            @test MOI.get(model, MOI.ConstraintDual(), norminf) ≈ vcat(1, -dual_nonneg) atol=atol rtol=rtol
         end
     end
 end


### PR DESCRIPTION
Mosek returns dual values that do not satisfy the current tests although they are correct. See https://travis-ci.org/github/jump-dev/MosekTools.jl/jobs/727649211#L374-L389
This PR relaxes the tests so that it passes the tests.