### PR TITLE
Use T <: Number for GreaterThan and LessThan

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -154,20 +154,20 @@ dual_set(s::Nonpositives) = copy(s)
 dual_set_type(::Type{Nonpositives}) = Nonpositives
 
 """
-    GreaterThan{T <: Real}(lower::T)
+    GreaterThan{T <: Number}(lower::T)
 
 The set ``[lower,\\infty) \\subseteq \\mathbb{R}``.
 """
-struct GreaterThan{T<:Real} <: AbstractScalarSet
+struct GreaterThan{T<:Number} <: AbstractScalarSet
     lower::T
 end
 
 """
-    LessThan{T <: Real}(upper::T)
+    LessThan{T <: Number}(upper::T)
 
 The set ``(-\\infty,upper] \\subseteq \\mathbb{R}``.
 """
-struct LessThan{T<:Real} <: AbstractScalarSet
+struct LessThan{T<:Number} <: AbstractScalarSet
     upper::T
 end
 


### PR DESCRIPTION
This is required for constraint programming, as working with integers is the norm. This brings these two sets closer to `EqualTo`, which already uses `Number`.