### PR TITLE
issue 441: unit test for double optimize

### DIFF
--- a/src/Test/UnitTests/solve.jl
+++ b/src/Test/UnitTests/solve.jl
@@ -172,3 +172,18 @@ function solve_result_index(model::MOI.ModelLike, config::TestConfig)
     end
 end
 unittests["solve_result_index"] = solve_result_index
+
+function solve_twice(model::MOI.ModelLike, config::TestConfig)
+    MOI.empty!(model)
+    x = MOI.add_variable(model)
+    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(1.0))
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{MOI.SingleVariable}(), MOI.SingleVariable(x))
+    if config.solve
+        MOI.optimize!(model)
+        MOI.optimize!(model)
+        MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+        MOI.get(model, MOI.VariablePrimal(), x) == 1.0
+    end
+end
+unittests["solve_twice"] = solve_twice

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -49,6 +49,7 @@ end
             "solve_single_variable_dual_min",
             "solve_single_variable_dual_max",
             "solve_result_index",
+            "solve_twice",
             ])
         MOI.empty!(model)
     end
@@ -391,6 +392,22 @@ end
             )
         )
         MOIT.solve_result_index(mock, config)
+    end
+
+    @testset "solve_twice" begin
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+                mock,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1.0]),
+            ),
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+                mock,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1.0]),
+            )
+        )
+        MOIT.solve_twice(mock, config)
     end
 end
 


### PR DESCRIPTION
Related to https://github.com/jump-dev/MathOptInterface.jl/issues/441

I followed the instructions in issue 441 (by odow) to create this PR + added 2 changes
- travis badge links updated to travis-ci.com instead of travis-ci.org (currently the badge goes to an extra redirect page)
- added a new page in the docs about testing. I think this needs some more revision, but I just wanted to get your opinion first about having such a page in the docs. It's basically the same instructions as odow laid out in the issue. I think that it'd be a good documentation for how the testing works (I personally wasn't expecting that the optimizers ran tests from the MOI package), as well as tests being tested, and where to plug in stuff in order to add a new test. Let me know if you think it's a bad idea.

I also tested that the ECOS tests would give out an error from the `solve_twice` if the early return in the `optimize!` is commented out ([source](https://github.com/jump-dev/ECOS.jl/blob/master/src/MOI_wrapper.jl#L250)).