### PR TITLE
Add support for Symbol's in map_indices

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -73,7 +73,7 @@ function map_indices(variable_map::AbstractDict{T, T}, x) where {T <: MOI.Index}
     return map_indices(vi -> variable_map[vi], x)
 end
 
-const ObjectWithoutIndex = Union{Nothing, DataType, Number, Enum, AbstractString, MOI.AnyAttribute, MOI.AbstractSet, Function, MOI.ModelLike}
+const ObjectWithoutIndex = Union{Nothing, DataType, Number, Enum, AbstractString, MOI.AnyAttribute, MOI.AbstractSet, Function, MOI.ModelLike, Symbol}
 const ObjectOrTupleWithoutIndex = Union{ObjectWithoutIndex, Tuple{Vararg{ObjectWithoutIndex}}}
 const ObjectOrTupleOrArrayWithoutIndex = Union{ObjectOrTupleWithoutIndex, AbstractArray{<:ObjectOrTupleWithoutIndex}, AbstractArray{<:AbstractArray{<:ObjectOrTupleWithoutIndex}}}
 

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -165,6 +165,13 @@ end
     @test gvq.affine_terms == MOI.VectorAffineTerm.([2, 1], sats)
     @test gvq.quadratic_terms == MOI.VectorQuadraticTerm.([1, 2, 2], sqts)
     @test MOIU.constant_vector(gvq) == [-3., -2.]
+
+    @testset "Constants" begin
+        @test MOIU.map_indices(index_map, :s) == :s
+        @test MOIU.map_indices(index_map, [:a, :b]) == [:a, :b]
+        @test MOIU.map_indices(index_map, "s") == "s"
+        @test MOIU.map_indices(index_map, ["a", "b"]) == ["a", "b"]
+    end
 end
 @testset "Conversion VectorOfVariables -> VectorAffineFunction" begin
     f = MOI.VectorAffineFunction{Int}(MOI.VectorOfVariables([z, x, y]))


### PR DESCRIPTION
It's needed for `set_optimizer_attribute` with NLopt as the value of some parameters are symbols.