### PR TITLE
Fix inference issue in MOIU.Model

### DIFF
--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -102,9 +102,8 @@ end
 
 @testset "Setting lower/upper bound twice" begin
     @testset "flag_to_set_type" begin
-        err = ErrorException("Invalid flag `0x11`.")
         T = Int
-        @test_throws err MOIU.flag_to_set_type(0x11, T)
+        @test_throws AssertionError MOIU.flag_to_set_type(0x11, T)
         @test MOIU.flag_to_set_type(0x10, T) == MOI.Integer
         @test MOIU.flag_to_set_type(0x20, T) == MOI.ZeroOne
     end


### PR DESCRIPTION
Closes https://github.com/jump-dev/MathOptInterface.jl/issues/1255

## Before

The troublesome line was (note the `S1::Type`)
```julia
julia> @code_warntype MOI.Utilities.throw_if_lower_bound_set(f.variable, typeof(s), mask, T)
Variables
  #self#::Core.Compiler.Const(MathOptInterface.Utilities.throw_if_lower_bound_set, false)
  variable::MathOptInterface.VariableIndex
  S2::Core.Compiler.Const(MathOptInterface.GreaterThan{Float64}, false)
  mask::UInt8
  T::Core.Compiler.Const(Float64, false)
  flag::UInt8
  S1::Type
  @_8::Bool

Body::Nothing
1 ─       Core.NewvarNode(:(S1))
│         (flag = MathOptInterface.Utilities.single_variable_flag(S2))
│   %3  = (flag::Core.Compiler.Const(0x02, false) & MathOptInterface.Utilities.LOWER_BOUND_MASK)::Core.Compiler.Const(0x02, false)
│   %4  = MathOptInterface.Utilities.iszero(%3)::Core.Compiler.Const(false, false)
│   %5  = !%4::Core.Compiler.Const(true, true)
│         %5
│   %7  = (mask & MathOptInterface.Utilities.LOWER_BOUND_MASK)::UInt8
│   %8  = MathOptInterface.Utilities.iszero(%7)::Bool
│         (@_8 = !%8)
└──       goto #3
2 ─       Core.Compiler.Const(:(@_8 = false), false)
3 ┄       goto #5 if not @_8
4 ─ %13 = (mask & MathOptInterface.Utilities.LOWER_BOUND_MASK)::UInt8
│         (S1 = MathOptInterface.Utilities.flag_to_set_type(%13, T))
│   %15 = MathOptInterface.LowerBoundAlreadySet::Core.Compiler.Const(MathOptInterface.LowerBoundAlreadySet, false)
│   %16 = S1::Type
│   %17 = Core.apply_type(%15, %16, S2)::Type{MathOptInterface.LowerBoundAlreadySet{_A,MathOptInterface.GreaterThan{Float64}}} where _A
│   %18 = (%17)(variable)::MathOptInterface.LowerBoundAlreadySet{_A,MathOptInterface.GreaterThan{Float64}} where _A
└──       MathOptInterface.Utilities.throw(%18)
5 ┄       return
```

```Julia
julia> function plain(N)
           model = MOIU.Model{Float64}()
           x = MOI.add_variables(model, N)
           return x
       end
plain (generic function with 1 method)

julia> function with_bounds(N)
           model = MOIU.Model{Float64}()
           x = MOI.add_variables(model, N)
           for xi in x
               MOI.add_constraint(model, MOI.SingleVariable(xi), MOI.GreaterThan(0.0))
           end
           return x
       end
with_bounds (generic function with 1 method)

julia> @btime plain(1_000_000);
  37.242 ms (175 allocations: 27.64 MiB)

julia> @btime with_bounds(1_000_000);
  95.231 ms (175 allocations: 27.64 MiB)
```

## After

With these hints, type inference succeeds
```julia
julia> @code_warntype MOI.Utilities.throw_if_lower_bound_set(f.variable, typeof(s), mask, T)
Variables
  #self#::Core.Compiler.Const(MathOptInterface.Utilities.throw_if_lower_bound_set, false)
  variable::MathOptInterface.VariableIndex
  S2::Core.Compiler.Const(MathOptInterface.GreaterThan{Float64}, false)
  mask::UInt8
  T::Core.Compiler.Const(Float64, false)
  flag::UInt8
  S1::Union{}
  @_8::Bool

Body::Nothing
1 ─       Core.NewvarNode(:(S1))
│         (flag = MathOptInterface.Utilities.single_variable_flag(S2))
│   %3  = (flag::Core.Compiler.Const(0x02, false) & MathOptInterface.Utilities.LOWER_BOUND_MASK)::Core.Compiler.Const(0x02, false)
│   %4  = MathOptInterface.Utilities.iszero(%3)::Core.Compiler.Const(false, false)
│   %5  = !%4::Core.Compiler.Const(true, true)
│         %5
│   %7  = (mask & MathOptInterface.Utilities.LOWER_BOUND_MASK)::UInt8
│   %8  = MathOptInterface.Utilities.iszero(%7)::Bool
│         (@_8 = !%8)
└──       goto #3
2 ─       Core.Compiler.Const(:(@_8 = false), false)
3 ┄       goto #5 if not @_8
4 ─ %13 = (mask & MathOptInterface.Utilities.LOWER_BOUND_MASK)::UInt8
│         (S1 = MathOptInterface.Utilities.flag_to_set_type(%13, T))
│         Core.Compiler.Const(:(MathOptInterface.LowerBoundAlreadySet), false)
│         Core.Compiler.Const(:(S1), false)
│         Core.Compiler.Const(:(Core.apply_type(%15, %16, S2)), false)
│         Core.Compiler.Const(:((%17)(variable)), false)
└──       Core.Compiler.Const(:(MathOptInterface.Utilities.throw(%18)), false)
5 ┄       return
```

```julia
julia> @btime plain(1_000_000);
  37.303 ms (175 allocations: 27.64 MiB)

julia> @btime with_bounds(1_000_000);
  39.206 ms (175 allocations: 27.64 MiB)
```