### PR TITLE
Pass copy operation for non-variable constraints

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -320,6 +320,47 @@ function MOI.supports(
     return MOI.supports(b.model, attr)
 end
 
+function MOIU.pass_nonvariable_constraints(
+    dest::AbstractBridgeOptimizer,
+    src::MOI.ModelLike,
+    copy_names::Bool,
+    idxmap::MOIU.IndexMap,
+    constraint_types,
+    pass_cons,
+    pass_attr;
+    filter_constraints::Union{Nothing,Function} = nothing,
+)
+    not_bridged_types = eltype(constraint_types)[]
+    bridged_types = eltype(constraint_types)[]
+    for (F, S) in constraint_types
+        if is_bridged(dest, F, S)
+            push!(bridged_types, (F, S))
+        else
+            push!(not_bridged_types, (F, S))
+        end
+    end
+    MOIU.pass_nonvariable_constraints(
+        dest.model,
+        src,
+        copy_names,
+        idxmap,
+        not_bridged_types,
+        pass_cons,
+        pass_attr;
+        filter_constraints = filter_constraints,
+    )
+    MOIU.pass_nonvariable_constraints_fallback(
+        dest,
+        src,
+        copy_names,
+        idxmap,
+        bridged_types,
+        pass_cons,
+        pass_attr;
+        filter_constraints = filter_constraints,
+    )
+end
+
 function MOI.copy_to(mock::AbstractBridgeOptimizer, src::MOI.ModelLike; kws...)
     return MOIU.automatic_copy_to(mock, src; kws...)
 end

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -323,11 +323,9 @@ end
 function MOIU.pass_nonvariable_constraints(
     dest::AbstractBridgeOptimizer,
     src::MOI.ModelLike,
-    copy_names::Bool,
     idxmap::MOIU.IndexMap,
     constraint_types,
-    pass_cons,
-    pass_attr;
+    pass_cons;
     filter_constraints::Union{Nothing,Function} = nothing,
 )
     not_bridged_types = eltype(constraint_types)[]
@@ -342,21 +340,17 @@ function MOIU.pass_nonvariable_constraints(
     MOIU.pass_nonvariable_constraints(
         dest.model,
         src,
-        copy_names,
         idxmap,
         not_bridged_types,
-        pass_cons,
-        pass_attr;
+        pass_cons;
         filter_constraints = filter_constraints,
     )
-    MOIU.pass_nonvariable_constraints_fallback(
+    return MOIU.pass_nonvariable_constraints_fallback(
         dest,
         src,
-        copy_names,
         idxmap,
         bridged_types,
-        pass_cons,
-        pass_attr;
+        pass_cons;
         filter_constraints = filter_constraints,
     )
 end

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -207,7 +207,8 @@ function _standardize(d::IndexMap)
 end
 
 function MOI.copy_to(m::CachingOptimizer, src::MOI.ModelLike; kws...)
-    return automatic_copy_to(m, src; kws...)
+    m.state == ATTACHED_OPTIMIZER && reset_optimizer(m)
+    return MOI.copy_to(m.model_cache, src; kws...)
 end
 function supports_default_copy_to(model::CachingOptimizer, copy_names::Bool)
     return supports_default_copy_to(model.model_cache, copy_names)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -755,21 +755,17 @@ end
 function pass_nonvariable_constraints(
     dest::AbstractModel,
     src::MOI.ModelLike,
-    copy_names::Bool,
     idxmap::IndexMap,
     constraint_types,
-    pass_cons,
-    pass_attr;
+    pass_cons;
     filter_constraints::Union{Nothing,Function} = nothing,
 )
-    pass_nonvariable_constraints(
+    return pass_nonvariable_constraints(
         dest.constraints,
         src,
-        copy_names,
         idxmap,
         constraint_types,
-        pass_cons,
-        pass_attr;
+        pass_cons;
         filter_constraints = filter_constraints,
     )
 end

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -752,6 +752,28 @@ function MOI.empty!(model::AbstractModel{T}) where {T}
     return
 end
 
+function pass_nonvariable_constraints(
+    dest::AbstractModel,
+    src::MOI.ModelLike,
+    copy_names::Bool,
+    idxmap::IndexMap,
+    constraint_types,
+    pass_cons,
+    pass_attr;
+    filter_constraints::Union{Nothing,Function} = nothing,
+)
+    pass_nonvariable_constraints(
+        dest.constraints,
+        src,
+        copy_names,
+        idxmap,
+        constraint_types,
+        pass_cons,
+        pass_attr;
+        filter_constraints = filter_constraints,
+    )
+end
+
 function MOI.copy_to(dest::AbstractModel, src::MOI.ModelLike; kws...)
     return automatic_copy_to(dest, src; kws...)
 end

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -86,45 +86,12 @@ function MOI.empty!(uf::UniversalFallback)
     return
 end
 
-function _pass_unsupported_attributes(
-    dest::UniversalFallback,
-    src::MOI.ModelLike,
-    copy_names::Bool,
-    idxmap::IndexMap,
-    pass_attr::Function,
-    ::Type{F},
-    ::Type{S},
-) where {F,S}
-    # Copy constraint attributes
-    attrs = MOI.get(src, MOI.ListOfConstraintAttributesSet{F,S}())
-    attrs = filter(attrs) do attr
-        return !MOI.supports(dest.model, attr, MOI.ConstraintIndex{F,S}) &&
-            (copy_names || !(attr isa MOI.ConstraintName))
-    end
-    if !isempty(attrs) # If `attrs` is empty, we can spare the computation of `cis_dest`
-        cis_src = MOI.get(src, MOI.ListOfConstraintIndices{F,S}())
-        cis_dest = map(ci -> idxmap[ci], cis_src)
-        _pass_attributes(
-            dest,
-            src,
-            idxmap,
-            attrs,
-            (MOI.ConstraintIndex{F,S},),
-            (cis_src,),
-            (cis_dest,),
-            pass_attr,
-        )
-    end
-end
-
 function pass_nonvariable_constraints(
     dest::UniversalFallback,
     src::MOI.ModelLike,
-    copy_names::Bool,
     idxmap::IndexMap,
     constraint_types,
-    pass_cons,
-    pass_attr;
+    pass_cons;
     filter_constraints::Union{Nothing,Function} = nothing,
 )
     supported_types = eltype(constraint_types)[]
@@ -139,32 +106,17 @@ function pass_nonvariable_constraints(
     pass_nonvariable_constraints(
         dest.model,
         src,
-        copy_names,
         idxmap,
         supported_types,
-        pass_cons,
-        pass_attr;
+        pass_cons;
         filter_constraints = filter_constraints,
     )
-    for (F, S) in supported_types
-        _pass_unsupported_attributes(
-            dest,
-            src,
-            copy_names,
-            idxmap,
-            pass_attr,
-            F,
-            S,
-        )
-    end
-    pass_nonvariable_constraints_fallback(
+    return pass_nonvariable_constraints_fallback(
         dest,
         src,
-        copy_names,
         idxmap,
         unsupported_types,
-        pass_cons,
-        pass_attr;
+        pass_cons;
         filter_constraints = filter_constraints,
     )
 end


### PR DESCRIPTION
If the `constraints` field of the model has a more efficient copy_to than adding constraints one by one (e.g. SparseMatrixCSC) then even if it's behind layers of bridges, CachingOptimizer and UniversalFallback, it should be copied (if not bridged), not added one by one.
This PR addresses that.

- [x] Bridge layer
- [x] Tests
- [x] Find out what to do with unsupported attributes

See https://github.com/jump-dev/MathOptInterface.jl/issues/1261

Requires https://github.com/jump-dev/MathOptInterface.jl/pull/1267