### PR TITLE
doc typo

### DIFF
--- a/docs/src/manual/implementing.md
+++ b/docs/src/manual/implementing.md
@@ -145,7 +145,7 @@ level.
 
 When implementing an interface, it is important to keep in mind that the way the
 user can express problems in JuMP is not directly limited by the constraints
-which a solver supports via MOI as JuMP performs automatic reformulation](@ref)
+which a solver supports via MOI as JuMP performs automatic reformulation
 via [The Bridges submodule](@ref).
 
 Therefore, we recommend to only support the constraint types that directly map


### PR DESCRIPTION
There was a slight error in the "implementing a solver" page, with a ref broken. I didn't find the equivalent section so the ref is now removed