### PR TITLE
[Utilities] Drop MOI.RawParameters when resetting a CachingOptimizer

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -127,6 +127,10 @@ function reset_optimizer(m::CachingOptimizer, optimizer::MOI.AbstractOptimizer)
     for attr in MOI.get(m.model_cache, MOI.ListOfOptimizerAttributesSet())
         # Skip attributes which don't apply to the new optimizer.
         if attr isa MOI.RawParameter
+            # Even if the optimizer claims to `supports` `attr`, the value 
+            # might have a different meaning (e.g., two solvers with `logLevel`
+            # as a RawParameter). To be on the safe side, just skip all raw 
+            # parameters.
             continue
         elseif !MOI.is_copyable(attr) || !MOI.supports(m.optimizer, attr)
             continue

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -125,9 +125,10 @@ function reset_optimizer(m::CachingOptimizer, optimizer::MOI.AbstractOptimizer)
     m.optimizer = optimizer
     m.state = EMPTY_OPTIMIZER
     for attr in MOI.get(m.model_cache, MOI.ListOfOptimizerAttributesSet())
+        # Skip attributes which don't apply to the new optimizer.
         if attr isa MOI.RawParameter
-            # Skip RawParameters because they may not apply to the new
-            # optimizer.
+            continue
+        elseif !MOI.is_copyable(attr) || !MOI.supports(m.optimizer, attr)
             continue
         end
         value = MOI.get(m.model_cache, attr)

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -662,6 +662,7 @@ function MOI.get(model::Issue1220, ::MOI.ListOfOptimizerAttributesSet)
     return collect(keys(model.optimizer_attributes))
 end
 MOI.supports(::Issue1220, ::MOI.AbstractOptimizerAttribute) = true
+MOI.supports(::Issue1220, ::MOI.NumberOfThreads) = false
 function MOI.get(model::Issue1220, attr::MOI.AbstractOptimizerAttribute)
     return model.optimizer_attributes[attr]
 end
@@ -673,7 +674,9 @@ end
     model = MOIU.CachingOptimizer(Issue1220(), Issue1220())
     MOI.set(model, MOI.Silent(), true)
     MOI.set(model, MOI.RawParameter("foo"), "bar")
+    MOI.set(model, MOI.NumberOfThreads(), 1)
     MOIU.reset_optimizer(model, Issue1220())
     @test MOI.get(model, MOI.Silent()) == true
     @test_throws KeyError MOI.get(model, MOI.RawParameter("foo"))
+    @test_throws KeyError MOI.get(model, MOI.NumberOfThreads())
 end

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -652,3 +652,28 @@ end
     MOIU.reset_optimizer(model, optimizer)
     constrained_variables_test(model)
 end
+
+struct Issue1220 <: MOI.AbstractOptimizer
+    optimizer_attributes::Dict{Any,Any}
+    Issue1220() = new(Dict{Any,Any}())
+end
+MOI.is_empty(model::Issue1220) = isempty(model.optimizer_attributes)
+function MOI.get(model::Issue1220, ::MOI.ListOfOptimizerAttributesSet)
+    return collect(keys(model.optimizer_attributes))
+end
+MOI.supports(::Issue1220, ::MOI.AbstractOptimizerAttribute) = true
+function MOI.get(model::Issue1220, attr::MOI.AbstractOptimizerAttribute)
+    return model.optimizer_attributes[attr]
+end
+function MOI.set(model::Issue1220, attr::MOI.AbstractOptimizerAttribute, value)
+    model.optimizer_attributes[attr] = value
+    return value
+end
+@testset "Issue1220_dont_pass_raw_parameter" begin
+    model = MOIU.CachingOptimizer(Issue1220(), Issue1220())
+    MOI.set(model, MOI.Silent(), true)
+    MOI.set(model, MOI.RawParameter("foo"), "bar")
+    MOIU.reset_optimizer(model, Issue1220())
+    @test MOI.get(model, MOI.Silent()) == true
+    @test_throws KeyError MOI.get(model, MOI.RawParameter("foo"))
+end


### PR DESCRIPTION
Closes #1220.

@blegat: An alternative is to not pass any OptimizerAttributes. If you're passing a new empty optimizer, it seems weird that the parameters would follow.

What do we expect to happen in the following at the JuMP level?
```Julia
model = Model(Cbc.Optimizer)
set_silent(model)
set_optimizer(model, Clp.Optimizer)
MOI.get(model, MOI.Silent())  # true or false?
```