### PR TITLE
Remove error of CleverDict for negative indices

### DIFF
--- a/src/Utilities/CleverDicts.jl
+++ b/src/Utilities/CleverDicts.jl
@@ -169,8 +169,6 @@ function Base.setindex!(c::CleverDict{K, V}, value::V, key::K)::V where {K, V}
     h = c.hash(key)::Int64
     if h > c.last_index
         c.last_index = ifelse(h == c.last_index + 1, h, -1)
-    elseif h <= 0
-        error("Invalid key, its hash must be > 0")
     end
     if 1 <= h <= length(c.vector) && _is_dense(c)
         c.vector[h] = value

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -682,6 +682,21 @@ end
     MOIT.contlineartest(bridged, MOIT.TestConfig{T}(solve=false), exclude)
 end
 
+@testset "SDPAModel with bridges and caching" begin
+    # This tests that the computation of the reverse dict in the
+    # caching optimizer works with negative indices
+    cached = MOIU.CachingOptimizer(MOIU.Model{Float64}(), MOIU.MANUAL)
+    vi_cache = MOI.add_variable(cached)
+    model = SDPAModel{Float64}()
+    bridged = MOIB.full_bridge_optimizer(model, Float64)
+    MOIU.reset_optimizer(cached, bridged)
+    MOIU.attach_optimizer(cached)
+    vi_bridged = first(MOI.get(bridged, MOI.ListOfVariableIndices()))
+    @test vi_bridged == MOI.VariableIndex(-1)
+    @test cached.model_to_optimizer_map[vi_cache] == vi_bridged
+    @test cached.optimizer_to_model_map[vi_bridged] == vi_cache
+end
+
 @testset "Continuous Conic with SDPAModel{Float64}" begin
     model = SDPAModel{Float64}()
     bridged = MOIB.full_bridge_optimizer(model, Float64)


### PR DESCRIPTION
This is quite a big issue and will require to tag MOI v0.9.17 asap as it will break whenever a variable bridge is used with combination of a CachingOptimizer. It was not detected in the solver tests as the CachingOptimizer as an inner model of the bridges so it does not see any negative indices. However, it is triggered for the cache used by JuMP to hold the non-bridged model so the breakage happens for almost any JuMP model with solvers using variables bridges such as CSDP, SDPA, ...

In short, reproducing the error is as easy as
```julia
julia> using JuMP, CSDP

julia> model = Model(CSDP.Optimizer)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: CSDP

julia> @variable(model, x)
x

julia> optimize!(model)
ERROR: Invalid key, its hash must be > 0
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] setindex!(::MathOptInterface.Utilities.CleverDicts.CleverDict{MathOptInterface.VariableIndex,MathOptInterface.VariableIndex,typeof(MathOptInterface.index_value),typeof(MathOptInterface.Utilities._index_to_variable)}, ::MathOptInterface.VariableIndex, ::MathOptInterface.VariableIndex) at /home/blegat/.julia/packages/MathOptInterface/8Mxwr/src/Utilities/CleverDicts.jl:173
 [3] _reverse_dict(::MathOptInterface.Utilities.CleverDicts.CleverDict{MathOptInterface.VariableIndex,MathOptInterface.VariableIndex,typeof(MathOptInterface.index_value),typeof(MathOptInterface.Utilities._index_to_variable)}, ::MathOptInterface.Utilities.CleverDicts.CleverDict{MathOptInterface.VariableIndex,MathOptInterface.VariableIndex,typeof(MathOptInterface.index_value),typeof(MathOptInterface.Utilities._index_to_variable)}) at /home/blegat/.julia/packages/MathOptInterface/8Mxwr/src/Utilities/cachingoptimizer.jl:169
 [4] _reverse_index_map(::MathOptInterface.Utilities.IndexMap) at /home/blegat/.julia/packages/MathOptInterface/8Mxwr/src/Utilities/cachingoptimizer.jl:162
 [5] attach_optimizer(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}) at /home/blegat/.julia/packages/MathOptInterface/8Mxwr/src/Utilities/cachingoptimizer.jl:155
 [6] optimize!(::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.AbstractOptimizer,MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}) at /home/blegat/.julia/packages/MathOptInterface/8Mxwr/src/Utilities/cachingoptimizer.jl:211
 [7] optimize!(::Model, ::Nothing; bridge_constraints::Bool, ignore_optimize_hook::Bool, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/blegat/.julia/packages/JuMP/e0Uc2/src/optimizer_interface.jl:130
 [8] optimize! at /home/blegat/.julia/packages/JuMP/e0Uc2/src/optimizer_interface.jl:106 [inlined] (repeats 2 times)
 [9] top-level scope at REPL[8]:1
```
Adding SumOfSquares to https://github.com/blegat/SolverTests would have detected this so I'm adding it.