### PR TITLE
tests: add unit test for add_constraint 

### DIFF
--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -361,3 +361,33 @@ function solve_zero_one_with_bounds_3(model::MOI.ModelLike, config::TestConfig)
     end
 end
 unittests["solve_zero_one_with_bounds_3"] = solve_zero_one_with_bounds_3
+
+# Taken from https://github.com/jump-dev/Ipopt.jl/pull/230/files#
+"""
+    add_constraint_nan(model::MOI.ModelLike, config::TestConfig)
+
+Add a NaN constraint. This should throw a proper error message.
+"""
+function add_constraint_checks(model::MOI.ModelLike, config::TestConfig)
+    @testset "first isnan check" begin
+      MOI.empty!(model)
+      x = MOI.add_variable(model)
+      @test_throws ErrorException MOI.add_constraint(model, x, MOI.EqualTo(NaN))
+    end
+
+    @testset "first has_lower_bound check" begin
+      MOI.empty!(model)
+      x = MOI.add_variable(model)
+      MOI.add_constraint(model, x, MOI.GreaterThan(5.0))
+      @test_throws MOI.LowerBoundAlreadySet MOI.add_constraint(model, x, MOI.EqualTo(5.0))
+    end
+
+    @testset "first has_upper_bound check" begin
+      MOI.empty!(model)
+      x = MOI.add_variable(model)
+      MOI.add_constraint(model, x, MOI.LessThan(5.0))
+      @test_throws MOI.UpperBoundAlreadySet MOI.add_constraint(model, x, MOI.EqualTo(5.0))
+    end
+end
+unittests["add_constraint_checks"] = add_constraint_checks
+

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -45,6 +45,7 @@ end
             "solve_zero_one_with_bounds_1",
             "solve_zero_one_with_bounds_2",
             "solve_zero_one_with_bounds_3",
+            "add_constraint_checks",
             "solve_unbounded_model",
             "solve_single_variable_dual_min",
             "solve_single_variable_dual_max",
@@ -335,6 +336,10 @@ end
         MOIT.solve_zero_one_with_bounds_1(mock, config)
         MOIT.solve_zero_one_with_bounds_2(mock, config)
         MOIT.solve_zero_one_with_bounds_3(mock, config)
+    end
+
+    @testset "add_constraint_checks" begin
+        MOIT.add_constraint_checks(mock, config)
     end
 
     @testset "solve_unbounded_model" begin


### PR DESCRIPTION
Tests for input nan, for lower-bound already set, and for upper-bound already set. This was prompted by PR 230 in Ipopt ([link](https://github.com/jump-dev/Ipopt.jl/pull/230/files)):  Fix error in add_constraint NaN handling for EqualTo

I figured I'd add a unit test for the checks here, and they'd be useful for other solvers as well. I checked ECOS and SCS, but they don't implement `add_constraint`. OTOH, GLPK.jl does implement it ([ref](https://github.com/jump-dev/GLPK.jl/blob/master/src/MOI_wrapper/MOI_wrapper.jl#L736)), but it needs this new test to be added to the unit test array ([ref](https://github.com/jump-dev/GLPK.jl/blob/master/test/MOI_wrapper.jl#L13)).