### PR TITLE
change findall into for comprehension

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -385,8 +385,8 @@ function Base.getindex(
             if term.output_index == j
                 push!(terms, MOI.VectorAffineTerm(i, term.scalar_term))
             end
-            @inbounds constant[i] = it.f.constants[j]
         end
+        @inbounds constant[i] = it.f.constants[j]
     end
     return VAF(terms, constant)
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -379,7 +379,7 @@ function Base.getindex(
     terms = MOI.VectorAffineTerm{T}[]
     # assume at least one term per index
     sizehint!(terms, length(I))
-    constant = sort!(it.f.constants[I])
+    constant = it.f.constants[sort(I)]
     for term in it.f.terms
         if term.output_index in I
             push!(terms, MOI.VectorAffineTerm(length(terms)+1, term.scalar_term))

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -379,10 +379,12 @@ function Base.getindex(
     terms = MOI.VectorAffineTerm{T}[]
     # assume at least one term per index
     sizehint!(terms, length(I))
-    constant = it.f.constants[sort(I)]
-    for term in sort(it.f.terms, by=t->t.output_index)
-        if term.output_index in I
-            push!(terms, MOI.VectorAffineTerm(length(terms)+1, term.scalar_term))
+    constant = it.f.constants[I]
+    for (i, j) in enumerate(I)
+        for term in it.f.terms
+            if term.output_index == j
+                push!(terms, MOI.VectorAffineTerm(i, term.scalar_term))
+            end
         end
     end
     return VAF(terms, constant)

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -377,11 +377,16 @@ function Base.getindex(
     I::AbstractVector,
 ) where {T}
     terms = MOI.VectorAffineTerm{T}[]
+    # assume at least one term per index
+    sizehint!(terms, length(I))
     constant = Vector{T}(undef, length(I))
     for (i, j) in enumerate(I)
-        g = it[j]
-        append!(terms, map(t -> MOI.VectorAffineTerm(i, t), g.terms))
-        constant[i] = g.constant
+        for term in it.f.terms
+            if term.output_index == j
+                push!(terms, MOI.VectorAffineTerm(i, term.scalar_term))
+            end
+            @inbounds constant[i] = it.f.constants[j]
+        end
     end
     return VAF(terms, constant)
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -379,7 +379,7 @@ function Base.getindex(
     terms = MOI.VectorAffineTerm{T}[]
     # assume at least one term per index
     sizehint!(terms, length(I))
-    constant = it.f.constants[I]
+    constant = sort!(it.f.constants[I])
     for term in it.f.terms
         if term.output_index in I
             push!(terms, MOI.VectorAffineTerm(length(terms)+1, term.scalar_term))

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -379,14 +379,11 @@ function Base.getindex(
     terms = MOI.VectorAffineTerm{T}[]
     # assume at least one term per index
     sizehint!(terms, length(I))
-    constant = Vector{T}(undef, length(I))
-    for (i, j) in enumerate(I)
-        for term in it.f.terms
-            if term.output_index == j
-                push!(terms, MOI.VectorAffineTerm(i, term.scalar_term))
-            end
+    constant = it.f.constants[I]
+    for term in it.f.terms
+        if term.output_index in I
+            push!(terms, MOI.VectorAffineTerm(length(terms)+1, term.scalar_term))
         end
-        @inbounds constant[i] = it.f.constants[j]
     end
     return VAF(terms, constant)
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -380,11 +380,10 @@ function Base.getindex(
     # assume at least one term per index
     sizehint!(terms, length(I))
     constant = it.f.constants[I]
-    for (i, j) in enumerate(I)
-        for term in it.f.terms
-            if term.output_index == j
-                push!(terms, MOI.VectorAffineTerm(i, term.scalar_term))
-            end
+    for term in it.f.terms
+        idx = findfirst(Base.Fix1(==, term.output_index), I)
+        if idx !== nothing
+            push!(terms, MOI.VectorAffineTerm(idx, term.scalar_term))
         end
     end
     return VAF(terms, constant)

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -355,8 +355,7 @@ function scalar_terms_at_index(
     terms::Vector{<:Union{MOI.VectorAffineTerm,MOI.VectorQuadraticTerm}},
     i::Int,
 )
-    I = findall(t -> t.output_index == i, terms)
-    return map(i -> terms[i].scalar_term, I)
+    return [terms[idx].scalar_term for idx in eachindex(terms) if terms[idx].output_index == i]
 end
 function Base.getindex(it::ScalarFunctionIterator{<:VAF}, i::Integer)
     return SAF(scalar_terms_at_index(it.f.terms, i), it.f.constants[i])

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -355,7 +355,7 @@ function scalar_terms_at_index(
     terms::Vector{<:Union{MOI.VectorAffineTerm,MOI.VectorQuadraticTerm}},
     i::Int,
 )
-    return [terms[idx].scalar_term for idx in eachindex(terms) if terms[idx].output_index == i]
+    return [term.scalar_term for term in terms if term.output_index == i]
 end
 function Base.getindex(it::ScalarFunctionIterator{<:VAF}, i::Integer)
     return SAF(scalar_terms_at_index(it.f.terms, i), it.f.constants[i])

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -380,7 +380,7 @@ function Base.getindex(
     # assume at least one term per index
     sizehint!(terms, length(I))
     constant = it.f.constants[sort(I)]
-    for term in it.f.terms
+    for term in sort(it.f.terms, by=t->t.output_index)
         if term.output_index in I
             push!(terms, MOI.VectorAffineTerm(length(terms)+1, term.scalar_term))
         end

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -246,11 +246,11 @@ end
     @test g.constant == 5
     h = it[[3, 1]]
     @test h isa MOI.VectorAffineFunction    
-    @test sort(h.terms, by=t->t.output_index) == sort(MOI.VectorAffineTerm.([1, 1, 2, 2, 2], MOI.ScalarAffineTerm.([2, 6, 7, 1, 4], [z, x, y, z, x])), by=t->t.output_index)
+    @test sort(h.terms, by=t->t.output_index) == MOI.VectorAffineTerm.([1, 1, 2, 2, 2], MOI.ScalarAffineTerm.([2, 6, 7, 1, 4], [z, x, y, z, x]))
     @test MOIU.constant_vector(h) == [5, 2]
     F = MOIU.operate(vcat, Int, it[[1, 2]], it[3])
     @test F isa MOI.VectorAffineFunction{Int}
-    @test sort(F.terms, by=t->t.output_index) == sort(MOI.VectorAffineTerm.([1, 1, 1, 2, 2, 2, 2, 3, 3], MOI.ScalarAffineTerm.([7, 1, 4, 1, 9, 3, 1, 2, 6], [y, z, x, x, z, y, y, z, x])), by=t->t.output_index)
+    @test sort(F.terms, by=t->t.output_index) == MOI.VectorAffineTerm.([1, 1, 1, 2, 2, 2, 2, 3, 3], MOI.ScalarAffineTerm.([7, 1, 4, 1, 9, 3, 1, 2, 6], [y, z, x, x, z, y, y, z, x]))
     @test MOIU.constant_vector(F) == MOIU.constant_vector(f)
 end
 @testset "Indexing on VectorQuadraticFunction" begin

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -245,7 +245,7 @@ end
     @test g.terms == MOI.ScalarAffineTerm.([2, 6], [z, x])
     @test g.constant == 5
     h = it[[3, 1]]
-    @test h isa MOI.VectorAffineFunction    
+    @test h isa MOI.VectorAffineFunction
     @test sort(h.terms, by=t->t.output_index) == MOI.VectorAffineTerm.([1, 1, 2, 2, 2], MOI.ScalarAffineTerm.([2, 6, 7, 1, 4], [z, x, y, z, x]))
     @test MOIU.constant_vector(h) == [5, 2]
     F = MOIU.operate(vcat, Int, it[[1, 2]], it[3])

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -245,12 +245,12 @@ end
     @test g.terms == MOI.ScalarAffineTerm.([2, 6], [z, x])
     @test g.constant == 5
     h = it[[3, 1]]
-    @test h isa MOI.VectorAffineFunction
-    @test h.terms == MOI.VectorAffineTerm.([1, 1, 2, 2, 2], MOI.ScalarAffineTerm.([2, 6, 7, 1, 4], [z, x, y, z, x]))
+    @test h isa MOI.VectorAffineFunction    
+    @test sort(h.terms, by=t->t.output_index) == sort(MOI.VectorAffineTerm.([1, 1, 2, 2, 2], MOI.ScalarAffineTerm.([2, 6, 7, 1, 4], [z, x, y, z, x])), by=t->t.output_index)
     @test MOIU.constant_vector(h) == [5, 2]
     F = MOIU.operate(vcat, Int, it[[1, 2]], it[3])
     @test F isa MOI.VectorAffineFunction{Int}
-    @test F.terms == MOI.VectorAffineTerm.([1, 1, 1, 2, 2, 2, 2, 3, 3], MOI.ScalarAffineTerm.([7, 1, 4, 1, 9, 3, 1, 2, 6], [y, z, x, x, z, y, y, z, x]))
+    @test sort(F.terms, by=t->t.output_index) == sort(MOI.VectorAffineTerm.([1, 1, 1, 2, 2, 2, 2, 3, 3], MOI.ScalarAffineTerm.([7, 1, 4, 1, 9, 3, 1, 2, 6], [y, z, x, x, z, y, y, z, x])), by=t->t.output_index)
     @test MOIU.constant_vector(F) == MOIU.constant_vector(f)
 end
 @testset "Indexing on VectorQuadraticFunction" begin


### PR DESCRIPTION
`findall` is eager, so is `map`, chaining the two functions should be done only once to avoid going through the terms twice.

Addressing issue noticed in:
https://github.com/jump-dev/MathOptInterface.jl/issues/1137