### PR TITLE
[Utilities] add supports_shift_constant

### DIFF
--- a/docs/src/apireference.md
+++ b/docs/src/apireference.md
@@ -1073,6 +1073,7 @@ The following utilities are available for moving the function constant to the
 set for scalar constraints:
 ```@docs
 Utilities.shift_constant
+Utilities.supports_shift_constant
 Utilities.normalize_and_add_constraint
 Utilities.normalize_constant
 ```

--- a/src/Utilities/sets.jl
+++ b/src/Utilities/sets.jl
@@ -1,15 +1,32 @@
 """
-    shift_constant(set::MOI.AbstractScalarSet,
-                   offset)
+    shift_constant(set::MOI.AbstractScalarSet, offset)
 
 Returns a new scalar set `new_set` such that `func`-in-`set` is equivalent to
 `func + offset`-in-`new_set`.
+
+Only define this function if it makes sense to!
+
+By default, this function returns `nothing`, which can be used as a flag to
+check if the set supports shifting:
+```Julia
+new_set = shift_constant(old_set, offset)
+if new_set === nothing
+    add_constraint(model, f, old_set)
+else
+    f.constant = 0
+    add_constraint(model, f, new_set)
+end
+```
 
 ## Examples
 
 The call `shift_constant(MOI.Interval(-2, 3), 1)` is equal to
 `MOI.Interval(-1, 4)`.
 """
+function shift_constant(::MOI.AbstractScalarSet, ::Any)
+    return nothing
+end
+
 function shift_constant(
     set::Union{MOI.LessThan{T},MOI.GreaterThan{T},MOI.EqualTo{T}},
     offset::T,

--- a/src/Utilities/sets.jl
+++ b/src/Utilities/sets.jl
@@ -6,26 +6,34 @@ Returns a new scalar set `new_set` such that `func`-in-`set` is equivalent to
 
 Only define this function if it makes sense to!
 
-By default, this function returns `nothing`, which can be used as a flag to
-check if the set supports shifting:
+Use [`supports_shift_constant`](@ref) to check if the set supports shifting:
 ```Julia
-new_set = shift_constant(old_set, offset)
-if new_set === nothing
-    add_constraint(model, f, old_set)
-else
+if supports_shift_constant(typeof(old_set))
+    new_set = shift_constant(old_set, offset)
     f.constant = 0
     add_constraint(model, f, new_set)
+else
+    add_constraint(model, f, old_set)
 end
 ```
+
+See also [`supports_shift_constant`](@ref).
 
 ## Examples
 
 The call `shift_constant(MOI.Interval(-2, 3), 1)` is equal to
 `MOI.Interval(-1, 4)`.
 """
-function shift_constant(::MOI.AbstractScalarSet, ::Any)
-    return nothing
-end
+function shift_constant end
+
+"""
+    supports_shift_constant(::Type{S}) where {S<:MOI.AbstractSet}
+
+Return `true` if [`shift_constant`](@ref) is defined for set `S`.
+
+See also [`shift_constant`](@ref).
+"""
+supports_shift_constant(::Type{S}) where {S<:MOI.AbstractSet} = false
 
 function shift_constant(
     set::Union{MOI.LessThan{T},MOI.GreaterThan{T},MOI.EqualTo{T}},
@@ -33,9 +41,14 @@ function shift_constant(
 ) where {T}
     return typeof(set)(MOI.constant(set) + offset)
 end
+supports_shift_constant(::Type{<:MOI.LessThan}) = true
+supports_shift_constant(::Type{<:MOI.GreaterThan}) = true
+supports_shift_constant(::Type{<:MOI.EqualTo}) = true
+
 function shift_constant(set::MOI.Interval, offset)
     return MOI.Interval(set.lower + offset, set.upper + offset)
 end
+supports_shift_constant(::Type{<:MOI.Interval}) = true
 
 const ScalarLinearSet{T} =
     Union{MOI.EqualTo{T},MOI.LessThan{T},MOI.GreaterThan{T}}

--- a/test/Utilities/sets.jl
+++ b/test/Utilities/sets.jl
@@ -33,11 +33,16 @@ end
 end
 
 @testset "Shifts" begin
+    @test MOIU.supports_shift_constant(MOI.EqualTo{Int})
     @test MOIU.shift_constant(MOI.EqualTo(3), 1) == MOI.EqualTo(4)
+    @test MOIU.supports_shift_constant(MOI.GreaterThan{Int})
     @test MOIU.shift_constant(MOI.GreaterThan(6), -1) == MOI.GreaterThan(5)
+    @test MOIU.supports_shift_constant(MOI.LessThan{Int})
     @test MOIU.shift_constant(MOI.LessThan(2), 2) == MOI.LessThan(4)
+    @test MOIU.supports_shift_constant(MOI.Interval{Int})
     @test MOIU.shift_constant(MOI.Interval(-2, 3), 1) == MOI.Interval(-1, 4)
-    @test MOIU.shift_constant(MOI.ZeroOne(), 0.0) === nothing
+    @test MOIU.supports_shift_constant(MOI.ZeroOne) == false
+    @test_throws MethodError MOIU.shift_constant(MOI.ZeroOne(), 1.0)
 end
 
 @testset "Dimension" begin

--- a/test/Utilities/sets.jl
+++ b/test/Utilities/sets.jl
@@ -37,6 +37,7 @@ end
     @test MOIU.shift_constant(MOI.GreaterThan(6), -1) == MOI.GreaterThan(5)
     @test MOIU.shift_constant(MOI.LessThan(2), 2) == MOI.LessThan(4)
     @test MOIU.shift_constant(MOI.Interval(-2, 3), 1) == MOI.Interval(-1, 4)
+    @test MOIU.shift_constant(MOI.ZeroOne(), 0.0) === nothing
 end
 
 @testset "Dimension" begin


### PR DESCRIPTION
In order to close https://github.com/jump-dev/JuMP.jl/issues/1943, we need a way of checking whether it is possible to push the function constant into the set. The easiest way is just to define this fallback, so the JuMP code will become:
```Julia
function build_constraint(
    ::Function,
    expr::Union{GenericAffExpr, GenericQuadExpr},
    set::MOI.AbstractScalarSet,
)
    offset = constant(expr)
    new_set = MOIU.shift_constant(set, -offset)
    if new_set === nothing
        return ScalarConstraint(expr, set)
    else
        add_to_expression!(expr, -offset)
        return ScalarConstraint(expr, new_set)
    end
end
```

This makes JuMP's heuristic of "I'll push the constant into the set" well-defined by "does it implement shift_constant".

As a follow-up question: should this be moved to MOI proper?