### PR TITLE
Add precompile statements

### DIFF
--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -140,6 +140,10 @@ include("modifications.jl")
 include("variables.jl")
 include("nlp.jl")
 
+if VERSION > v"1.4.2"
+    include("precompile.jl")
+end
+
 # submodules
 include("Utilities/Utilities.jl") # MOI.Utilities
 include("Test/Test.jl")           # MOI.Test

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -65,4 +65,9 @@ include("universalfallback.jl")
 
 include("lazy_iterators.jl")
 
+if VERSION > v"1.4.2"
+    include("precompile.jl")
+    _precompile_()
+end
+
 end # module

--- a/src/Utilities/precompile.jl
+++ b/src/Utilities/precompile.jl
@@ -1,0 +1,44 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    T = Float64
+    scalar_sets = (
+        MOI.LessThan{T},
+        MOI.GreaterThan{T},
+        MOI.EqualTo{T},
+        MOI.Interval{T},
+        MOI.Integer,
+        MOI.ZeroOne,
+        MOI.Semiinteger{T},
+        MOI.Semicontinuous{T},
+    )
+    scalar_functions = (
+        MOI.SingleVariable,
+        MOI.ScalarAffineFunction{T},
+        MOI.ScalarQuadraticFunction{T},
+    )
+    vector_sets = (
+        MOI.Nonnegatives,
+        MOI.Nonpositives,
+        MOI.Zeros,
+        MOI.Reals,
+        MOI.SecondOrderCone,
+        MOI.RotatedSecondOrderCone,
+        MOI.PositiveSemidefiniteConeSquare,
+        MOI.PositiveSemidefiniteConeTriangle,
+    )
+    vector_functions = (
+        MOI.VectorOfVariables,
+        MOI.VectorAffineFunction{T},
+        MOI.VectorQuadraticFunction{T},
+    )
+    constraints = vcat(
+        [(F, S) for F in scalar_functions, S in scalar_sets],
+        [(F, S) for F in vector_functions, S in vector_sets],
+    )
+    MOI.precompile_model(UniversalFallback{Model{T}}, constraints)
+    MOI.precompile_model(
+        CachingOptimizer{MOI.AbstractOptimizer,UniversalFallback{Model{T}}},
+        constraints,
+    )
+    return
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,68 @@
+function precompile_constraint(model, F, S)
+    Base.precompile(get, (model, ListOfConstraintIndices{F,S}))
+    Base.precompile(get, (model, ListOfConstraintAttributesSet{F,S}))
+    Base.precompile(get, (model, ConstraintSet, ConstraintIndex{F,S}))
+    Base.precompile(get, (model, ConstraintSet, Vector{ConstraintIndex{F,S}}))
+    Base.precompile(set, (model, ConstraintSet, ConstraintIndex{F,S}, S))
+
+    Base.precompile(get, (model, ConstraintFunction, ConstraintIndex{F,S}))
+    Base.precompile(set, (model, ConstraintFunction, ConstraintIndex{F,S}, F))
+    Base.precompile(get, (model, ConstraintFunction, Vector{ConstraintIndex{F,S}}))
+
+    Base.precompile(get, (model, ConstraintDual, ConstraintIndex{F,S}))
+    Base.precompile(get, (model, ConstraintPrimal, ConstraintIndex{F,S}))
+
+    Base.precompile(get, (model, AbstractConstraintAttribute, ConstraintIndex{F,S}))
+    Base.precompile(get, (model, AbstractConstraintAttribute, Vector{ConstraintIndex{F,S}}))
+
+    Base.precompile(add_constraint, (model, F, S))
+    Base.precompile(add_constraints, (model, Vector{F}, Vector{S}))
+    Base.precompile(delete, (model, ConstraintIndex{F,S}))
+    Base.precompile(is_valid, (model, ConstraintIndex{F,S}))
+    Base.precompile(get, (model, ConstraintName, ConstraintIndex{F,S}))
+    Base.precompile(set, (model, ConstraintName, ConstraintIndex{F,S}, String))
+end
+
+function precompile_variables(model)
+    Base.precompile(delete, (model, VariableIndex))
+    Base.precompile(delete, (model, Vector{VariableIndex}))
+    Base.precompile(get, (model, AbstractVariableAttribute, VariableIndex))
+    Base.precompile(get, (model, AbstractVariableAttribute, Vector{VariableIndex}))
+    Base.precompile(get, (model, VariableName, VariableIndex))
+    Base.precompile(set, (model, VariableName, VariableIndex, String))
+    Base.precompile(get, (model, VariablePrimalStart, VariableIndex))
+    Base.precompile(set, (model, VariablePrimalStart, VariableIndex, Float64))
+    Base.precompile(get, (model, VariablePrimalStart, Vector{VariableIndex}))
+    Base.precompile(set, (model, VariablePrimalStart, Vector{VariableIndex}, Vector{Float64}))
+    Base.precompile(get, (model, VariablePrimal, VariableIndex))
+    Base.precompile(get, (model, VariablePrimal, Vector{VariableIndex}))
+    Base.precompile(add_constrained_variables, (model, Reals))
+end
+
+function precompile_model(model, constraints)
+    Base.precompile(empty!, (model,))
+    Base.precompile(is_empty, (model,))
+    Base.precompile(get, (model, ListOfConstraints))
+    Base.precompile(optimize!, (model,))
+    Base.precompile(add_variable, (model,))
+    Base.precompile(add_variables, (model, Int))
+    for attr in (
+        ListOfVariableIndices,
+        ListOfVariableAttributesSet,
+        TerminationStatus,
+        DualStatus,
+        PrimalStatus,
+        ObjectiveValue,
+        Silent,
+        TimeLimitSec,
+        NumberOfVariables,
+    )
+        Base.precompile(get, (model, attr))
+    end
+
+    precompile_variables(model)
+    for (F, S) in constraints
+        precompile_constraint(model, F, S)
+    end
+    Base.precompile(Tuple{typeof(add_constrained_variables),model,Reals})
+end


### PR DESCRIPTION
Cherry-picked from #1264 

Before
```
(base) oscar@Oscars-MBP scripts % '/Applications/Julia-1.6.app/Contents/Resources/julia/bin/julia' --project=. precompile.jl
 12.614850 seconds (43.66 M allocations: 2.490 GiB, 7.94% gc time, 23.81% compilation time)
```

After
```
(base) oscar@Oscars-MBP scripts % '/Applications/Julia-1.6.app/Contents/Resources/julia/bin/julia' --project=. precompile.jl
 10.383495 seconds (30.05 M allocations: 1.717 GiB, 5.08% gc time, 22.69% compilation time)
```

If you add #1264 with the improved inference, it drops to
```
(base) oscar@Oscars-MBP scripts % '/Applications/Julia-1.6.app/Contents/Resources/julia/bin/julia' --project=. precompile.jl
  8.106619 seconds (22.41 M allocations: 1.234 GiB, 5.04% gc time, 27.18% compilation time)
```
