### PR TITLE
[Utilities] Fix modifying an un-set objective sets the objective

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -510,10 +510,12 @@ end
 
 function MOI.modify(
     model::AbstractModel,
-    obj::MOI.ObjectiveFunction,
+    ::MOI.ObjectiveFunction,
     change::MOI.AbstractFunctionModification,
 )
-    return model.objective = modify_function(model.objective, change)
+    model.objective = modify_function(model.objective, change)
+    model.objectiveset = true
+    return
 end
 
 function MOI.get(::AbstractModel, ::MOI.ListOfOptimizerAttributesSet)

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -331,3 +331,11 @@ end
     @test !haskey(dest.ext, :my_store)
     @test model.ext[:my_store] == 2
 end
+
+@testset "Objective set via modify" begin
+    model = MOIU.Model{Float64}()
+    x = MOI.add_variable(model)
+    attr = MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()
+    MOI.modify(model, attr, MOI.ScalarCoefficientChange(x, 1.0))
+    @test attr in MOI.get(model, MOI.ListOfModelAttributesSet())
+end


### PR DESCRIPTION
Closes #1214 

See the issue for background, but we have a decision.

Should `set_objective_coefficient` in the following:
```Julia
model = Model()
@variable(model, x)
set_objective_coefficient(model, x, 1.0)
```

1. Throw an error along the likes of "Unable to modify objective because no objective is set."
2. Assume an empty `ScalarAffineFunction` objective exists and modify the linear term?

Currently, this PR does 2, but I would also support the first option.