### PR TITLE
Tweak wording of LazyConstraintCallback docs

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -649,7 +649,7 @@ solution by submitting a [`LazyConstraint`](@ref). For instance, it may be
 called at an incumbent of a mixed-integer problem. Note that there is no
 guarantee that the callback is called at *every* feasible primal solution.
 
-The feasible primal solution is accessed through
+The current primal solution is accessed through
 [`CallbackVariablePrimal`](@ref). Trying to access other result
 attributes will throw [`OptimizeInProgress`](@ref) as discussed in
 [`AbstractCallback`](@ref).


### PR DESCRIPTION
x-ref: https://github.com/jump-dev/GLPK.jl/issues/146

GLPK sometimes asks for a lazy constraint at an integer-infeasible point. We can either tweak these docs to drop the mention of primal feasibility, or tweak GLPK to check for integer feasibility before asking for a lazy constraint.