### PR TITLE
Add auto_bridge to CachingOptimizer

### DIFF
--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -37,6 +37,7 @@ copy_to
 ```@docs
 AbstractModelAttribute
 Name
+CoefficientType
 ObjectiveFunction
 ObjectiveFunctionType
 ObjectiveSense

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -803,6 +803,10 @@ function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.ListOfModelAttributesSet)
     return unbridged_function(b, list)
 end
 
+function MOI.get(b::AbstractBridgeOptimizer, attr::MOI.CoefficientType)
+    return MOI.get(b.model, attr)
+end
+
 function MOI.get(
     b::AbstractBridgeOptimizer,
     attr::Union{MOI.AbstractModelAttribute,MOI.AbstractOptimizerAttribute},

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -388,16 +388,25 @@ end
 
 
 """
-    _bridge_if_needed(f::Function, m::CachingOptimizer)
+    _bridge_if_needed(
+        f::Function,
+        m::CachingOptimizer;
+        add::Bool = false,
+    )
 
-Return `f(m)`, adding bridges if `f(m.optimizer)` is currently `false`, but
-after doing so, it will allow `m.optimizer` to return `f(m) == true`. If bridges
-are added, it will return `f(m) = true`, not the original `f(m) = false`.
+Return `f(m)`, under the assumption that the `.optimizer` field of `m` will be
+wrapped in a `LazyBridgeOptimizer` if `f(m)` is currently false, and that doing
+so would allow `f(m) == true`. However, only modify the `.optimizer` field if
+`add == true`.
 
 `f` is a function that takes `m` as a single argument. It is typically a call
 like `f(m) = MOI.supports_constraint(m, F, S)` for some `F` and `S`.
 """
-function _bridge_if_needed(f::Function, model::CachingOptimizer)
+function _bridge_if_needed(
+    f::Function,
+    model::CachingOptimizer;
+    add::Bool = false,
+)
     if !f(model.model_cache)
         # If the cache doesn't, we dont.
         return false
@@ -415,7 +424,9 @@ function _bridge_if_needed(f::Function, model::CachingOptimizer)
     T = MOI.get(model, MOI.CoefficientType())
     bridge = MOI.instantiate(model.optimizer; with_bridge_type = T)
     if f(bridge)
-        model.optimizer = bridge
+        if add
+            model.optimizer = bridge
+        end
         return true  # We bridged, and now we support.
     end
     return false  # Everything fails.
@@ -434,10 +445,11 @@ function MOI.add_constrained_variable(
     m::CachingOptimizer,
     set::S,
 ) where {S<:MOI.AbstractScalarSet}
-    if !MOI.supports_add_constrained_variable(m, S)
-        if state(m) == ATTACHED_OPTIMIZER
-            throw(MOI.UnsupportedConstraint{MOI.SingleVariable,S}())
-        end
+    supports = _bridge_if_needed(m; add = true) do model
+        return MOI.supports_add_constrained_variable(model, S)
+    end
+    if !supports && state(m) == ATTACHED_OPTIMIZER
+        throw(MOI.UnsupportedConstraint{MOI.SingleVariable,S}())
     end
     if m.state == MOIU.ATTACHED_OPTIMIZER
         if m.mode == MOIU.AUTOMATIC
@@ -505,12 +517,11 @@ function MOI.add_constrained_variables(
     m::CachingOptimizer,
     set::S,
 ) where {S<:MOI.AbstractVectorSet}
-    if !MOI.supports_add_constrained_variables(m, S)
-        if state(m) == ATTACHED_OPTIMIZER
-            throw(
-                MOI.UnsupportedConstraint{MOI.VectorOfVariables,S}()
-            )
-        end
+    supports = _bridge_if_needed(m; add = true) do model
+        return MOI.supports_add_constrained_variables(model, S)
+    end
+    if !supports && state(m) == ATTACHED_OPTIMIZER
+        throw(MOI.UnsupportedConstraint{MOI.VectorOfVariables,S}())
     end
     if m.state == ATTACHED_OPTIMIZER
         if m.mode == AUTOMATIC
@@ -568,10 +579,11 @@ function MOI.add_constraint(
     func::F,
     set::S,
 ) where {F<:MOI.AbstractFunction,S<:MOI.AbstractSet}
-    if !MOI.supports_constraint(m, F, S)
-        if state(m) == ATTACHED_OPTIMIZER
-            throw(MOI.UnsupportedConstraint{F,S}())
-        end
+    supports = _bridge_if_needed(m; add = true) do model
+        return MOI.supports_constraint(model, F, S)
+    end
+    if !supports && state(m) == ATTACHED_OPTIMIZER
+        throw(MOI.UnsupportedConstraint{F,S}())
     end
     if m.state == ATTACHED_OPTIMIZER
         if m.mode == AUTOMATIC
@@ -802,12 +814,33 @@ end
 # they are sent to the optimizer and when they are returned from the optimizer.
 # As a result, values of attributes must implement `map_indices`.
 
-function MOI.set(m::CachingOptimizer, attr::MOI.AbstractModelAttribute, value)
-    if !MOI.supports(m, attr)
-        if state(m) == ATTACHED_OPTIMIZER
-            throw(MOI.UnsupportedAttribute(attr))
+function MOI.set(m::CachingOptimizer, attr::MOI.ObjectiveFunction, value)
+    supports = _bridge_if_needed(m; add = true) do model
+        return MOI.supports(model, attr)
+    end
+    if !supports && state(m) == ATTACHED_OPTIMIZER
+        throw(MOI.UnsupportedAttribute(attr))
+    end
+    if m.state == ATTACHED_OPTIMIZER
+        optimizer_value = map_indices(m.model_to_optimizer_map, value)
+        if m.mode == AUTOMATIC
+            try
+                MOI.set(m.optimizer, attr, optimizer_value)
+            catch err
+                if err isa MOI.NotAllowedError
+                    reset_optimizer(m)
+                else
+                    rethrow(err)
+                end
+            end
+        else
+            MOI.set(m.optimizer, attr, optimizer_value)
         end
     end
+    return MOI.set(m.model_cache, attr, value)
+end
+
+function MOI.set(m::CachingOptimizer, attr::MOI.AbstractModelAttribute, value)
     if m.state == ATTACHED_OPTIMIZER
         optimizer_value = map_indices(m.model_to_optimizer_map, value)
         if m.mode == AUTOMATIC

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -102,6 +102,14 @@ function CachingOptimizer(
     )
 end
 
+function MOI.get(model::CachingOptimizer, attr::MOI.CoefficientType)
+    if state(model) == NO_OPTIMIZER
+        return MOI.get(model.model_cache, attr)
+     else
+        return MOI.get(model.optimizer, attr)
+    end
+end
+
 ## Methods for managing the state of CachingOptimizer.
 
 """

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -39,10 +39,8 @@ A `CachingOptimizer` has two modes of operation (`CachingOptimizerMode`):
   perform a modification not supported by the optimizer results in a drop to
   `EMPTY_OPTIMIZER` mode.
 """
-mutable struct CachingOptimizer{
-    OptimizerType,
-    ModelType<:MOI.ModelLike,
-} <: MOI.AbstractOptimizer
+mutable struct CachingOptimizer{OptimizerType,ModelType<:MOI.ModelLike} <:
+               MOI.AbstractOptimizer
     optimizer::Union{Nothing,OptimizerType}
     model_cache::ModelType
     state::CachingOptimizerState
@@ -96,8 +94,8 @@ function CachingOptimizer(
     model_cache::MOI.ModelLike,
     optimizer::Union{Nothing,MOI.AbstractOptimizer} = nothing;
     mode::CachingOptimizerMode = AUTOMATIC,
-    state::CachingOptimizerState =
-        optimizer === nothing ? NO_OPTIMIZER : EMPTY_OPTIMIZER,
+    state::CachingOptimizerState = optimizer === nothing ? NO_OPTIMIZER :
+                                   EMPTY_OPTIMIZER,
     auto_bridge::Bool = false,
 )
     T = optimizer !== nothing ? typeof(optimizer) : MOI.AbstractOptimizer
@@ -139,7 +137,7 @@ end
 function MOI.get(model::CachingOptimizer, attr::MOI.CoefficientType)
     if state(model) == NO_OPTIMIZER
         return MOI.get(model.model_cache, attr)
-     else
+    else
         return MOI.get(model.optimizer, attr)
     end
 end
@@ -385,7 +383,6 @@ function MOI.add_variables(m::CachingOptimizer, n)
     end
     return vindices
 end
-
 
 """
     _bridge_if_needed(

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -335,6 +335,10 @@ function MOI.get(mock::MockOptimizer, attr::MOI.AbstractModelAttribute)
     end
 end
 
+function MOI.get(mock::MockOptimizer, attr::MOI.CoefficientType)
+    return MOI.get(mock.inner_model, attr)
+end
+
 #####
 ##### Names
 #####

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -5,6 +5,8 @@ abstract type AbstractModelLike{T} <: MOI.ModelLike end
 abstract type AbstractOptimizer{T} <: MOI.AbstractOptimizer end
 const AbstractModel{T} = Union{AbstractModelLike{T},AbstractOptimizer{T}}
 
+MOI.get(::AbstractModel{T}, ::MOI.CoefficientType) where {T} = T
+
 # Variables
 function MOI.get(model::AbstractModel, ::MOI.NumberOfVariables)::Int64
     if model.variable_indices === nothing

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -921,6 +921,17 @@ attr = MOI.get(model, MOI.ObjectiveFunctionType())
 """
 struct ObjectiveFunctionType <: AbstractModelAttribute end
 
+"""
+    CoefficientType()
+
+Return the coefficient type of a model.
+
+Defaults to `Float64`.
+"""
+struct CoefficientType <: AbstractModelAttribute end
+
+get(::ModelLike, ::CoefficientType) = Float64
+
 ## Optimizer attributes
 
 """

--- a/src/instantiate.jl
+++ b/src/instantiate.jl
@@ -92,6 +92,13 @@ function _instantiate_and_check(optimizer_constructor::OptimizerWithAttributes)
     return optimizer
 end
 
+function _instantiate_and_check(optimizer::AbstractOptimizer)
+    if !is_empty(optimizer)
+        error("The provided `optimizer_constructor` is a non-empty optimizer.")
+    end
+    return optimizer
+end
+
 """
     instantiate(
         optimizer_constructor,
@@ -130,3 +137,6 @@ function instantiate(
     end
     return Bridges.full_bridge_optimizer(optimizer, with_bridge_type)
 end
+
+# Add a fallback so we don't add bridges on-top-of bridges!
+instantiate(optimizer::Bridges.LazyBridgeOptimizer; kwargs...) = optimizer

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -724,6 +724,12 @@ end
     x = MOI.add_variables(model, 2)
     @test model.optimizer isa CachingAutoBridge{Float64}
     # Supports:
+    @test MOI.supports_constraint(
+        model,
+        MOI.ScalarAffineFunction{Float64},
+        MOI.LessThan{Float64},
+    )
+    @test model.optimizer isa CachingAutoBridge{Float64}
     MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
@@ -731,6 +737,12 @@ end
     )
     @test model.optimizer isa CachingAutoBridge{Float64}
     # Doesn't support:
+    @test MOI.supports_constraint(
+        model,
+        MOI.VectorOfVariables,
+        MOI.Nonnegatives,
+    )
+    @test model.optimizer isa CachingAutoBridge{Float64}
     MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Nonnegatives(2))
     @test model.optimizer isa MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
 end
@@ -743,6 +755,12 @@ end
     )
     @test MOIU.state(model) == MOIU.EMPTY_OPTIMIZER
     x = MOI.add_variables(model, 3)
+    @test !MOI.supports_constraint(
+        model,
+        MOI.VectorOfVariables,
+        MOI.SecondOrderCone,
+    )
+    @test model.optimizer isa CachingAutoBridge{Float64}
     MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.SecondOrderCone(3))
     @test model.optimizer isa CachingAutoBridge{Float64}
     @test_throws(
@@ -763,6 +781,8 @@ end
     x, cx = MOI.add_constrained_variable(model, MOI.GreaterThan(0.0))
     @test model.optimizer isa CachingAutoBridge{Float64}
     # Doesn't support:
+    @test MOI.supports_add_constrained_variables(model, MOI.Nonnegatives)
+    @test model.optimizer isa CachingAutoBridge{Float64}
     y, cy = MOI.add_constrained_variables(model, MOI.Nonnegatives(2))
     @test model.optimizer isa MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
 end
@@ -782,6 +802,8 @@ end
     @test model.optimizer isa CachingAutoBridge{Float64}
     # Doesn't support:
     f = MOI.SingleVariable(x)
+    @test MOI.supports(model, MOI.ObjectiveFunction{typeof(f)}())
+    @test model.optimizer isa CachingAutoBridge{Float64}
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     @test model.optimizer isa MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
 end

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -744,7 +744,8 @@ end
     )
     @test model.optimizer isa CachingAutoBridge{Float64}
     MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Nonnegatives(2))
-    @test model.optimizer isa MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
+    @test model.optimizer isa
+          MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
 end
 
 @testset "auto-bridge-true-constraints-fails" begin
@@ -784,7 +785,8 @@ end
     @test MOI.supports_add_constrained_variables(model, MOI.Nonnegatives)
     @test model.optimizer isa CachingAutoBridge{Float64}
     y, cy = MOI.add_constrained_variables(model, MOI.Nonnegatives(2))
-    @test model.optimizer isa MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
+    @test model.optimizer isa
+          MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
 end
 
 @testset "auto-bridge-true-objective" begin
@@ -805,7 +807,8 @@ end
     @test MOI.supports(model, MOI.ObjectiveFunction{typeof(f)}())
     @test model.optimizer isa CachingAutoBridge{Float64}
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
-    @test model.optimizer isa MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
+    @test model.optimizer isa
+          MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
 end
 
 @testset "auto-bridge-false" begin
@@ -813,7 +816,8 @@ end
         MOIU.Model{Float64}(),
         CachingAutoBridge{Float64}(),
     )
-    @test MOIU.state(model) == MOIU.ATTACHED_OPTIMIZER
+    @test MOIU.state(model) == MOIU.EMPTY_OPTIMIZER
+    MOIU.attach_optimizer(model)
     x = MOI.add_variables(model, 2)
     @test model.optimizer isa CachingAutoBridge{Float64}
     # Constrained variables
@@ -824,7 +828,11 @@ end
     # Constraints
     @test_throws(
         MOI.UnsupportedConstraint,
-        MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Nonnegatives(2)),
+        MOI.add_constraint(
+            model,
+            MOI.VectorOfVariables(x),
+            MOI.Nonnegatives(2),
+        ),
     )
     # Objective functions
     f = MOI.SingleVariable(x[1])
@@ -835,10 +843,8 @@ end
 end
 
 @testset "auto-bridge-true-constraints-already-bridged" begin
-    optimizer = MOI.Bridges.full_bridge_optimizer(
-        CachingAutoBridge{Float64}(),
-        Float64,
-    )
+    optimizer =
+        MOI.Bridges.full_bridge_optimizer(CachingAutoBridge{Float64}(), Float64)
     model = MOIU.CachingOptimizer(
         MOIU.Model{Float64}(),
         optimizer;
@@ -846,15 +852,18 @@ end
     )
     @test MOIU.state(model) == MOIU.EMPTY_OPTIMIZER
     x = MOI.add_variables(model, 2)
-    @test model.optimizer isa MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
+    @test model.optimizer isa
+          MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
     # Supports:
     MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
         MOI.LessThan(1.0),
     )
-    @test model.optimizer isa MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
+    @test model.optimizer isa
+          MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
     # Doesn't support:
     MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Nonnegatives(2))
-    @test model.optimizer isa MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
+    @test model.optimizer isa
+          MOI.Bridges.LazyBridgeOptimizer{CachingAutoBridge{Float64}}
 end

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -140,6 +140,22 @@ function test_no_constraint_name()
     )
 end
 
+function test_coefficient_type()
+    model = MOI.Utilities.Model{Int}()
+    @test MOI.get(model, MOI.CoefficientType()) == Int
+    mock = MOI.Utilities.MockOptimizer(model)
+    @test MOI.get(mock, MOI.CoefficientType()) == Int
+    bridge = MOI.Bridges.full_bridge_optimizer(mock, Int)
+    @test MOI.get(bridge, MOI.CoefficientType()) == Int
+    cache = MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.Model{Float64}(),
+        MOI.Utilities.AUTOMATIC,
+    )
+    @test MOI.get(cache, MOI.CoefficientType()) == Float64
+    MOI.Utilities.reset_optimizer(cache, bridge)
+    @test MOI.get(cache, MOI.CoefficientType()) == Int
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if startswith("$name", "test_")


### PR DESCRIPTION
## What problem is this trying to solve

Consider this model in Clp
```Julia
model = Model(Clp.Optimizer)
@variable(model, x[1:2] >= 0)
optimize!(model)
```
**Pop quiz: how many caches are there?**
```Julia
julia> backend(model)
MOIU.CachingOptimizer{MOI.AbstractOptimizer,MOIU.UniversalFallback{MOIU.Model{Float64}}}
in state ATTACHED_OPTIMIZER
in mode AUTOMATIC
with model cache MOIU.UniversalFallback{MOIU.Model{Float64}}
  fallback for MOIU.Model{Float64}
with optimizer MOIB.LazyBridgeOptimizer{MOIU.CachingOptimizer{Clp.Optimizer,MOIU.UniversalFallback{MOIU.Model{Float64}}}}
  with 0 variable bridges
  with 0 constraint bridges
  with 0 objective bridges
  with inner model MOIU.CachingOptimizer{Clp.Optimizer,MOIU.UniversalFallback{MOIU.Model{Float64}}}
    in state ATTACHED_OPTIMIZER
    in mode AUTOMATIC
    with model cache MOIU.UniversalFallback{MOIU.Model{Float64}}
      fallback for MOIU.Model{Float64}
    with optimizer Clp.Optimizer
```
There are two! There is the outer cache, then a bridging layer, and then the inner cache. 
But there are `0` bridges added to this problem! So our two caches are just copies of each other.

Why do we need two? Because a user might write this
```Julia
model = Model(Clp.Optimizer)
@variable(model, x[1:2])
@constraint(model, x in MOI.Nonnegatives(2))
optimize!(model)
Julia> backend(model)
MOIU.CachingOptimizer{MOI.AbstractOptimizer,MOIU.UniversalFallback{MOIU.Model{Float64}}}
in state ATTACHED_OPTIMIZER
in mode AUTOMATIC
with model cache MOIU.UniversalFallback{MOIU.Model{Float64}}
  fallback for MOIU.Model{Float64}
with optimizer MOIB.LazyBridgeOptimizer{MOIU.CachingOptimizer{Clp.Optimizer,MOIU.UniversalFallback{MOIU.Model{Float64}}}}
  with 0 variable bridges
  with 1 constraint bridge
  with 0 objective bridges
  with inner model MOIU.CachingOptimizer{Clp.Optimizer,MOIU.UniversalFallback{MOIU.Model{Float64}}}
    in state ATTACHED_OPTIMIZER
    in mode AUTOMATIC
    with model cache MOIU.UniversalFallback{MOIU.Model{Float64}}
      fallback for MOIU.Model{Float64}
    with optimizer Clp.Optimizer
```

For the majority of users just trying to solve LPs and MIPs, this means that their first solve involves a double copy, and lots of extra inference sorting out the bridging functions.

## The alternative

If you knew there was going to be no bridging, you could write
```Julia
model = Model(Clp.Optimizer; bridge_constraints = false)
@variable(model, x[1:2] >= 0)
optimize!(model)
julia> backend(model)
MOIU.CachingOptimizer{MOI.AbstractOptimizer,MOIU.UniversalFallback{MOIU.Model{Float64}}}
in state ATTACHED_OPTIMIZER
in mode AUTOMATIC
with model cache MOIU.UniversalFallback{MOIU.Model{Float64}}
  fallback for MOIU.Model{Float64}
with optimizer Clp.Optimizer
```
and if you get it wrong, you get a nice error message:
```Julia
model = Model(Clp.Optimizer; bridge_constraints = false)
@variable(model, x[1:2])
julia> @constraint(model, x in MOI.Nonnegatives(2))
ERROR: Constraints of type MathOptInterface.VectorOfVariables-in-MathOptInterface.Nonnegatives are not supported by the solver, try using `bridge_constraints=true` in the `JuMP.Model` constructor if you believe the constraint can be reformulated to constraints supported by the solver.
```

Thus, one option is to change the default in JuMP from `bridge_constraints = true` to `bridge_constraints = false`.

Pros: faster. Users are more aware when bridges are used. Most users don't use bridges
Cons: breaking. But it's a one-line change for users.

## Proposed approach

Start with the equivalent of `bridge_constraints = false`. If, when adding a constraint, the constraint is unsupported, add a `full_bridge_optimizer`.

Pros: Opt-in at MOI level. Better performance without breaking at JuMP level.
Cons: More complexity. Might be good for users to see when bridges are used.

See the companion PR in JuMP: https://github.com/jump-dev/JuMP.jl/pull/2513 which contains benchmarks proving the efficacy.

## TODOs

- [ ] Decide whether to do this, or change JuMP's default.
- [x] Tests
- [x] Benchmarks
- [ ] Docs
- [x] A way to get the `Number` type, rather than hard-coding `Float64`
- [ ] A way for JuMP to add extra bridges?
- [x] Bikeshed the argument name

Closes #1156 
Closes #1249
Closes #1251