### PR TITLE
Enable doctests and correct previously untested errors

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,4 +20,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ docs/make.jl
+        run: julia --project=docs/ --code-coverage=user docs/make.jl
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,6 +20,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ --code-coverage=user docs/make.jl
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+        run: julia --project=docs/ docs/make.jl

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,10 @@
 using Documenter, MathOptInterface
 
+"""
+Pass `julia docs/make.jl --fix` to rebuild the doctests.
+"""
+const _FIX = findfirst(isequal("--fix"), ARGS) !== nothing
+
 makedocs(
     sitename = "MathOptInterface",
     format = Documenter.HTML(
@@ -8,8 +13,10 @@ makedocs(
         mathengine = Documenter.MathJax2(),
         collapselevel = 1,
     ),
-    # See https://github.com/jump-dev/JuMP.jl/issues/1576
     strict = true,
+    modules = [MathOptInterface],
+    checkdocs = :exports,
+    doctest = _FIX ? :fix : true,
     pages = [
         "Introduction" => "index.md",
         "Manual" => [

--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -95,7 +95,7 @@ UserCut
 
 ```@docs
 ModelLike
-isempty
+is_empty
 empty!
 write_to_file
 read_from_file

--- a/src/Bridges/Constraint/bridge.jl
+++ b/src/Bridges/Constraint/bridge.jl
@@ -82,9 +82,11 @@ function MOIB.added_constraint_types(BT::Type{<:AbstractBridge},
 end
 
 """
-    concrete_bridge_type(BT::Type{<:AbstractBridge},
-                         F::Type{<:MOI.AbstractFunction},
-                         S::Type{<:MOI.AbstractSet})::DataType
+    concrete_bridge_type(
+        BT::Type{<:AbstractBridge},
+        F::Type{<:MOI.AbstractFunction},
+        S::Type{<:MOI.AbstractSet}
+    )::DataType
 
 Return the concrete type of the bridge supporting `F`-in-`S` constraints. This
 function can only be called if `MOI.supports_constraint(BT, F, S)` is `true`.
@@ -96,21 +98,25 @@ constraint is bridged into a
 [`MathOptInterface.SingleVariable`](@ref)-in-[`MathOptInterface.GreaterThan`](@ref)
 and a
 [`MathOptInterface.SingleVariable`](@ref)-in-[`MathOptInterface.LessThan`](@ref)
-by the [`SplitIntervalBridge`](@ref),
-```jldoctest
-BT = MOI.Bridges.Constraint.SplitIntervalBridge{Float64}
-F = MOI.SingleVariable
-S = MOI.Interval{Float64}
-MOI.Bridges.Constraint.concrete_bridge_type(BT, F, S)
+by the [`SplitIntervalBridge`](@ref):
+
+```jldoctest; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+MOI.Bridges.Constraint.concrete_bridge_type(
+    MOI.Bridges.Constraint.SplitIntervalBridge{Float64},
+    MOI.SingleVariable,
+    MOI.Interval{Float64},
+)
 
 # output
 
-MOI.Bridges.Constraint.SplitIntervalBridge{Float64,MOI.SingleVariable}
+MathOptInterface.Bridges.Constraint.SplitIntervalBridge{Float64,MathOptInterface.SingleVariable,MathOptInterface.Interval{Float64},MathOptInterface.GreaterThan{Float64},MathOptInterface.LessThan{Float64}}
 ```
 """
-function concrete_bridge_type(bridge_type::DataType,
-                              ::Type{<:MOI.AbstractFunction},
-                              ::Type{<:MOI.AbstractSet})
+function concrete_bridge_type(
+    bridge_type::DataType,
+    ::Type{<:MOI.AbstractFunction},
+    ::Type{<:MOI.AbstractSet},
+)
     return bridge_type
 end
 

--- a/src/Bridges/Variable/bridge.jl
+++ b/src/Bridges/Variable/bridge.jl
@@ -90,8 +90,10 @@ function supports_constrained_variable(::Type{<:AbstractBridge},
 end
 
 """
-    added_constrained_variable_types(BT::Type{<:MOI.Bridges.Variable.AbstractBridge},
-                                     S::Type{<:MOI.AbstractSet})
+    added_constrained_variable_types(
+        BT::Type{<:MOI.Bridges.Variable.AbstractBridge},
+        S::Type{<:MOI.AbstractSet},
+    )
 
 Return a list of the types of constrained variables that bridges of type `BT`
 add for bridging constrained variabled in `S`. This falls back to
@@ -103,14 +105,17 @@ so bridges should not implement this.
 As a variable in [`MathOptInterface.GreaterThan`](@ref) is bridged into
 variables in [`MathOptInterface.Nonnegatives`](@ref) by the
 [`VectorizeBridge`](@ref):
-```jldoctest
-BT = MOI.Bridges.Variable.VectorizeBridge{Float64}
-S = MOI.GreaterThan{Float64}
-MOI.Bridges.added_constrained_variable_types(BT, S)
+
+```jldoctest; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+MOI.Bridges.added_constrained_variable_types(
+    MOI.Bridges.Variable.VectorizeBridge{Float64},
+    MOI.GreaterThan{Float64},
+)
 
 # output
 
-[(MOI.Nonnegatives,)]
+1-element Array{Tuple{DataType},1}:
+ (MathOptInterface.Nonnegatives,)
 ```
 """
 function MOIB.added_constrained_variable_types(
@@ -119,8 +124,10 @@ function MOIB.added_constrained_variable_types(
 end
 
 """
-    added_constraint_types(BT::Type{<:MOI.Bridges.Variable.AbstractBridge},
-                           S::Type{<:MOI.AbstractSet})
+    added_constraint_types(
+        BT::Type{<:MOI.Bridges.Variable.AbstractBridge},
+        S::Type{<:MOI.AbstractSet},
+    )
 
 Return a list of the types of constraints that bridges of type `BT` add for
 for bridging constrained variabled in `S`. This falls back to
@@ -135,14 +142,18 @@ In addition to creating variables in
 [`MathOptInterface.SingleVariable`](@ref)-in-[`MathOptInterface.EqualTo`](@ref) and
 [`MathOptInterface.ScalarAffineFunction`](@ref)-in-[`MathOptInterface.EqualTo`](@ref)
 constraints:
-```jldoctest
-BT = MOI.Bridges.Variable.RSOCtoPSDBridge{Float64}
-S = MOI.RotatedSecondOrderCone{
-MOI.Bridges.added_constraint_types(BT, S)
+
+```jldoctest; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+MOI.Bridges.added_constraint_types(
+    MOI.Bridges.Variable.RSOCtoPSDBridge{Float64},
+    MOI.RotatedSecondOrderCone,
+)
 
 # output
 
-[(MOI.SingleVariable, MOI.EqualTo{Float64}), (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64})]
+2-element Array{Tuple{DataType,DataType},1}:
+ (MathOptInterface.SingleVariable, MathOptInterface.EqualTo{Float64})
+ (MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.EqualTo{Float64})
 ```
 """
 function MOIB.added_constraint_types(
@@ -151,8 +162,10 @@ function MOIB.added_constraint_types(
 end
 
 """
-    concrete_bridge_type(BT::Type{<:AbstractBridge},
-                         S::Type{<:MOI.AbstractSet})::DataType
+    concrete_bridge_type(
+        BT::Type{<:AbstractBridge},
+        S::Type{<:MOI.AbstractSet},
+    )::DataType
 
 Return the concrete type of the bridge supporting variables in `S` constraints.
 This function can only be called if `MOI.supports_constrained_variable(BT, S)`
@@ -162,15 +175,17 @@ is `true`.
 
 As a variable in [`MathOptInterface.GreaterThan`](@ref) is bridged into
 variables in [`MathOptInterface.Nonnegatives`](@ref) by the
-[`VectorizeBridge`](@ref),
-```jldoctest
-BT = MOI.Bridges.Variable.VectorizeBridge{Float64}
-S = MOI.GreaterThan{Float64}
-MOI.Bridges.Variable.concrete_bridge_type(BT, S)
+[`VectorizeBridge`](@ref):
+
+```jldoctest; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+MOI.Bridges.Variable.concrete_bridge_type(
+    MOI.Bridges.Variable.VectorizeBridge{Float64},
+    MOI.GreaterThan{Float64},
+)
 
 # output
 
-MOI.Bridges.Variable.VectorizeBridge{Float64,MOI.Nonnegatives}
+MathOptInterface.Bridges.Variable.VectorizeBridge{Float64,MathOptInterface.Nonnegatives}
 ```
 """
 function concrete_bridge_type(bridge_type::DataType,


### PR DESCRIPTION
Required for JuMP: https://github.com/jump-dev/JuMP.jl/pull/2393/files#r535004411. Should have been done anyway.