### PR TITLE
Fix complexity of getindex(::ScalarFunctionIterator, i)

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -328,7 +328,7 @@ A type that allows iterating over the scalar-functions that comprise an
 """
 struct ScalarFunctionIterator{F<:MOI.AbstractVectorFunction}
     f::F
-    # Dictionaries which map output indices to their terms.
+    # Vectors which map output indices to their terms.
     affine::Vector{Vector{Int}}
     quadratic::Vector{Vector{Int}}
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -330,7 +330,7 @@ struct ScalarFunctionIterator{F<:MOI.AbstractVectorFunction}
     f::F
     # Dictionaries which map output indices to their terms.
     affine::Vector{Vector{Int}}
-    quadratic:Vector{Vector{Int}}
+    quadratic::Vector{Vector{Int}}
 end
 
 function ScalarFunctionIterator(f::MOI.VectorOfVariables)

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -329,29 +329,29 @@ A type that allows iterating over the scalar-functions that comprise an
 struct ScalarFunctionIterator{F<:MOI.AbstractVectorFunction}
     f::F
     # Dictionaries which map output indices to their terms.
-    affine::Dict{Int,Vector{Int}}
-    quadratic::Dict{Int,Vector{Int}}
+    affine::Vector{Vector{Int}}
+    quadratic:Vector{Vector{Int}}
 end
 
 function ScalarFunctionIterator(f::MOI.VectorOfVariables)
     return ScalarFunctionIterator(
         f,
-        Dict{Int,Vector{Int}}(),
-        Dict{Int,Vector{Int}}(),
+        Vector{Int}[],
+        Vector{Int}[],
     )
 end
 
 function ScalarFunctionIterator(f::MOI.VectorAffineFunction)
-    d = Dict(i => Int[] for i = 1:MOI.output_dimension(f))
+    d = [Int[] for i = 1:MOI.output_dimension(f)]
     for (i, term) in enumerate(f.terms)
         push!(d[term.output_index], i)
     end
-    return ScalarFunctionIterator(f, d, Dict{Int,Vector{Int}}())
+    return ScalarFunctionIterator(f, d, Vector{Int}[])
 end
 
 function ScalarFunctionIterator(f::MOI.VectorQuadraticFunction)
-    aff = Dict(i => Int[] for i = 1:MOI.output_dimension(f))
-    quad = Dict(i => Int[] for i = 1:MOI.output_dimension(f))
+    aff = [Int[] for i = 1:MOI.output_dimension(f)]
+    quad = [Int[] for i = 1:MOI.output_dimension(f)]
     for (i, term) in enumerate(f.affine_terms)
         push!(aff[term.output_index], i)
     end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -372,22 +372,19 @@ function Base.getindex(
 )
     return MOI.VectorOfVariables(it.f.variables[I])
 end
+
 function Base.getindex(
     it::ScalarFunctionIterator{VAF{T}},
     I::AbstractVector,
 ) where {T}
-    terms = MOI.VectorAffineTerm{T}[]
-    # assume at least one term per index
-    sizehint!(terms, length(I))
-    constant = it.f.constants[I]
-    for term in it.f.terms
-        idx = findfirst(Base.Fix1(==, term.output_index), I)
-        if idx !== nothing
-            push!(terms, MOI.VectorAffineTerm(idx, term.scalar_term))
-        end
-    end
-    return VAF(terms, constant)
+    return VAF(
+        MOI.VectorAffineTerm{T}[
+            term for term in it.f.terms if term.output_index in I
+        ],
+        it.f.constants[I],
+    )
 end
+
 function Base.getindex(
     it::ScalarFunctionIterator{VQF{T}},
     I::AbstractVector,

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -377,9 +377,11 @@ function Base.getindex(
     it::ScalarFunctionIterator{VAF{T}},
     I::AbstractVector,
 ) where {T}
+    d = Dict(I[i] => i for i = 1:length(I))
     return VAF(
         MOI.VectorAffineTerm{T}[
-            term for term in it.f.terms if term.output_index in I
+            MOI.VectorAffineTerm(d[term.output_index], term.scalar_term)
+            for term in it.f.terms if haskey(d, term.output_index)
         ],
         it.f.constants[I],
     )


### PR DESCRIPTION
**Updated times for most recent commit**
Before
```Julia
julia> @time main(300)
 10.678643 seconds (632.16 k allocations: 132.960 MiB, 1.65% gc time)
```
After
```julia
julia> @time main(300);
  0.167274 seconds (182.72 k allocations: 137.331 MiB, 17.05% gc time)
```

## Code

```Julia
function main(n)
    model = MOIU.Model{Float64}()
    x = MOI.add_variables(model, n^2)
    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
    f = MOI.ScalarQuadraticFunction{Float64}(
        MOI.ScalarAffineTerm{Float64}.(rand(n^2), x),
        MOI.ScalarQuadraticTerm{Float64}.(1.0, x, x),
        0.0,
    )
    MOI.set(
        model,
        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
        f,
    )
    MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Nonnegatives(n))
    bridged = MOI.Bridges.full_bridge_optimizer(
        MOI.Utilities.CachingOptimizer(
            MOI.Utilities.Model{Float64}(),
            SCS.Optimizer(),
        ),
        Float64,
    )
    MOI.copy_to(bridged, model)
    return bridged
end
```

Closes #1137 
Closes #418 