### PR TITLE
update travis badge urls from travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ An abstraction layer for mathematical optimization solvers. Replaces [MathProgBa
 [docs-stable-url]: http://jump.dev/MathOptInterface.jl/stable
 [docs-dev-url]: http://jump.dev/MathOptInterface.jl/dev
 
-[build-img]: https://travis-ci.org/JuMP-dev/MathOptInterface.jl.svg?branch=master
-[build-url]: https://travis-ci.org/JuMP-dev/MathOptInterface.jl
+[build-img]: https://travis-ci.com/JuMP-dev/MathOptInterface.jl.svg?branch=master
+[build-url]: https://travis-ci.com/JuMP-dev/MathOptInterface.jl
 [codecov-img]: http://codecov.io/github/JuMP-dev/MathOptInterface.jl/coverage.svg?branch=master
 [codecov-url]: http://codecov.io/github/JuMP-dev/MathOptInterface.jl?branch=master
 


### PR DESCRIPTION
 (current url points to an extra step for redirection)

This will need to be rebased after the merge of #1186 (or 1186 rebased after this PR, whichever is merged first)