### PR TITLE
Benchmark last in test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,11 +27,11 @@ end
 
 # Utilities submodule tests
 @testset "MOI.$(submodule)" for submodule in [
-    "Benchmarks",
     "Bridges",
     "FileFormats",
     "Test",
     "Utilities",
+    "Benchmarks",
 ]
     include("$(submodule)/$(submodule).jl")
 end


### PR DESCRIPTION
Alphabetical order is nice and tidy, but running benchmarks before running actual tests does not make sense, we would want to test first for correctness before running benchmarks for early termination.