### PR TITLE
Fix wrong coefficient type with bridges

### DIFF
--- a/src/Bridges/Constraint/interval.jl
+++ b/src/Bridges/Constraint/interval.jl
@@ -37,9 +37,9 @@ function MOI.supports_constraint(
     return true
 end
 function MOI.supports_constraint(
-    ::Type{SplitIntervalBridge{T}}, ::Type{<:MOI.AbstractVectorFunction},
+    ::Type{SplitIntervalBridge{T}}, F::Type{<:MOI.AbstractVectorFunction},
     ::Type{MOI.Zeros}) where T
-    return true
+    return MOIU.is_coefficient_type(F, T)
 end
 MOIB.added_constrained_variable_types(::Type{<:SplitIntervalBridge}) = Tuple{DataType}[]
 function MOIB.added_constraint_types(::Type{SplitIntervalBridge{T, F, S, LS, US}}) where {T, F, S, LS, US}

--- a/src/Bridges/Constraint/scalarize.jl
+++ b/src/Bridges/Constraint/scalarize.jl
@@ -23,9 +23,12 @@ function bridge_constraint(::Type{ScalarizeBridge{T, F, S}},
 end
 
 function MOI.supports_constraint(::Type{ScalarizeBridge{T}},
-                                 ::Type{<:MOI.AbstractVectorFunction},
+                                 F::Type{<:MOI.AbstractVectorFunction},
                                  ::Type{<:MOIU.VectorLinearSet}) where T
-    return true
+    # If `F` is `MOI.VectorAffineFunction{Complex{Float64}}`, `S` is `MOI.Zeros` and `T` is `Float64`,
+    # it would create a set `MOI.EqualTo{Float64}` which is incorrect hence we say
+    # we only support it if the coefficient type of `F` is `T`.
+    return MOIU.is_coefficient_type(F, T)
 end
 MOIB.added_constrained_variable_types(::Type{<:ScalarizeBridge}) = Tuple{DataType}[]
 function MOIB.added_constraint_types(::Type{ScalarizeBridge{T, F, S}}) where {T, F, S}

--- a/src/Bridges/Constraint/slack.jl
+++ b/src/Bridges/Constraint/slack.jl
@@ -120,9 +120,12 @@ function bridge_constraint(::Type{ScalarSlackBridge{T, F, S}}, model,
 end
 
 # start allowing everything (scalar)
-MOI.supports_constraint(::Type{ScalarSlackBridge{T}},
-                        ::Type{<:MOI.AbstractScalarFunction},
-                        ::Type{<:MOI.AbstractScalarSet}) where {T} = true
+function MOI.supports_constraint(
+    ::Type{ScalarSlackBridge{T}},
+    F::Type{<:MOI.AbstractScalarFunction},
+    ::Type{<:MOI.AbstractScalarSet}) where {T}
+    return MOIU.is_coefficient_type(F, T)
+end
 # then restrict (careful with ambiguity)
 MOI.supports_constraint(::Type{ScalarSlackBridge{T}},
                         ::Type{<:MOI.SingleVariable},
@@ -179,9 +182,12 @@ function bridge_constraint(::Type{VectorSlackBridge{T, F, S}}, model,
     return VectorSlackBridge{T, F, S}(slack, slack_in_set, equality)
 end
 
-MOI.supports_constraint(::Type{VectorSlackBridge{T}},
-                        ::Type{<:MOI.AbstractVectorFunction},
-                        ::Type{<:MOI.AbstractVectorSet}) where {T} = true
+function MOI.supports_constraint(
+    ::Type{VectorSlackBridge{T}},
+    F::Type{<:MOI.AbstractVectorFunction},
+    ::Type{<:MOI.AbstractVectorSet}) where {T}
+    return MOIU.is_coefficient_type(F, T)
+end
 MOI.supports_constraint(::Type{VectorSlackBridge{T}},
                         ::Type{<:MOI.VectorOfVariables},
                         ::Type{<:MOI.Zeros}) where {T} = false

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -2051,6 +2051,10 @@ function Base.:*(g::TypedLike{T}, β::T) where T<:Number
     return operate_coefficients(α -> α * β, g)
 end
 
+is_coefficient_type(::Type{<:Union{MOI.SingleVariable, MOI.VectorOfVariables}}, ::Type) = true
+is_coefficient_type(::Type{<:TypedLike{T}}, ::Type{T}) where T = true
+is_coefficient_type(::Type{<:TypedLike}, ::Type) = false
+
 similar_type(::Type{<:MOI.ScalarAffineFunction}, ::Type{T}) where T = MOI.ScalarAffineFunction{T}
 similar_type(::Type{<:MOI.ScalarQuadraticFunction}, ::Type{T}) where T = MOI.ScalarQuadraticFunction{T}
 similar_type(::Type{<:MOI.VectorAffineFunction}, ::Type{T}) where T = MOI.VectorAffineFunction{T}


### PR DESCRIPTION
When adding the complex bridges defined in [ComplexOptInterface](https://github.com/blegat/ComplexOptInterface.jl), the `LazyBridgeOptimizer` tries to bridge the complex constraints with the real bridges and then fails with cryptic errors. With this PR, it realizes that the real bridges do not support bridging the complex constraints hence it allows `LazyBridgeOptimizer` to select the complex bridges.