### PR TITLE
[breaking] Rename .variable_index fields to .variable

### DIFF
--- a/src/Bridges/Constraint/indicator_activate_on_zero.jl
+++ b/src/Bridges/Constraint/indicator_activate_on_zero.jl
@@ -3,7 +3,7 @@
 
 The `IndicatorActiveOnFalseBridge` replaces an indicator constraint activated
 on 0 with a variable ``z_0`` with the constraint activated on 1, with a variable ``z_1``.
-It stores the added `variable_index` and added constraints:
+It stores the added `variable` and added constraints:
 - ``z_1 \\in \\mathbb{B}`` in `zero_one_cons`
 - ``z_0 + z_1 == 1`` in `` in `disjunction_cons`
 - The added `ACTIVATE_ON_ONE` indicator constraint in `indicator_cons_index`.
@@ -13,7 +13,7 @@ struct IndicatorActiveOnFalseBridge{
     F<:MOI.AbstractVectorFunction,
     S<:MOI.AbstractScalarSet,
 } <: AbstractBridge
-    variable_index::MOI.VariableIndex
+    variable::MOI.VariableIndex
     zero_one_cons::MOI.ConstraintIndex{MOI.SingleVariable,MOI.ZeroOne}
     disjunction_cons::MOI.ConstraintIndex{
         MOI.ScalarAffineFunction{T},

--- a/src/Bridges/Constraint/indicator_sos.jl
+++ b/src/Bridges/Constraint/indicator_sos.jl
@@ -231,9 +231,9 @@ function MOI.get(
     attr::MOI.ConstraintPrimal,
     bridge::IndicatorSOS1Bridge,
 )
-    zvalue = 
+    zvalue =
         MOI.get(model, MOI.VariablePrimal(attr.result_index), bridge.z_variable)
-    wvalue = 
+    wvalue =
         MOI.get(model, MOI.VariablePrimal(attr.result_index), bridge.w_variable)
     lin_primal_start = MOI.get(model, attr, bridge.linear_constraint_index)
     return [zvalue, lin_primal_start - wvalue]

--- a/src/Bridges/Constraint/indicator_sos.jl
+++ b/src/Bridges/Constraint/indicator_sos.jl
@@ -231,16 +231,10 @@ function MOI.get(
     attr::MOI.ConstraintPrimal,
     bridge::IndicatorSOS1Bridge,
 )
-    zvalue = MOI.get(
-        model,
-        MOI.VariablePrimal(attr.result_index),
-        bridge.z_variable,
-    )
-    wvalue = MOI.get(
-        model,
-        MOI.VariablePrimal(attr.result_index),
-        bridge.w_variable,
-    )
+    zvalue = 
+        MOI.get(model, MOI.VariablePrimal(attr.result_index), bridge.z_variable)
+    wvalue = 
+        MOI.get(model, MOI.VariablePrimal(attr.result_index), bridge.w_variable)
     lin_primal_start = MOI.get(model, attr, bridge.linear_constraint_index)
     return [zvalue, lin_primal_start - wvalue]
 end

--- a/src/Bridges/Constraint/quad_to_soc.jl
+++ b/src/Bridges/Constraint/quad_to_soc.jl
@@ -111,7 +111,7 @@ function matrix_from_quadratic_terms(
     index_to_variable_map = Dict{Int,MOI.VariableIndex}()
     n = 0
     for term in terms
-        for variable in (term.variable_index_1, term.variable_index_2)
+        for variable in (term.variable_1, term.variable_2)
             if !(variable in keys(variable_to_index_map))
                 n += 1
                 variable_to_index_map[variable] = n
@@ -123,8 +123,8 @@ function matrix_from_quadratic_terms(
     J = Int[]
     V = T[]
     for term in terms
-        i = variable_to_index_map[term.variable_index_1]
-        j = variable_to_index_map[term.variable_index_2]
+        i = variable_to_index_map[term.variable_1]
+        j = variable_to_index_map[term.variable_2]
         push!(I, i)
         push!(J, j)
         push!(V, term.coefficient)

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1447,7 +1447,7 @@ function modify_bridged_change(
     for t in func.terms
         coefs =
             [(i, coef * t.coefficient) for (i, coef) in change.new_coefficients]
-        MOI.modify(b, obj, MOI.MultirowChange(t.variable_index, coefs))
+        MOI.modify(b, obj, MOI.MultirowChange(t.variable, coefs))
     end
 end
 function modify_bridged_change(
@@ -1470,7 +1470,7 @@ function modify_bridged_change(
     end
     for t in func.terms
         coef = t.coefficient * change.new_coefficient
-        MOI.modify(b, obj, MOI.ScalarCoefficientChange(t.variable_index, coef))
+        MOI.modify(b, obj, MOI.ScalarCoefficientChange(t.variable, coef))
     end
 end
 function MOI.modify(

--- a/src/FileFormats/CBF/CBF.jl
+++ b/src/FileFormats/CBF/CBF.jl
@@ -152,7 +152,7 @@ function Base.write(io::IO, model::Model)
             println(io, "OBJACOORD")
             println(io, length(obj_function.terms))
             for t in obj_function.terms
-                println(io, t.variable_index.value - 1, " ", t.coefficient)
+                println(io, t.variable.value - 1, " ", t.coefficient)
             end
             println(io)
         end
@@ -220,7 +220,7 @@ function Base.write(io::IO, model::Model)
                         acoord,
                         (
                             num_rows + 4 - t.output_index,
-                            t.scalar_term.variable_index.value,
+                            t.scalar_term.variable.value,
                             t.scalar_term.coefficient,
                         ),
                     )
@@ -235,7 +235,7 @@ function Base.write(io::IO, model::Model)
                         acoord,
                         (
                             num_rows + t.output_index,
-                            t.scalar_term.variable_index.value,
+                            t.scalar_term.variable.value,
                             t.scalar_term.coefficient,
                         ),
                     )
@@ -316,7 +316,7 @@ function Base.write(io::IO, model::Model)
                 hcoord,
                 (
                     length(psd_side_dims),
-                    t.scalar_term.variable_index.value,
+                    t.scalar_term.variable.value,
                     i,
                     j,
                     t.scalar_term.coefficient,

--- a/src/FileFormats/LP/LP.jl
+++ b/src/FileFormats/LP/LP.jl
@@ -111,7 +111,7 @@ function write_function(
                 print_shortest(io, abs(term.coefficient))
             end
 
-            print(io, " ", variable_names[term.variable_index])
+            print(io, " ", variable_names[term.variable])
         end
     end
     return

--- a/src/FileFormats/MOF/write.jl
+++ b/src/FileFormats/MOF/write.jl
@@ -129,7 +129,7 @@ function moi_to_object(
 )
     return OrderedObject(
         "coefficient" => foo.coefficient,
-        "variable" => name_map[foo.variable_index],
+        "variable" => name_map[foo.variable],
     )
 end
 
@@ -150,8 +150,8 @@ function moi_to_object(
 )
     return OrderedObject(
         "coefficient" => foo.coefficient,
-        "variable_1" => name_map[foo.variable_index_1],
-        "variable_2" => name_map[foo.variable_index_2],
+        "variable_1" => name_map[foo.variable_1],
+        "variable_2" => name_map[foo.variable_2],
     )
 end
 

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -256,7 +256,7 @@ function extract_terms(
     multiplier::Float64 = 1.0,
 )
     for term in func.terms
-        variable_name = v_names[term.variable_index]
+        variable_name = v_names[term.variable]
         push!(
             coefficients[variable_name],
             (row_name, multiplier * term.coefficient),

--- a/src/FileFormats/SDPA/SDPA.jl
+++ b/src/FileFormats/SDPA/SDPA.jl
@@ -101,7 +101,7 @@ function Base.write(io::IO, model::Model{T}) where {T}
 
     num_vars = MOI.get(model, MOI.NumberOfVariables())
     println(io, num_vars)
-    function _check_variable_index(vi::MOI.VariableIndex)
+    function _check_variable(vi::MOI.VariableIndex)
         if vi.value > num_vars
             error(
                 "Non-contiguous variable indices not supported. This might " *
@@ -147,8 +147,8 @@ function Base.write(io::IO, model::Model{T}) where {T}
             )
         end
         for term in obj.terms
-            _check_variable_index(term.variable_index)
-            c[term.variable_index.value] = term.coefficient
+            _check_variable(term.variable)
+            c[term.variable.value] = term.coefficient
         end
         if sense == MOI.MAX_SENSE
             for i in eachindex(c)
@@ -194,8 +194,8 @@ function Base.write(io::IO, model::Model{T}) where {T}
             end
         end
         for term in func.terms
-            vi = term.scalar_term.variable_index
-            _check_variable_index(vi)
+            vi = term.scalar_term.variable
+            _check_variable(vi)
             α = term.scalar_term.coefficient
             if !iszero(α)
                 _print_entry(vi.value, block, psd, term.output_index, α)
@@ -270,7 +270,7 @@ function Base.read!(io::IO, model::Model{T}) where {T}
         if startswith(line, '"')
             continue
         end
-        # The lines starting with * should also be skipped 
+        # The lines starting with * should also be skipped
         # according to http://plato.asu.edu/ftp/sdpa_format.txt.
         if startswith(line, '*')
             # Exceptions for integer variables

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -260,24 +260,20 @@ end
 variables(func::MOI.SingleVariable) = func.variable
 variables(func::MOI.VectorOfVariables) = func.variables
 function variables(func::MOI.ScalarAffineFunction)
-    return Set(term.variable_index for term in func.terms)
+    return Set(term.variable for term in func.terms)
 end
 function variables(func::MOI.VectorAffineFunction)
-    return Set(term.scalar_term.variable_index for term in func.terms)
+    return Set(term.scalar_term.variable for term in func.terms)
 end
 function variables(func::MOI.ScalarQuadraticFunction)
-    return Set(term.variable_index for term in func.affine_terms) ∪
-           Set(term.variable_index_1 for term in func.quadratic_terms)
-    return Set(term.variable_index_2 for term in func.quadratic_terms)
+    return Set(term.variable for term in func.affine_terms) ∪
+           Set(term.variable_1 for term in func.quadratic_terms)
+    return Set(term.variable_2 for term in func.quadratic_terms)
 end
 function variables(func::MOI.VectorQuadraticFunction)
-    return Set(term.scalar_term.variable_index for term in func.affine_terms) ∪
-           Set(
-        term.scalar_term.variable_index_1 for term in func.quadratic_terms
-    )
-    return Set(
-        term.scalar_term.variable_index_2 for term in func.quadratic_terms
-    )
+    return Set(term.scalar_term.variable for term in func.affine_terms) ∪
+           Set(term.scalar_term.variable_1 for term in func.quadratic_terms)
+    return Set(term.scalar_term.variable_2 for term in func.quadratic_terms)
 end
 
 """

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -197,7 +197,7 @@ function linear1test(model::MOI.ModelLike, config::TestConfig{T}) where {T}
     if config.query
         # Test that the modification of v has not affected the model
         vars = map(
-            t -> t.variable_index,
+            t -> t.variable,
             MOI.get(model, MOI.ConstraintFunction(), c).terms,
         )
         @test vars == [v[1], v[2]] || vars == [v[2], v[1]]

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -54,13 +54,12 @@ end
 
 # Affine term
 function eval_term(varval::Function, t::MOI.ScalarAffineTerm)
-    return t.coefficient * varval(t.variable_index)
+    return t.coefficient * varval(t.variable)
 end
 # Quadratic term
 function eval_term(varval::Function, t::MOI.ScalarQuadraticTerm)
-    tval =
-        t.coefficient * varval(t.variable_index_1) * varval(t.variable_index_2)
-    return t.variable_index_1 == t.variable_index_2 ? tval / 2 : tval
+    tval = t.coefficient * varval(t.variable_1) * varval(t.variable_2)
+    return t.variable_1 == t.variable_2 ? tval / 2 : tval
 end
 
 """
@@ -127,7 +126,7 @@ map_indices(::F, block::MOI.NLPBlockData) where {F<:Function} = block
 
 # Terms
 function map_indices(index_map::F, t::MOI.ScalarAffineTerm) where {F<:Function}
-    return MOI.ScalarAffineTerm(t.coefficient, index_map(t.variable_index))
+    return MOI.ScalarAffineTerm(t.coefficient, index_map(t.variable))
 end
 
 function map_indices(index_map::F, t::MOI.VectorAffineTerm) where {F<:Function}
@@ -141,7 +140,7 @@ function map_indices(
     index_map::F,
     t::MOI.ScalarQuadraticTerm,
 ) where {F<:Function}
-    inds = index_map.((t.variable_index_1, t.variable_index_2))
+    inds = index_map.((t.variable_1, t.variable_2))
     return MOI.ScalarQuadraticTerm(t.coefficient, inds...)
 end
 
@@ -259,17 +258,17 @@ function substitute_variables(
     variable_map::F,
     term::MOI.ScalarQuadraticTerm{T},
 ) where {T,F<:Function}
-    # We could have `T = Complex{Float64}` and `variable_map(term.variable_index)`
+    # We could have `T = Complex{Float64}` and `variable_map(term.variable)`
     # be a `MOI.ScalarAffineFunction{Float64}` with the Hermitian to PSD bridge.
     # We convert to `MOI.ScalarAffineFunction{T}` to avoid any issue.
-    f1::MOI.ScalarAffineFunction{T} = variable_map(term.variable_index_1)
-    f2::MOI.ScalarAffineFunction{T} = variable_map(term.variable_index_2)
+    f1::MOI.ScalarAffineFunction{T} = variable_map(term.variable_1)
+    f2::MOI.ScalarAffineFunction{T} = variable_map(term.variable_2)
     f12 = operate(*, T, f1, f2)::MOI.ScalarQuadraticFunction{T}
     coef = term.coefficient
     # The quadratic terms are evaluated as x'Qx/2 so a diagonal term should
     # be divided by 2 while an off-diagonal term appears twice in the matrix
     # and is divided by 2 so it stays the same.
-    if term.variable_index_1 == term.variable_index_2
+    if term.variable_1 == term.variable_2
         coef /= 2
     end
     return operate!(*, T, f12, coef)
@@ -280,7 +279,7 @@ function substitute_variables(
     term::MOI.ScalarAffineTerm{T},
 ) where {T,F<:Function}
     # See comment for `term::MOI.ScalarQuadraticTerm` for the conversion.
-    func::MOI.ScalarAffineFunction{T} = variable_map(term.variable_index)
+    func::MOI.ScalarAffineFunction{T} = variable_map(term.variable)
     return operate(*, T, term.coefficient, func)::MOI.ScalarAffineFunction{T}
 end
 
@@ -590,35 +589,32 @@ end
 """
     unsafe_add(t1::MOI.ScalarAffineTerm, t2::MOI.ScalarAffineTerm)
 
-Sums the coefficients of `t1` and `t2` and returns an output `MOI.ScalarAffineTerm`. It is unsafe because it uses the `variable_index` of `t1` as the `variable_index` of the output without checking that it is equal to that of `t2`.
+Sums the coefficients of `t1` and `t2` and returns an output `MOI.ScalarAffineTerm`. It is unsafe because it uses the `variable` of `t1` as the `variable` of the output without checking that it is equal to that of `t2`.
 """
 function unsafe_add(t1::MOI.ScalarAffineTerm, t2::MOI.ScalarAffineTerm)
-    return MOI.ScalarAffineTerm(
-        t1.coefficient + t2.coefficient,
-        t1.variable_index,
-    )
+    return MOI.ScalarAffineTerm(t1.coefficient + t2.coefficient, t1.variable)
 end
 
 """
     unsafe_add(t1::MOI.ScalarQuadraticTerm, t2::MOI.ScalarQuadraticTerm)
 
 Sums the coefficients of `t1` and `t2` and returns an output
-`MOI.ScalarQuadraticTerm`. It is unsafe because it uses the `variable_index`'s
-of `t1` as the `variable_index`'s of the output without checking that they are
+`MOI.ScalarQuadraticTerm`. It is unsafe because it uses the `variable`'s
+of `t1` as the `variable`'s of the output without checking that they are
 the same (up to permutation) to those of `t2`.
 """
 function unsafe_add(t1::MOI.ScalarQuadraticTerm, t2::MOI.ScalarQuadraticTerm)
     return MOI.ScalarQuadraticTerm(
         t1.coefficient + t2.coefficient,
-        t1.variable_index_1,
-        t1.variable_index_2,
+        t1.variable_1,
+        t1.variable_2,
     )
 end
 
 """
     unsafe_add(t1::MOI.VectorAffineTerm, t2::MOI.VectorAffineTerm)
 
-Sums the coefficients of `t1` and `t2` and returns an output `MOI.VectorAffineTerm`. It is unsafe because it uses the `output_index` and `variable_index` of `t1` as the `output_index` and `variable_index` of the output term without checking that they are equal to those of `t2`.
+Sums the coefficients of `t1` and `t2` and returns an output `MOI.VectorAffineTerm`. It is unsafe because it uses the `output_index` and `variable` of `t1` as the `output_index` and `variable` of the output term without checking that they are equal to those of `t2`.
 """
 function unsafe_add(
     t1::VT,
@@ -945,11 +941,11 @@ end
 _keep_all(keep::Function, v::MOI.VariableIndex) = keep(v)
 
 function _keep_all(keep::Function, t::MOI.ScalarAffineTerm)
-    return keep(t.variable_index)
+    return keep(t.variable)
 end
 
 function _keep_all(keep::Function, t::MOI.ScalarQuadraticTerm)
-    return keep(t.variable_index_1) && keep(t.variable_index_2)
+    return keep(t.variable_1) && keep(t.variable_2)
 end
 
 function _keep_all(
@@ -1048,7 +1044,7 @@ function _modifycoefficient(
     new_coefficient::T,
 ) where {T}
     terms = copy(terms)
-    i = something(findfirst(t -> t.variable_index == variable, terms), 0)
+    i = something(findfirst(t -> t.variable == variable, terms), 0)
     if iszero(i)  # The variable was not already in the function
         if !iszero(new_coefficient)
             push!(terms, MOI.ScalarAffineTerm(new_coefficient, variable))
@@ -1062,7 +1058,7 @@ function _modifycoefficient(
         # To account for duplicates, we need to delete any other instances of
         # `variable` in `terms`.
         for j in length(terms):-1:(i+1)
-            if terms[j].variable_index == variable
+            if terms[j].variable == variable
                 deleteat!(terms, j)
             end
         end
@@ -1099,7 +1095,7 @@ function _modifycoefficients(
     coef_dict = Dict(k => v for (k, v) in new_coefficients)
     elements_to_delete = Int[]
     for (i, term) in enumerate(terms)
-        if term.scalar_term.variable_index != variable
+        if term.scalar_term.variable != variable
             continue
         end
         new_coef = Base.get(coef_dict, term.output_index, nothing)
@@ -1236,13 +1232,13 @@ function operate_term(
     return term
 end
 function operate_term(::typeof(-), term::MOI.ScalarAffineTerm)
-    return MOI.ScalarAffineTerm(-term.coefficient, term.variable_index)
+    return MOI.ScalarAffineTerm(-term.coefficient, term.variable)
 end
 function operate_term(::typeof(-), term::MOI.ScalarQuadraticTerm)
     return MOI.ScalarQuadraticTerm(
         -term.coefficient,
-        term.variable_index_1,
-        term.variable_index_2,
+        term.variable_1,
+        term.variable_2,
     )
 end
 function operate_term(::typeof(-), term::MOI.VectorAffineTerm)
@@ -1259,7 +1255,7 @@ function operate_term(::typeof(-), term::MOI.VectorQuadraticTerm)
 end
 
 function operate_term(::typeof(*), α::T, t::MOI.ScalarAffineTerm{T}) where {T}
-    return MOI.ScalarAffineTerm(α * t.coefficient, t.variable_index)
+    return MOI.ScalarAffineTerm(α * t.coefficient, t.variable)
 end
 # `<:Number` is a workaround for https://github.com/jump-dev/MathOptInterface.jl/issues/980
 function operate_term(
@@ -1267,7 +1263,7 @@ function operate_term(
     t::MOI.ScalarAffineTerm{T},
     β::T,
 ) where {T<:Number}
-    return MOI.ScalarAffineTerm(t.coefficient * β, t.variable_index)
+    return MOI.ScalarAffineTerm(t.coefficient * β, t.variable)
 end
 function operate_term(
     ::typeof(*),
@@ -1275,7 +1271,7 @@ function operate_term(
     t::MOI.ScalarAffineTerm{T},
     β::T,
 ) where {T}
-    return MOI.ScalarAffineTerm(α * t.coefficient * β, t.variable_index)
+    return MOI.ScalarAffineTerm(α * t.coefficient * β, t.variable)
 end
 
 function operate_term(
@@ -1285,8 +1281,8 @@ function operate_term(
 ) where {T}
     return MOI.ScalarQuadraticTerm(
         α * t.coefficient,
-        t.variable_index_1,
-        t.variable_index_2,
+        t.variable_1,
+        t.variable_2,
     )
 end
 function operate_term(
@@ -1296,8 +1292,8 @@ function operate_term(
 ) where {T}
     return MOI.ScalarQuadraticTerm(
         t.coefficient * β,
-        t.variable_index_1,
-        t.variable_index_2,
+        t.variable_1,
+        t.variable_2,
     )
 end
 function operate_term(
@@ -1308,8 +1304,8 @@ function operate_term(
 ) where {T}
     return MOI.ScalarQuadraticTerm(
         α * t.coefficient * β,
-        t.variable_index_1,
-        t.variable_index_2,
+        t.variable_1,
+        t.variable_2,
     )
 end
 
@@ -1319,10 +1315,10 @@ function operate_term(
     t2::MOI.ScalarAffineTerm,
 )
     coef = t1.coefficient * t2.coefficient
-    if t1.variable_index == t2.variable_index
+    if t1.variable == t2.variable
         coef *= 2
     end
-    return MOI.ScalarQuadraticTerm(coef, t1.variable_index, t2.variable_index)
+    return MOI.ScalarQuadraticTerm(coef, t1.variable, t2.variable)
 end
 
 function operate_term(::typeof(*), α::T, t::MOI.VectorAffineTerm{T}) where {T}
@@ -1370,7 +1366,7 @@ function operate_term(
 end
 
 function operate_term(::typeof(/), t::MOI.ScalarAffineTerm{T}, α::T) where {T}
-    return MOI.ScalarAffineTerm(t.coefficient / α, t.variable_index)
+    return MOI.ScalarAffineTerm(t.coefficient / α, t.variable)
 end
 function operate_term(
     ::typeof(/),
@@ -1379,8 +1375,8 @@ function operate_term(
 ) where {T}
     return MOI.ScalarQuadraticTerm(
         t.coefficient / α,
-        t.variable_index_1,
-        t.variable_index_2,
+        t.variable_1,
+        t.variable_2,
     )
 end
 function operate_term(::typeof(/), t::MOI.VectorAffineTerm{T}, α::T) where {T}
@@ -2251,8 +2247,8 @@ function operate(
     end
     quad_terms = map(
         t -> MOI.ScalarQuadraticTerm(
-            t.variable_index == g.variable ? 2t.coefficient : t.coefficient,
-            t.variable_index,
+            t.variable == g.variable ? 2t.coefficient : t.coefficient,
+            t.variable,
             g.variable,
         ),
         f.terms,
@@ -2904,7 +2900,7 @@ function convert_approx(
        )
         throw(InexactError(:convert_approx, MOI.SingleVariable, func))
     end
-    return MOI.SingleVariable(f.terms[i].variable_index)
+    return MOI.SingleVariable(f.terms[i].variable)
 end
 function convert_approx(
     ::Type{MOI.VectorOfVariables},
@@ -2927,13 +2923,13 @@ end
 Base.promote_rule(::Type{F}, ::Type{T}) where {T,F<:TypedScalarLike{T}} = F
 
 function operate_coefficient(f, term::MOI.ScalarAffineTerm)
-    return MOI.ScalarAffineTerm(f(term.coefficient), term.variable_index)
+    return MOI.ScalarAffineTerm(f(term.coefficient), term.variable)
 end
 function operate_coefficient(f, term::MOI.ScalarQuadraticTerm)
     return MOI.ScalarQuadraticTerm(
         f(term.coefficient),
-        term.variable_index_1,
-        term.variable_index_2,
+        term.variable_1,
+        term.variable_2,
     )
 end
 function operate_coefficient(f, term::MOI.VectorAffineTerm)

--- a/src/Utilities/mutable_arithmetics.jl
+++ b/src/Utilities/mutable_arithmetics.jl
@@ -6,25 +6,21 @@ MA.mutability(::Type{<:TypedLike}) = MA.IsMutable()
 
 function MA.mutable_copy(func::MOI.ScalarAffineFunction)
     terms = [
-        MOI.ScalarAffineTerm(
-            MA.copy_if_mutable(t.coefficient),
-            t.variable_index,
-        ) for t in func.terms
+        MOI.ScalarAffineTerm(MA.copy_if_mutable(t.coefficient), t.variable)
+        for t in func.terms
     ]
     return MOI.ScalarAffineFunction(terms, MA.copy_if_mutable(func.constant))
 end
 function MA.mutable_copy(func::MOI.ScalarQuadraticFunction)
     affine_terms = [
-        MOI.ScalarAffineTerm(
-            MA.copy_if_mutable(t.coefficient),
-            t.variable_index,
-        ) for t in func.affine_terms
+        MOI.ScalarAffineTerm(MA.copy_if_mutable(t.coefficient), t.variable)
+        for t in func.affine_terms
     ]
     quadratic_terms = [
         MOI.ScalarQuadraticTerm(
             MA.copy_if_mutable(t.coefficient),
-            t.variable_index_1,
-            t.variable_index_2,
+            t.variable_1,
+            t.variable_2,
         ) for t in func.quadratic_terms
     ]
     return MOI.ScalarQuadraticFunction(

--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -17,7 +17,7 @@ using Base.Meta: isexpr
 
 struct ParsedScalarAffineTerm
     coefficient::Float64
-    variable_index::Symbol
+    variable::Symbol
 end
 
 struct ParsedScalarAffineFunction
@@ -37,8 +37,8 @@ end
 
 struct ParsedScalarQuadraticTerm
     coefficient::Float64
-    variable_index_1::Symbol
-    variable_index_2::Symbol
+    variable_1::Symbol
+    variable_2::Symbol
 end
 
 struct ParsedScalarQuadraticFunction

--- a/src/Utilities/results.jl
+++ b/src/Utilities/results.jl
@@ -213,7 +213,7 @@ function variable_coefficient(
 ) where {T}
     coef = zero(T)
     for term in func.terms
-        if term.variable_index == vi
+        if term.variable == vi
             coef += term.coefficient
         end
     end
@@ -226,7 +226,7 @@ function variable_coefficient(
     coef = zeros(T, MOI.output_dimension(func))
     for vector_term in func.terms
         term = vector_term.scalar_term
-        if term.variable_index == vi
+        if term.variable == vi
             coef[vector_term.output_index] += term.coefficient
         end
     end
@@ -240,15 +240,15 @@ function variable_coefficient(
     coef = zero(T)
     # `vi`'th row of `Qx + a` where `func` is `x'Qx/2 + a'x + b`.
     for term in func.affine_terms
-        if term.variable_index == vi
+        if term.variable == vi
             coef += term.coefficient
         end
     end
     for term in func.quadratic_terms
-        if term.variable_index_1 == vi
-            coef += term.coefficient * value(term.variable_index_2)
-        elseif term.variable_index_2 == vi
-            coef += term.coefficient * value(term.variable_index_1)
+        if term.variable_1 == vi
+            coef += term.coefficient * value(term.variable_2)
+        elseif term.variable_2 == vi
+            coef += term.coefficient * value(term.variable_1)
         end
     end
     return coef
@@ -262,17 +262,17 @@ function variable_coefficient(
     # `vi`'th row of `Qx + a` where `func` is `x'Qx/2 + a'x + b`.
     for vector_term in func.affine_terms
         term = vector_term.scalar_term
-        if term.variable_index == vi
+        if term.variable == vi
             coef[vector_term.output_index] += term.coefficient
         end
     end
     for vector_term in func.quadratic_terms
         term = vector_term.scalar_term
         oi = vector_term.output_index
-        if term.variable_index_1 == vi
-            coef[oi] += term.coefficient * value(term.variable_index_2)
-        elseif term.variable_index_2 == vi
-            coef[oi] += term.coefficient * value(term.variable_index_1)
+        if term.variable_1 == vi
+            coef[oi] += term.coefficient * value(term.variable_2)
+        elseif term.variable_2 == vi
+            coef[oi] += term.coefficient * value(term.variable_1)
         end
     end
     return coef

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -23,3 +23,22 @@ function Base.getproperty(
     end
     return getfield(attr, f)
 end
+
+function Base.getproperty(f::ScalarAffineTerm, key::Symbol)
+    if key == :variable_index
+        @warn("`.variable_index` is deprecated in favor of `.variable`.")
+        return getfield(f, :variable)
+    end
+    return getfield(f, key)
+end
+
+function Base.getproperty(f::ScalarQuadraticTerm, key::Symbol)
+    if key == :variable_index_1
+        @warn("`.variable_index_1` is deprecated in favor of `.variable_1`.")
+        return getfield(f, :variable_1)
+    elseif key == :variable_index_2
+        @warn("`.variable_index_2` is deprecated in favor of `.variable_2`.")
+        return getfield(f, :variable_2)
+    end
+    return getfield(f, key)
+end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -60,15 +60,15 @@ output_dimension(f::VectorOfVariables) = length(f.variables)
 """
     struct ScalarAffineTerm{T}
         coefficient::T
-        variable_index::VariableIndex
+        variable::VariableIndex
     end
 
 Represents ``c x_i`` where ``c`` is `coefficient` and ``x_i`` is the variable
-identified by `variable_index`.
+identified by `variable`.
 """
 struct ScalarAffineTerm{T}
     coefficient::T
-    variable_index::VariableIndex
+    variable::VariableIndex
 end
 
 # Note: ScalarAffineFunction is mutable because its `constant` field is likely of an immutable
@@ -133,18 +133,18 @@ output_dimension(f::VectorAffineFunction) = length(f.constants)
 """
     struct ScalarQuadraticTerm{T}
         coefficient::T
-        variable_index_1::VariableIndex
-        variable_index_2::VariableIndex
+        variable_1::VariableIndex
+        variable_2::VariableIndex
     end
 
 Represents ``c x_i x_j`` where ``c`` is `coefficient`, ``x_i`` is the variable
-identified by `variable_index_1` and ``x_j`` is the variable identified by
-`variable_index_2`.
+identified by `variable_1` and ``x_j`` is the variable identified by
+`variable_2`.
 """
 struct ScalarQuadraticTerm{T}
     coefficient::T
-    variable_index_1::VariableIndex
-    variable_index_2::VariableIndex
+    variable_1::VariableIndex
+    variable_2::VariableIndex
 end
 
 # Note: ScalarQuadraticFunction is mutable because its `constant` field is likely of an immutable
@@ -345,9 +345,9 @@ Returns the indices of the input term `t` as a tuple of `Int`s.
 * For `t::VectorQuadraticTerm`, this is a 3-tuple of the row/output and
   variable indices in non-decreasing order.
 """
-term_indices(t::ScalarAffineTerm) = (t.variable_index.value,)
+term_indices(t::ScalarAffineTerm) = (t.variable.value,)
 function term_indices(t::ScalarQuadraticTerm)
-    return minmax(t.variable_index_1.value, t.variable_index_2.value)
+    return minmax(t.variable_1.value, t.variable_2.value)
 end
 function term_indices(t::Union{VectorAffineTerm,VectorQuadraticTerm})
     return (t.output_index, term_indices(t.scalar_term)...)
@@ -511,7 +511,7 @@ function Base.convert(::Type{SingleVariable}, f::ScalarAffineFunction)
     )
         throw(InexactError(:convert, SingleVariable, f))
     end
-    return SingleVariable(f.terms[1].variable_index)
+    return SingleVariable(f.terms[1].variable)
 end
 
 function Base.convert(
@@ -544,7 +544,7 @@ function Base.convert(
     ::Type{ScalarAffineTerm{T}},
     t::ScalarAffineTerm,
 ) where {T}
-    return ScalarAffineTerm{T}(t.coefficient, t.variable_index)
+    return ScalarAffineTerm{T}(t.coefficient, t.variable)
 end
 
 function Base.convert(

--- a/test/Bridges/Constraint/indicator_activate_on_zero.jl
+++ b/test/Bridges/Constraint/indicator_activate_on_zero.jl
@@ -52,7 +52,7 @@ include("../utilities.jl")
     @test BT === BT2
     @test bridge isa BT
 
-    z1comp = bridge.variable_index
+    z1comp = bridge.variable
     @test MOI.get(model, MOI.ConstraintFunction(), bridge.zero_one_cons) ==
           MOI.SingleVariable(z1comp)
     @test MOI.get(model, MOI.ConstraintSet(), bridge.disjunction_cons) ==
@@ -60,7 +60,7 @@ include("../utilities.jl")
     disjunction_cons =
         MOI.get(model, MOI.ConstraintFunction(), bridge.disjunction_cons)
     for t in disjunction_cons.terms
-        @test t.variable_index == z1 || t.variable_index == z1comp
+        @test t.variable == z1 || t.variable == z1comp
         @test t.coefficient ≈ 1.0
     end
 end

--- a/test/Bridges/Constraint/indicator_sos.jl
+++ b/test/Bridges/Constraint/indicator_sos.jl
@@ -92,7 +92,7 @@ include("../utilities.jl")
     }
     @test bridge3 isa BT3
 
-    w1 = bridge1.w_variable_index
+    w1 = bridge1.w_variable
     @test MOI.get(
         model,
         MOI.ConstraintFunction(),
@@ -113,7 +113,7 @@ include("../utilities.jl")
     )
     @test MOI.get(model, MOI.ConstraintSet(), lin_cons1) == MOI.LessThan(8.0)
 
-    w2 = bridge2.w_variable_index
+    w2 = bridge2.w_variable
     @test bridge2.bound_constraint_index === nothing
     @test MOI.get(
         model,
@@ -132,7 +132,7 @@ include("../utilities.jl")
     )
     @test MOI.get(model, MOI.ConstraintSet(), lin_cons2) == MOI.EqualTo(9.0)
 
-    w3 = bridge3.w_variable_index
+    w3 = bridge3.w_variable
     @test MOI.get(
         model,
         MOI.ConstraintFunction(),
@@ -303,7 +303,7 @@ end
     )
     bridge1 = MOIB.Constraint.bridge_constraint(BT, mock, f, iset)
     # w value should be defaulted to 0
-    MOI.set(mock, MOI.VariablePrimalStart(), bridge1.w_variable_index, 0.0)
+    MOI.set(mock, MOI.VariablePrimalStart(), bridge1.w_variable, 0.0)
     affine_value = 6.0
     MOI.set(mock, MOI.ConstraintPrimalStart(), bridge1, [1.0, affine_value])
     @test MOI.get(mock, MOI.VariablePrimalStart(), z) ≈ 1.0
@@ -315,7 +315,7 @@ end
 
     # after setting the w value
     w_value = 3.0
-    MOI.set(mock, MOI.VariablePrimalStart(), bridge1.w_variable_index, w_value)
+    MOI.set(mock, MOI.VariablePrimalStart(), bridge1.w_variable, w_value)
     # linear function should not move
     @test all(
         MOI.get(mock, MOI.ConstraintPrimalStart(), bridge1) .≈
@@ -360,9 +360,9 @@ end
     )
 
     # VariablePrimal
-    MOI.set(mock, MOI.VariablePrimal(), bridge1.w_variable_index, 33.0)
+    MOI.set(mock, MOI.VariablePrimal(), bridge1.w_variable, 33.0)
     z_value = 1.0
-    MOI.set(mock, MOI.VariablePrimal(), bridge1.z_variable_index, z_value)
+    MOI.set(mock, MOI.VariablePrimal(), bridge1.z_variable, z_value)
     MOI.set(mock, MOI.VariablePrimal(), x, affine_value)
 
     # linear function should not move

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -60,10 +60,10 @@ end
 @testset "Names" begin
     @testset "Blank variable name" begin
         model = MOF.Model()
-        variable_index = MOI.add_variable(model)
-        @test_throws Exception MOF.moi_to_object(variable_index, model)
+        variable = MOI.add_variable(model)
+        @test_throws Exception MOF.moi_to_object(variable, model)
         MOI.FileFormats.create_unique_names(model, warn = true)
-        @test MOF.moi_to_object(variable_index, model) ==
+        @test MOF.moi_to_object(variable, model) ==
               MOF.OrderedObject("name" => "x1")
     end
     @testset "Duplicate variable name" begin

--- a/test/deprecate.jl
+++ b/test/deprecate.jl
@@ -19,6 +19,23 @@ const MOI = MathOptInterface
         MOI.NLPBlockDual,
     )
         attr = attr_type(1)
-        @test_logs (:warn, "Field attr.N is deprecated, use attr.result_index") attr.N
+        @test_logs(
+            (:warn, "Field attr.N is deprecated, use attr.result_index"),
+            attr.N,
+        )
     end
+end
+
+@testset "ScalarAffineTerm" begin
+    x = MOI.VariableIndex(1)
+    t = MOI.ScalarAffineTerm(1.0, x)
+    @test_logs (:warn,) t.variable_index == x
+end
+
+@testset "ScalarQuadraticTerm" begin
+    x = MOI.VariableIndex(1)
+    y = MOI.VariableIndex(2)
+    t = MOI.ScalarQuadraticTerm(1.0, x, y)
+    @test_logs (:warn,) t.variable_index_1 == x
+    @test_logs (:warn,) t.variable_index_2 == y
 end


### PR DESCRIPTION
I'm not necessarily sold on this one. 

The other option is to rename `SingleVariable` to `.variable_index` and `VectorOfVariables` to `.variable_indices`. Either way, we should standardize.

Closes #641 