### PR TITLE
Fix MethodError principle in MOIU/model

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -733,27 +733,29 @@ function MOI.modify(
 end
 
 function MOI.set(
-    model::AbstractModel,
+    ::AbstractModel,
     ::MOI.ConstraintFunction,
-    ci::CI{MOI.SingleVariable},
-    change::MOI.AbstractFunction,
+    ::MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractSet},
+    ::MOI.SingleVariable,
 )
     return throw(MOI.SettingSingleVariableFunctionNotAllowed())
 end
+
 function MOI.set(
     model::AbstractModel,
     ::MOI.ConstraintFunction,
-    ci::CI,
-    change::MOI.AbstractFunction,
-)
+    ci::MOI.ConstraintIndex{F,<:MOI.AbstractSet},
+    change::F,
+) where {F<:MOI.AbstractFunction}
     return _modify(model, ci, getconstrloc(model, ci), change)
 end
+
 function MOI.set(
     model::AbstractModel,
     ::MOI.ConstraintSet,
-    ci::CI{MOI.SingleVariable},
-    change::MOI.AbstractSet,
-)
+    ci::MOI.ConstraintIndex{MOI.SingleVariable,S},
+    change::S,
+) where {S<:MOI.AbstractScalarSet}
     MOI.throw_if_not_valid(model, ci)
     flag = single_variable_flag(typeof(change))
     if !iszero(flag & LOWER_BOUND_MASK)
@@ -763,12 +765,13 @@ function MOI.set(
         model.upper_bound[ci.value] = extract_upper_bound(change)
     end
 end
+
 function MOI.set(
     model::AbstractModel,
     ::MOI.ConstraintSet,
-    ci::CI,
-    change::MOI.AbstractSet,
-)
+    ci::MOI.ConstraintIndex{<:MOI.AbstractFunction,S},
+    change::S,
+) where {S<:MOI.AbstractSet}
     return _modify(model, ci, getconstrloc(model, ci), change)
 end
 

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -338,3 +338,21 @@ end
     MOI.modify(model, attr, MOI.ScalarCoefficientChange(x, 1.0))
     @test attr in MOI.get(model, MOI.ListOfModelAttributesSet())
 end
+
+@testset "Incorrect modifications" begin
+    model = MOIU.Model{Float64}()
+    x = MOI.add_variable(model)
+    c = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0),
+        MOI.EqualTo(1.0),
+    )
+    @test_throws(
+        ArgumentError,
+        MOI.set(model, MOI.ConstraintSet(), c, MOI.LessThan(1.0)),
+    )
+    @test_throws(
+        ArgumentError,
+        MOI.set(model, MOI.ConstraintFunction(), c, MOI.SingleVariable(x)),
+    )
+end


### PR DESCRIPTION
Closes #1277 

Now we get nice error messages
```Julia
julia> MOI.set(model, MOI.ConstraintFunction(), c, MOI.SingleVariable(x))
ERROR: ArgumentError: Cannot modify functions of different types.
Constraint type is MathOptInterface.ScalarAffineFunction{Float64} while the replacement
function is of type MathOptInterface.SingleVariable.
Stacktrace:
 [1] throw_set_error_fallback(::MathOptInterface.Utilities.Model{Float64}, ::MathOptInterface.ConstraintFunction, ::MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64},MathOptInterface.EqualTo{Float64}}, ::MathOptInterface.SingleVariable; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /Users/oscar/.julia/dev/MathOptInterface/src/attributes.jl:1255
 [2] throw_set_error_fallback(::MathOptInterface.Utilities.Model{Float64}, ::MathOptInterface.ConstraintFunction, ::MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64},MathOptInterface.EqualTo{Float64}}, ::MathOptInterface.SingleVariable) at /Users/oscar/.julia/dev/MathOptInterface/src/attributes.jl:1255
 [3] set(::MathOptInterface.Utilities.Model{Float64}, ::MathOptInterface.ConstraintFunction, ::MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64},MathOptInterface.EqualTo{Float64}}, ::MathOptInterface.SingleVariable) at /Users/oscar/.julia/dev/MathOptInterface/src/attributes.jl:396
 [4] top-level scope at REPL[8]:1

julia> MOI.set(model, MOI.ConstraintSet(), c, MOI.LessThan(1.0))
ERROR: ArgumentError: Cannot modify sets of different types. Constraint
type is MathOptInterface.EqualTo{Float64} while the replacement set is of
type MathOptInterface.LessThan{Float64}. Use `transform` instead.
Stacktrace:
 [1] throw_set_error_fallback(::MathOptInterface.Utilities.Model{Float64}, ::MathOptInterface.ConstraintSet, ::MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64},MathOptInterface.EqualTo{Float64}}, ::MathOptInterface.LessThan{Float64}; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /Users/oscar/.julia/dev/MathOptInterface/src/attributes.jl:1284
 [2] throw_set_error_fallback(::MathOptInterface.Utilities.Model{Float64}, ::MathOptInterface.ConstraintSet, ::MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64},MathOptInterface.EqualTo{Float64}}, ::MathOptInterface.LessThan{Float64}) at /Users/oscar/.julia/dev/MathOptInterface/src/attributes.jl:1284
 [3] set(::MathOptInterface.Utilities.Model{Float64}, ::MathOptInterface.ConstraintSet, ::MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64},MathOptInterface.EqualTo{Float64}}, ::MathOptInterface.LessThan{Float64}) at /Users/oscar/.julia/dev/MathOptInterface/src/attributes.jl:396
 [4] top-level scope at REPL[9]:1
```