### PR TITLE
Reminder to exclude tests for unsupported features

### DIFF
--- a/docs/src/submodules/Test/overview.md
+++ b/docs/src/submodules/Test/overview.md
@@ -20,7 +20,9 @@ so that all solvers can benefit.
 ## How to test a solver
 
 The skeleton below can be used for the wrapper test file of a solver named
-`FooBar`. Remove unnecessary tests as appropriate.
+`FooBar`. Remove unnecessary tests as appropriate, for example tests for
+features that the solver does not support (tests are not skipped depending
+on the value of `supports`). 
 
 ```julia
 # ============================ /test/MOI_wrapper.jl ============================


### PR DESCRIPTION
Initially, I had assumed that if my solver implements `supports(feature) = false`, the relevant tests would be skipped automatically. Instead, they are typically failing, since the tests contain `@assert supports(feature)`.