### PR TITLE
Fix return types in model.jl

### DIFF
--- a/docs/src/manual/basic_usage.md
+++ b/docs/src/manual/basic_usage.md
@@ -291,7 +291,6 @@ MOI.set(optimizer, MOI.ObjectiveSense(), MOI.MAX_SENSE)
 
 # output
 
-MAX_SENSE::OptimizationSense = 1
 ```
 
 We add the knapsack constraint and integrality constraints:

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -470,7 +470,7 @@ function MOI.get(model::AbstractModel, ConType::Type{<:CI}, name::String)
     end
     ci = get(model.name_to_con, name, nothing)
     throw_if_multiple_with_name(ci, name)
-    return ci
+    return ci isa ConType ? ci : nothing
 end
 
 function MOI.get(


### PR DESCRIPTION
Some of these were causing unexpected returns from function calls.

Here was an example:
```Julia
julia> c = MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Nonnegatives(2))
MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables,MathOptInterface.Nonnegatives}(2)

julia> MOI.delete(model, c)
Dict{MathOptInterface.ConstraintIndex,String} with 0 entries  # <-- What is this?
```