### PR TITLE
Add test with zero in off-diagonal entry

### DIFF
--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -314,6 +314,13 @@ function solve_qp_edge_cases(model::MOI.ModelLike, config::TestConfig)
 end
 unittests["solve_qp_edge_cases"] = solve_qp_edge_cases
 
+"""
+    solve_qp_zero_offdiag(model::MOI.ModelLike, config::TestConfig)
+
+Test quadratic program with a zero off-diagonal term.
+
+If `config.solve=true` confirm that it solves correctly.
+"""
 function solve_qp_zero_offdiag(model::MOI.ModelLike, config::TestConfig)
     MOI.empty!(model)
     x = MOI.add_variables(model, 2)

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -357,6 +357,7 @@ function solve_qp_zero_offdiag(model::MOI.ModelLike, config::TestConfig)
         variable_primal = [(x[1], 1.0), (x[2], 2.0)],
     )
 end
+unittests["solve_qp_zero_offdiag"] = solve_qp_zero_offdiag
 
 """
     solve_duplicate_terms_obj(model::MOI.ModelLike, config::TestConfig)

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -314,6 +314,43 @@ function solve_qp_edge_cases(model::MOI.ModelLike, config::TestConfig)
 end
 unittests["solve_qp_edge_cases"] = solve_qp_edge_cases
 
+function solve_qp_zero_offdiag(model::MOI.ModelLike, config::TestConfig)
+    MOI.empty!(model)
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    vc1 = MOI.add_constraint(
+        model,
+        MOI.SingleVariable(x[1]),
+        MOI.GreaterThan(1.0),
+    )
+    @test vc1.value == x[1].value
+    vc2 = MOI.add_constraint(
+        model,
+        MOI.SingleVariable(x[2]),
+        MOI.GreaterThan(2.0),
+    )
+    @test vc2.value == x[2].value
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+        MOI.ScalarQuadraticFunction(
+            MOI.ScalarAffineTerm{Float64}[],  # affine terms
+            MOI.ScalarQuadraticTerm.(
+                [2.0, 0.0, 2.0],
+                [x[1], x[1], x[2]],
+                [x[1], x[2], x[2]],
+            ),  # quad
+            0.0,  # constant
+        ),
+    )
+    test_model_solution(
+        model,
+        config;
+        objective_value = 5.0,
+        variable_primal = [(x[1], 1.0), (x[2], 2.0)],
+    )
+end
+
 """
     solve_duplicate_terms_obj(model::MOI.ModelLike, config::TestConfig)
 

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -35,6 +35,7 @@ end
             "solve_duplicate_terms_scalar_affine",
             "solve_duplicate_terms_vector_affine",
             "solve_qp_edge_cases",
+            "solve_qp_zero_offdiag",
             "solve_qcp_edge_cases",
             "solve_affine_deletion_edge_cases",
             "solve_duplicate_terms_obj",
@@ -232,6 +233,15 @@ end
             )
         )
         MOIT.solve_qp_edge_cases(mock, config)
+    end
+    @testset "solve_qp_zero_offdiag" begin
+        MOIU.set_mock_optimize!(mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(mock,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1.0, 2.0])
+            )
+        )
+        MOIT.solve_qp_zero_offdiag(mock, config)
     end
     @testset "solve_duplicate_terms_obj" begin
         MOIU.set_mock_optimize!(mock,
@@ -513,7 +523,7 @@ end
         )
         MOIT.solve_farkas_variable_lessthan_max(mock, config)
     end
-    
+
     @testset "solve_twice" begin
         MOIU.set_mock_optimize!(mock,
             (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(


### PR DESCRIPTION
This test would have caught the OSQP issue fixed by https://github.com/oxfordcontrol/OSQP.jl/pull/90

- [x] Add comments
- [x] Add tests