### PR TITLE
[breaking] error on SingleVariable ConstraintNames

### DIFF
--- a/docs/src/manual/implementing.md
+++ b/docs/src/manual/implementing.md
@@ -511,6 +511,29 @@ These methods have the following rules:
   variable or constraint
 * If there are multiple variables or constraints with the name, throw an error.
 
+!!! warning
+    You should _not_ implement [`ConstraintName`](@ref) for
+    [`SingleVariable`](@ref) constraints. If you implement [`ConstraintName`](@ref)
+    for other constraints, you may need to add the following two methods to
+    avoid method ambiguities:
+    ```julia
+    function MOI.supports(
+        ::Optimizer,
+        ::MOI.ConstraintName,
+        ::Type{MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
+    )
+        return throw(MOI.SingleVariableConstraintNameError())
+    end
+    function MOI.set(
+        ::Optimizer,
+        ::MOI.ConstraintName,
+        ::MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet},
+        ::String,
+    )
+        return throw(MOI.SingleVariableConstraintNameError())
+    end
+    ```
+
 ## Solutions
 
 Implement [`optimize!`](@ref) to solve the model:

--- a/docs/src/manual/implementing.md
+++ b/docs/src/manual/implementing.md
@@ -514,13 +514,13 @@ These methods have the following rules:
 !!! warning
     You should _not_ implement [`ConstraintName`](@ref) for
     [`SingleVariable`](@ref) constraints. If you implement [`ConstraintName`](@ref)
-    for other constraints, you may need to add the following two methods to
-    avoid method ambiguities:
+    for other constraints, you can add the following two methods to disable
+    [`ConstraintName`](@ref) for [`SingleVariable`](@ref) constraints.
     ```julia
     function MOI.supports(
         ::Optimizer,
         ::MOI.ConstraintName,
-        ::Type{MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
+        ::Type{<:MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
     )
         return throw(MOI.SingleVariableConstraintNameError())
     end

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1324,7 +1324,7 @@ function MOI.supports(
     ::MOI.ConstraintName,
     ::Type{MOI.ConstraintIndex{MOI.SingleVariable,S}},
 ) where {S}
-    return false
+    return throw(MOI.SingleVariableConstraintNameError())
 end
 
 function MOI.set(

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1322,15 +1322,15 @@ end
 function MOI.supports(
     ::AbstractBridgeOptimizer,
     ::MOI.ConstraintName,
-    ::Type{MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
-)
+    ::Type{MOI.ConstraintIndex{MOI.SingleVariable,S}},
+) where {S}
     return false
 end
 
 function MOI.set(
     ::AbstractBridgeOptimizer,
     ::MOI.ConstraintName,
-    ::CI{MOI.SingleVariable,<:MOI.AbstractScalarSet},
+    ::MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet},
     ::String,
 )
     return throw(MOI.SingleVariableConstraintNameError())

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1319,6 +1319,23 @@ function MOI.set(
     return
 end
 
+function MOI.supports(
+    ::AbstractBridgeOptimizer,
+    ::MOI.ConstraintName,
+    ::Type{MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
+)
+    return false
+end
+
+function MOI.set(
+    ::AbstractBridgeOptimizer,
+    ::MOI.ConstraintName,
+    ::CI{MOI.SingleVariable,<:MOI.AbstractScalarSet},
+    ::String,
+)
+    return throw(MOI.SingleVariableConstraintNameError())
+end
+
 # Query index from name (similar to `UniversalFallback`)
 function MOI.get(
     b::AbstractBridgeOptimizer,

--- a/src/FileFormats/MOF/write.jl
+++ b/src/FileFormats/MOF/write.jl
@@ -88,10 +88,12 @@ function moi_to_object(
 ) where {F,S}
     func = MOI.get(model, MOI.ConstraintFunction(), index)
     set = MOI.get(model, MOI.ConstraintSet(), index)
-    name = MOI.get(model, MOI.ConstraintName(), index)
     object = OrderedObject()
-    if name != ""
-        object["name"] = name
+    if F != MOI.SingleVariable
+        name = MOI.get(model, MOI.ConstraintName(), index)
+        if name != ""
+            object["name"] = name
+        end
     end
     object["function"] = moi_to_object(func, name_map)
     object["set"] = moi_to_object(set, name_map)

--- a/src/FileFormats/utils.jl
+++ b/src/FileFormats/utils.jl
@@ -39,6 +39,9 @@ function create_unique_constraint_names(
 )
     original_names = Set{String}()
     for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
+        if F == MOI.SingleVariable
+            continue  # SingleVariable constraints do not need a name.
+        end
         for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
             name = MOI.get(model, MOI.ConstraintName(), index)
             push!(original_names, _replace(name, replacements))
@@ -46,6 +49,9 @@ function create_unique_constraint_names(
     end
     added_names = Set{String}()
     for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
+        if F == MOI.SingleVariable
+            continue  # SingleVariable constraints do not need a name.
+        end
         for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
             original_name = MOI.get(model, MOI.ConstraintName(), index)
             new_name = _replace(

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -333,12 +333,20 @@ function basic_constraint_test_helper(
         c = MOI.add_constraint(model, constraint_function, set)
         @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 1
 
-        if name && F != MOI.SingleVariable
+        if name
             @testset "ConstraintName" begin
-                @test MOI.get(model, MOI.ConstraintName(), c) == ""
-                @test MOI.supports(model, MOI.ConstraintName(), typeof(c))
-                MOI.set(model, MOI.ConstraintName(), c, "c")
-                @test MOI.get(model, MOI.ConstraintName(), c) == "c"
+                if F == MOI.SingleVariable
+                    @test !MOI.supports(model, MOI.ConstraintName(), typeof(c))
+                    @test_throws(
+                        MOI.SingleVariableConstraintNameError(),
+                        MOI.set(model, MOI.ConstraintName(), c, "c"),
+                    )
+                else
+                    @test MOI.get(model, MOI.ConstraintName(), c) == ""
+                    @test MOI.supports(model, MOI.ConstraintName(), typeof(c))
+                    MOI.set(model, MOI.ConstraintName(), c, "c")
+                    @test MOI.get(model, MOI.ConstraintName(), c) == "c"
+                end
             end
         end
 

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -333,7 +333,7 @@ function basic_constraint_test_helper(
         c = MOI.add_constraint(model, constraint_function, set)
         @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 1
 
-        if name && !(func isa MOI.SingleVariable)
+        if name && F != MOI.SingleVariable
             @testset "ConstraintName" begin
                 @test MOI.get(model, MOI.ConstraintName(), c) == ""
                 @test MOI.supports(model, MOI.ConstraintName(), typeof(c))

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -333,7 +333,7 @@ function basic_constraint_test_helper(
         c = MOI.add_constraint(model, constraint_function, set)
         @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 1
 
-        if name
+        if name && !(func isa MOI.SingleVariable)
             @testset "ConstraintName" begin
                 @test MOI.get(model, MOI.ConstraintName(), c) == ""
                 @test MOI.supports(model, MOI.ConstraintName(), typeof(c))

--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -336,7 +336,10 @@ function basic_constraint_test_helper(
         if name
             @testset "ConstraintName" begin
                 if F == MOI.SingleVariable
-                    @test !MOI.supports(model, MOI.ConstraintName(), typeof(c))
+                    @test_throws(
+                        MOI.SingleVariableConstraintNameError(),
+                        MOI.supports(model, MOI.ConstraintName(), typeof(c)),
+                    )
                     @test_throws(
                         MOI.SingleVariableConstraintNameError(),
                         MOI.set(model, MOI.ConstraintName(), c, "c"),

--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -14,29 +14,19 @@ function getconstraint(model::MOI.ModelLike, config::TestConfig)
     c2: 1.0 * x <= 2.0
 """,
     )
+    F = MOI.ScalarAffineFunction{Float64}
     @test MOI.get(model, MOI.ConstraintIndex, "c3") === nothing
+    @test MOI.get(model, MOI.ConstraintIndex{F,MOI.LessThan{Float64}}, "c1") ===
+          nothing
     @test MOI.get(
         model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}},
-        "c1",
-    ) === nothing
-    @test MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}},
+        MOI.ConstraintIndex{F,MOI.GreaterThan{Float64}},
         "c2",
     ) === nothing
-    c1 = MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}},
-        "c1",
-    )
+    c1 = MOI.get(model, MOI.ConstraintIndex{F,MOI.GreaterThan{Float64}}, "c1")
     @test MOI.get(model, MOI.ConstraintIndex, "c1") == c1
     @test MOI.is_valid(model, c1)
-    c2 = MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}},
-        "c2",
-    )
+    c2 = MOI.get(model, MOI.ConstraintIndex{F,MOI.LessThan{Float64}}, "c2")
     @test MOI.get(model, MOI.ConstraintIndex, "c2") == c2
     @test MOI.is_valid(model, c2)
 end

--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -10,8 +10,8 @@ function getconstraint(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x
     minobjective: 2.0x
-    c1: x >= 1.0
-    c2: x <= 2.0
+    c1: 1.0 * x >= 1.0
+    c2: 1.0 * x <= 2.0
 """,
     )
     @test MOI.get(model, MOI.ConstraintIndex, "c3") === nothing
@@ -465,9 +465,9 @@ function solve_zero_one_with_bounds_1(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x
     maxobjective: 2.0x
-    c1: x in ZeroOne()
-    c2: x >= 0.0
-    c3: x <= 1.0
+    x in ZeroOne()
+    x >= 0.0
+    x <= 1.0
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
@@ -487,9 +487,9 @@ function solve_zero_one_with_bounds_2(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x
     maxobjective: 2.0x
-    c1: x in ZeroOne()
-    c2: x >= 0.0
-    c3: x <= 0.5
+    x in ZeroOne()
+    x >= 0.0
+    x <= 0.5
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
@@ -509,9 +509,9 @@ function solve_zero_one_with_bounds_3(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x
     maxobjective: 2.0x
-    c1: x in ZeroOne()
-    c2: x >= 0.2
-    c3: x <= 0.5
+    x in ZeroOne()
+    x >= 0.2
+    x <= 0.5
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -18,7 +18,7 @@ function set_function_single_variable(model::MOI.ModelLike, config::TestConfig)
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
     y = MOI.get(model, MOI.VariableIndex, "y")
-    c = MOI.Constraintindex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test c.value == x.value
@@ -49,7 +49,7 @@ function solve_set_singlevariable_lessthan(
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.Constraintindex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     @test c.value == x.value
     test_model_solution(
         model,
@@ -94,7 +94,7 @@ function solve_transform_singlevariable_lessthan(
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.Constraintindex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     @test c.value == x.value
     test_model_solution(
         model,
@@ -510,7 +510,7 @@ function delete_variable_with_single_variable_obj(
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
     y = MOI.get(model, MOI.VariableIndex, "y")
-    c = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     @test c.value == x.value
     MOI.delete(model, y)
     return test_model_solution(

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -13,12 +13,12 @@ function set_function_single_variable(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x, y
     maxobjective: 1.0x + 1.0y
-    c: x <= 1.0
+    x <= 1.0
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
     y = MOI.get(model, MOI.VariableIndex, "y")
-    c = MOI.get(model, MOI.ConstraintIndex, "c")
+    c = MOI.Constraintindex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test c.value == x.value
@@ -45,11 +45,11 @@ function solve_set_singlevariable_lessthan(
         """
     variables: x
     maxobjective: 1.0x
-    c: x <= 1.0
+    x <= 1.0
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.get(model, MOI.ConstraintIndex, "c")
+    c = MOI.Constraintindex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     @test c.value == x.value
     test_model_solution(
         model,
@@ -90,11 +90,11 @@ function solve_transform_singlevariable_lessthan(
         """
     variables: x
     maxobjective: 1.0x
-    c: x <= 1.0
+    x <= 1.0
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.get(model, MOI.ConstraintIndex, "c")
+    c = MOI.Constraintindex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     @test c.value == x.value
     test_model_solution(
         model,
@@ -505,16 +505,12 @@ function delete_variable_with_single_variable_obj(
         """
     variables: x, y
     minobjective: x
-    c: x >= 1.0
+    x >= 1.0
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
     y = MOI.get(model, MOI.VariableIndex, "y")
-    c = MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}},
-        "c",
-    )
+    c = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     @test c.value == x.value
     MOI.delete(model, y)
     return test_model_solution(
@@ -546,9 +542,9 @@ function delete_variables_in_a_batch(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x, y, z
     minobjective: 1.0 * x + 2.0 * y + 3.0 * z
-    c1: x >= 1.0
-    c2: y >= 1.0
-    c3: z >= 1.0
+    x >= 1.0
+    y >= 1.0
+    z >= 1.0
 """,
     )
     x, y, z = MOI.get(model, MOI.ListOfVariableIndices())

--- a/src/Test/UnitTests/modifications.jl
+++ b/src/Test/UnitTests/modifications.jl
@@ -510,7 +510,9 @@ function delete_variable_with_single_variable_obj(
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
     y = MOI.get(model, MOI.VariableIndex, "y")
-    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(
+        x.value,
+    )
     @test c.value == x.value
     MOI.delete(model, y)
     return test_model_solution(

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -109,7 +109,7 @@ function solve_constant_obj(model::MOI.ModelLike, config::TestConfig)
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test c.value == x.value
@@ -144,7 +144,7 @@ function solve_blank_obj(model::MOI.ModelLike, config::TestConfig)
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     @test c.value == x.value
     test_model_solution(
         model,
@@ -181,7 +181,7 @@ function solve_singlevariable_obj(model::MOI.ModelLike, config::TestConfig)
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     @test c.value == x.value
     return test_model_solution(
         model,

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -105,15 +105,11 @@ function solve_constant_obj(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x
     minobjective: 2.0x + 1.0
-    c: x >= 1.0
+    x >= 1.0
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}},
-        "c",
-    )
+    c = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test c.value == x.value
@@ -144,15 +140,11 @@ function solve_blank_obj(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x
     minobjective: 0.0x + 0.0
-    c: x >= 1.0
+    x >= 1.0
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}},
-        "c",
-    )
+    c = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     @test c.value == x.value
     test_model_solution(
         model,
@@ -185,15 +177,11 @@ function solve_singlevariable_obj(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x
     minobjective: x
-    c: x >= 1.0
+    x >= 1.0
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}},
-        "c",
-    )
+    c = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     @test c.value == x.value
     return test_model_solution(
         model,

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -109,7 +109,9 @@ function solve_constant_obj(model::MOI.ModelLike, config::TestConfig)
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(
+        x.value,
+    )
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test c.value == x.value
@@ -144,7 +146,9 @@ function solve_blank_obj(model::MOI.ModelLike, config::TestConfig)
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(
+        x.value,
+    )
     @test c.value == x.value
     test_model_solution(
         model,
@@ -181,7 +185,9 @@ function solve_singlevariable_obj(model::MOI.ModelLike, config::TestConfig)
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(
+        x.value,
+    )
     @test c.value == x.value
     return test_model_solution(
         model,

--- a/src/Test/UnitTests/solve.jl
+++ b/src/Test/UnitTests/solve.jl
@@ -12,8 +12,8 @@ function solve_objbound_edge_cases(model::MOI.ModelLike, config::TestConfig)
             """
     variables: x
     minobjective: 2.0x + -1.0
-    c1: x >= 1.5
-    c2: x in Integer()
+    x >= 1.5
+    x in Integer()
 """,
         )
         x = MOI.get(model, MOI.VariableIndex, "x")
@@ -36,8 +36,8 @@ function solve_objbound_edge_cases(model::MOI.ModelLike, config::TestConfig)
             """
     variables: x
     maxobjective: 2.0x + 1.0
-    c1: x <= 1.5
-    c2: x in Integer()
+    x <= 1.5
+    x in Integer()
 """,
         )
         x = MOI.get(model, MOI.VariableIndex, "x")
@@ -60,7 +60,7 @@ function solve_objbound_edge_cases(model::MOI.ModelLike, config::TestConfig)
             """
     variables: x
     minobjective: 2.0x + -1.0
-    c1: x >= 1.5
+    x >= 1.5
 """,
         )
         x = MOI.get(model, MOI.VariableIndex, "x")
@@ -83,7 +83,7 @@ function solve_objbound_edge_cases(model::MOI.ModelLike, config::TestConfig)
             """
     variables: x
     maxobjective: 2.0x + 1.0
-    c1: x <= 1.5
+    x <= 1.5
 """,
         )
         x = MOI.get(model, MOI.VariableIndex, "x")

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -240,7 +240,9 @@ function solve_with_upperbound(model::MOI.ModelLike, config::TestConfig)
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test c1.value == x.value
-    c2 = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c2 = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(
+        x.value,
+    )
     @test c2.value == x.value
     return test_model_solution(
         model,
@@ -273,7 +275,9 @@ function solve_with_lowerbound(model::MOI.ModelLike, config::TestConfig)
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c1 = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c1 = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(
+        x.value,
+    )
     @test c1.value == x.value
     c2 = MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     @test c2.value == x.value

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -186,8 +186,8 @@ function getvariable(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x
     minobjective: 2.0x
-    c1: x >= 1.0
-    c2: x <= 2.0
+    x >= 1.0
+    x <= 2.0
 """,
     )
     @test MOI.get(model, MOI.VariableIndex, "y") === nothing
@@ -231,24 +231,16 @@ function solve_with_upperbound(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x
     maxobjective: 2.0x
-    c1: x <= 1.0
-    c2: x >= 0.0
+    x <= 1.0
+    x >= 0.0
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c1 = MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}},
-        "c1",
-    )
+    c1 = MOI.Constraintindex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test c1.value == x.value
-    c2 = MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}},
-        "c2",
-    )
+    c2 = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     @test c2.value == x.value
     return test_model_solution(
         model,
@@ -276,22 +268,14 @@ function solve_with_lowerbound(model::MOI.ModelLike, config::TestConfig)
         """
     variables: x
     minobjective: 2.0x
-    c1: x >= 1.0
-    c2: x <= 2.0
+    x >= 1.0
+    x <= 2.0
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c1 = MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}},
-        "c1",
-    )
+    c1 = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     @test c1.value == x.value
-    c2 = MOI.get(
-        model,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}},
-        "c2",
-    )
+    c2 = MOI.Constraintindex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     @test c2.value == x.value
     return test_model_solution(
         model,
@@ -318,8 +302,8 @@ function solve_integer_edge_cases(model::MOI.ModelLike, config::TestConfig)
             """
     variables: x
     minobjective: 2.0x
-    c1: x >= 1.5
-    c2: x in Integer()
+    x >= 1.5
+    x in Integer()
 """,
         )
         x = MOI.get(model, MOI.VariableIndex, "x")
@@ -338,8 +322,8 @@ function solve_integer_edge_cases(model::MOI.ModelLike, config::TestConfig)
             """
     variables: x
     minobjective: -2.0x
-    c1: x <= 1.5
-    c2: x in Integer()
+    x <= 1.5
+    x in Integer()
 """,
         )
         x = MOI.get(model, MOI.VariableIndex, "x")
@@ -359,8 +343,8 @@ function solve_integer_edge_cases(model::MOI.ModelLike, config::TestConfig)
             """
     variables: x
     minobjective: -2.0x
-    c1: x <= 2.0
-    c2: x in ZeroOne()
+    x <= 2.0
+    x in ZeroOne()
 """,
         )
         x = MOI.get(model, MOI.VariableIndex, "x")
@@ -380,8 +364,8 @@ function solve_integer_edge_cases(model::MOI.ModelLike, config::TestConfig)
             """
     variables: x
     minobjective: 1.0x
-    c1: x <= 0.0
-    c2: x in ZeroOne()
+    x <= 0.0
+    x in ZeroOne()
 """,
         )
         x = MOI.get(model, MOI.VariableIndex, "x")

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -236,11 +236,11 @@ function solve_with_upperbound(model::MOI.ModelLike, config::TestConfig)
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c1 = MOI.Constraintindex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
+    c1 = MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test c1.value == x.value
-    c2 = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c2 = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     @test c2.value == x.value
     return test_model_solution(
         model,
@@ -273,9 +273,9 @@ function solve_with_lowerbound(model::MOI.ModelLike, config::TestConfig)
 """,
     )
     x = MOI.get(model, MOI.VariableIndex, "x")
-    c1 = MOI.Constraintindex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
+    c1 = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(x.value)
     @test c1.value == x.value
-    c2 = MOI.Constraintindex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
+    c2 = MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value)
     @test c2.value == x.value
     return test_model_solution(
         model,

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -99,7 +99,6 @@ function nametest(model::MOI.ModelLike)
         @test MOI.get(model, MOI.VariableName(), v[1]) == ""
         x, cx = MOI.add_constrained_variable(model, MOI.GreaterThan(0.0))
         @test MOI.get(model, MOI.VariableName(), x) == ""
-        @test MOI.get(model, MOI.ConstraintName(), cx) == ""
         y, cy = MOI.add_constrained_variables(model, MOI.Nonpositives(4))
         for yi in y
             @test MOI.get(model, MOI.VariableName(), yi) == ""
@@ -164,15 +163,13 @@ function nametest(model::MOI.ModelLike)
         )
         @test MOI.get(model, MOI.ConstraintName(), c) == ""
         @test MOI.get(model, MOI.ConstraintName(), c2) == ""
-        @test MOI.get(model, MOI.ConstraintName(), cx) == ""
         @test MOI.get(model, MOI.ConstraintName(), cy) == ""
 
         @test MOI.supports(model, MOI.ConstraintName(), typeof(c))
         MOI.set(model, MOI.ConstraintName(), c, "")
         @test MOI.supports(model, MOI.ConstraintName(), typeof(c2))
         MOI.set(model, MOI.ConstraintName(), c2, "") # Shouldn't error with duplicate empty name
-        @test MOI.supports(model, MOI.ConstraintName(), typeof(cx))
-        MOI.set(model, MOI.ConstraintName(), cx, "")
+        @test !MOI.supports(model, MOI.ConstraintName(), typeof(cx))
         @test MOI.supports(model, MOI.ConstraintName(), typeof(cy))
         MOI.set(model, MOI.ConstraintName(), cy, "")
 
@@ -223,30 +220,25 @@ function nametest(model::MOI.ModelLike)
 
         MOI.set(model, MOI.ConstraintName(), [c], ["Con1"])
 
-        MOI.set(model, MOI.ConstraintName(), [c2, cx], ["Con2", "Con2"])
+        MOI.set(model, MOI.ConstraintName(), [c2, cy], ["Con2", "Con2"])
         @test_throws Exception MOI.get(model, MOI.ConstraintIndex, "Con2")
         @test_throws Exception MOI.get(model, typeof(c2), "Con2")
-        @test_throws Exception MOI.get(model, typeof(cx), "Con2")
-
-        MOI.set(model, MOI.ConstraintName(), [cx, cy], ["Con3", "Con3"])
-        @test_throws Exception MOI.get(model, MOI.ConstraintIndex, "Con3")
-        @test_throws Exception MOI.get(model, typeof(cx), "Con3")
-        @test_throws Exception MOI.get(model, typeof(cy), "Con3")
+        @test_throws Exception MOI.get(model, typeof(cy), "Con2")
 
         MOI.set(model, MOI.ConstraintName(), cy, "Con4")
 
-        for (i, ca) in enumerate([c, c2, cx, cy])
+        for (i, ca) in enumerate([c, c2, cy])
             namea = "Con$i"
             @test MOI.get(model, MOI.ConstraintName(), ca) == namea
             @test MOI.get(model, typeof(ca), namea) == ca
             @test MOI.get(model, MOI.ConstraintIndex, namea) == ca
-            for cb in [c, c2, cx, cy]
+            for cb in [c, c2, cy]
                 if ca === cb
                     continue
                 end
                 nameb = MOI.get(model, MOI.ConstraintName(), cb)
-                @test MOI.get(model, typeof(cb), namea) == nothing
-                @test MOI.get(model, typeof(ca), nameb) == nothing
+                @test MOI.get(model, typeof(cb), namea) === nothing
+                @test MOI.get(model, typeof(ca), nameb) === nothing
             end
         end
 
@@ -257,14 +249,8 @@ function nametest(model::MOI.ModelLike)
         @test MOI.get(model, typeof(c), "Con1") === nothing
         @test MOI.get(model, MOI.ConstraintIndex, "Con1") === nothing
 
-        MOI.set(model, MOI.ConstraintName(), cx, "Con2")
-        @test_throws Exception MOI.get(model, MOI.ConstraintIndex, "Con2")
-        @test_throws Exception MOI.get(model, typeof(c2), "Con2")
-        @test_throws Exception MOI.get(model, typeof(cx), "Con2")
-
         MOI.delete(model, x)
         @test MOI.get(model, MOI.VariableIndex, "Varx") === nothing
-        @test MOI.get(model, typeof(cx), "Con3") === nothing
         @test MOI.get(model, MOI.ConstraintIndex, "Con3") === nothing
         @test MOI.get(model, typeof(c2), "Con2") === c2
         @test MOI.get(model, MOI.ConstraintIndex, "Con2") === c2
@@ -295,31 +281,6 @@ function nametest(model::MOI.ModelLike)
             @test_throws ErrorException MOI.get(model, MOI.VariableIndex, "x")
             MOI.delete(model, x)
             @test MOI.get(model, MOI.VariableIndex, "x") == z
-        end
-        @testset "SingleVariable" begin
-            MOI.empty!(model)
-            x = MOI.add_variables(model, 3)
-            c = MOI.add_constraints(
-                model,
-                MOI.SingleVariable.(x),
-                MOI.GreaterThan(0.0),
-            )
-            MOI.set(model, MOI.ConstraintName(), c[1], "x")
-            MOI.set(model, MOI.ConstraintName(), c[2], "x")
-            MOI.set(model, MOI.ConstraintName(), c[3], "z")
-            @test MOI.get(model, MOI.ConstraintIndex, "z") == c[3]
-            @test_throws ErrorException MOI.get(model, MOI.ConstraintIndex, "x")
-            MOI.set(model, MOI.ConstraintName(), c[2], "y")
-            @test MOI.get(model, MOI.ConstraintIndex, "x") == c[1]
-            @test MOI.get(model, MOI.ConstraintIndex, "y") == c[2]
-            MOI.set(model, MOI.ConstraintName(), c[3], "x")
-            @test_throws ErrorException MOI.get(model, MOI.ConstraintIndex, "x")
-            MOI.delete(model, c[1])
-            @test MOI.get(model, MOI.ConstraintIndex, "x") == c[3]
-            MOI.set(model, MOI.ConstraintName(), c[2], "x")
-            @test_throws ErrorException MOI.get(model, MOI.ConstraintIndex, "x")
-            MOI.delete(model, x[3])
-            @test MOI.get(model, MOI.ConstraintIndex, "x") == c[2]
         end
         @testset "ScalarAffineFunction" begin
             MOI.empty!(model)

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -218,8 +218,6 @@ function nametest(model::MOI.ModelLike)
         @test MOI.get(model, MOI.ConstraintIndex, "Con1") == c
         @test MOI.get(model, MOI.ConstraintIndex, "Con2") === nothing
 
-        MOI.set(model, MOI.ConstraintName(), [c], ["Con1"])
-
         MOI.set(model, MOI.ConstraintName(), [c2, cy], ["Con2", "Con2"])
         @test_throws Exception MOI.get(model, MOI.ConstraintIndex, "Con2")
         @test_throws Exception MOI.get(model, typeof(c2), "Con2")
@@ -227,7 +225,7 @@ function nametest(model::MOI.ModelLike)
 
         MOI.set(model, MOI.ConstraintName(), cy, "Con4")
 
-        for (i, ca) in enumerate([c, c2, cy])
+        for (i, ca) in zip([1, 2, 4], [c, c2, cy])
             namea = "Con$i"
             @test MOI.get(model, MOI.ConstraintName(), ca) == namea
             @test MOI.get(model, typeof(ca), namea) == ca

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -49,15 +49,10 @@ function nametest(model::MOI.ModelLike)
             MOI.GreaterThan(0.0),
         )
         c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
-        MOI.set(model, MOI.ConstraintName(), c1, "c1")
-        @test MOI.get(model, MOI.ConstraintIndex, "c1") == c1
-        MOI.set(model, MOI.ConstraintName(), c1, "c2")
-        @test MOI.get(model, MOI.ConstraintIndex, "c1") === nothing
-        @test MOI.get(model, MOI.ConstraintIndex, "c2") == c1
-        MOI.set(model, MOI.ConstraintName(), c2, "c1")
-        @test MOI.get(model, MOI.ConstraintIndex, "c1") == c2
-        MOI.set(model, MOI.ConstraintName(), c1, "c1")
-        @test_throws ErrorException MOI.get(model, MOI.ConstraintIndex, "c1")
+        @test_throws(
+            MOI.SingleVariableConstraintNameError(),
+            MOI.set(model, MOI.ConstraintName(), c1, "c1"),
+        )
     end
 
     @testset "Affine constraints" begin
@@ -795,7 +790,6 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike; copy_names = false)
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test csv.value == w.value
-    MOI.set(src, MOI.ConstraintName(), csv, "csv")
     cvv = MOI.add_constraint(src, MOI.VectorOfVariables(v), MOI.Nonnegatives(3))
     MOI.set(src, MOI.ConstraintName(), cvv, "cvv")
     csa = MOI.add_constraint(
@@ -909,8 +903,6 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike; copy_names = false)
     @test (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) in loc
     @test (MOI.VectorAffineFunction{Float64}, MOI.Zeros) in loc
 
-    @test !MOI.supports(dest, MOI.ConstraintName(), typeof(csv)) ||
-          MOI.get(dest, MOI.ConstraintName(), dict[csv]) == dest_name("csv")
     @test MOI.get(dest, MOI.ConstraintFunction(), dict[csv]) ==
           MOI.SingleVariable(dict[w])
     @test MOI.get(dest, MOI.ConstraintSet(), dict[csv]) == MOI.EqualTo(2.0)

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -169,7 +169,6 @@ function nametest(model::MOI.ModelLike)
         MOI.set(model, MOI.ConstraintName(), c, "")
         @test MOI.supports(model, MOI.ConstraintName(), typeof(c2))
         MOI.set(model, MOI.ConstraintName(), c2, "") # Shouldn't error with duplicate empty name
-        @test !MOI.supports(model, MOI.ConstraintName(), typeof(cx))
         @test MOI.supports(model, MOI.ConstraintName(), typeof(cy))
         MOI.set(model, MOI.ConstraintName(), cy, "")
 

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -151,7 +151,7 @@ function pass_attributes(
 ) where {F,S}
     # Copy constraint attributes
     attrs = MOI.get(src, MOI.ListOfConstraintAttributesSet{F,S}())
-    if !copy_names
+    if !copy_names || F == MOI.SingleVariable
         attrs = filter(attr -> !(attr isa MOI.ConstraintName), attrs)
     end
     # If `attrs` is empty, we can spare the computation of `cis_dest`

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -897,9 +897,22 @@ function Base.isone(
 end
 
 """
-    test_models_equal(model1::ModelLike, model2::ModelLike, variablenames::Vector{String}, constraintnames::Vector{String})
+    test_models_equal(
+        model1::ModelLike,
+        model2::ModelLike,
+        variablenames::Vector{String},
+        constraintnames::Vector{String},
+        single_variable_constraints::Vector{Tuple{String,<:MOI.AbstractScalarSet}}
+    )
 
-Test that `model1` and `model2` are identical using `variablenames` as as keys for the variable names and `constraintnames` as keys for the constraint names. Uses `Base.Test` macros.
+Test that `model1` and `model2` are identical using `variablenames` as as keys
+for the variable names and `constraintnames` as keys for the constraint names.
+
+In addition, it checks that there is a SingleVariable-in-Set constraint for each
+`(name, set)` tuple in `single_variable_constraints`, where `name` is the name
+of the corresponding variable.
+
+Uses `Base.Test` macros.
 """
 function test_models_equal(
     model1::MOI.ModelLike,
@@ -910,11 +923,13 @@ function test_models_equal(
 )
     for (x_name, set) in single_variable_constraints
         x1 = MOI.get(model1, MOI.VariableIndex, x_name)
-        ci1 = MOI.ConstraintIndex{MOI.SingleVariable,set}(x1.value)
+        ci1 = MOI.ConstraintIndex{MOI.SingleVariable,typeof(set)}(x1.value)
         @test MOI.is_valid(model1, ci1)
+        @test MOI.get(model1, MOI.ConstraintSet(), ci1) == set
         x2 = MOI.get(model2, MOI.VariableIndex, x_name)
-        ci2 = MOI.ConstraintIndex{MOI.SingleVariable,set}(x2.value)
+        ci2 = MOI.ConstraintIndex{MOI.SingleVariable,typeof(set)}(x2.value)
         @test MOI.is_valid(model2, ci2)
+        @test MOI.get(model2, MOI.ConstraintSet(), ci2) == set
     end
     # TODO: give test-friendly feedback instead of errors?
     test_variablenames_equal(model1, variablenames)
@@ -953,6 +968,7 @@ function test_models_equal(
             @test value1 == value2
         end
     end
+    return
 end
 
 _keep_all(keep::Function, v::MOI.VariableIndex) = keep(v)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -387,6 +387,24 @@ function MOI.set(
         throw_mock_unsupported_names(attr)
     end
 end
+
+function MOI.supports(
+    ::MockOptimizer,
+    ::MOI.ConstraintName,
+    ::Type{MOI.ConstraintIndex{MOI.ConstraintIndex,<:MOI.AbstractSet}},
+)
+    return throw(MOI.SingleVariableConstraintNameError())
+end
+
+function MOI.set(
+    ::MockOptimizer,
+    ::MOI.ConstraintName,
+    ::MOI.ConstraintIndex{MOI.ConstraintIndex,<:MOI.AbstractSet},
+    ::String,
+)
+    return throw(MOI.SingleVariableConstraintNameError())
+end
+
 function MOI.get(b::MockOptimizer, IdxT::Type{<:MOI.Index}, name::String)
     index = MOI.get(b.inner_model, IdxT, name)
     if index === nothing

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -388,23 +388,6 @@ function MOI.set(
     end
 end
 
-function MOI.supports(
-    ::MockOptimizer,
-    ::MOI.ConstraintName,
-    ::Type{MOI.ConstraintIndex{MOI.ConstraintIndex,<:MOI.AbstractSet}},
-)
-    return throw(MOI.SingleVariableConstraintNameError())
-end
-
-function MOI.set(
-    ::MockOptimizer,
-    ::MOI.ConstraintName,
-    ::MOI.ConstraintIndex{MOI.ConstraintIndex,<:MOI.AbstractSet},
-    ::String,
-)
-    return throw(MOI.SingleVariableConstraintNameError())
-end
-
 function MOI.get(b::MockOptimizer, IdxT::Type{<:MOI.Index}, name::String)
     index = MOI.get(b.inner_model, IdxT, name)
     if index === nothing

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -250,10 +250,11 @@ function MOI.get(
 end
 
 MOI.supports(model::AbstractModel, ::MOI.ConstraintName, ::Type{<:CI}) = true
+
 function MOI.supports(
     ::AbstractModel,
     ::MOI.ConstraintName,
-    ::Type{MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
+    ::Type{<:MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
 )
     return false
 end

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -250,6 +250,14 @@ function MOI.get(
 end
 
 MOI.supports(model::AbstractModel, ::MOI.ConstraintName, ::Type{<:CI}) = true
+function MOI.supports(
+    ::AbstractModel,
+    ::MOI.ConstraintName,
+    ::Type{MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
+)
+    return false
+end
+
 function MOI.set(
     model::AbstractModel,
     ::MOI.ConstraintName,
@@ -259,6 +267,15 @@ function MOI.set(
     model.con_to_name[ci] = name
     model.name_to_con = nothing # Invalidate the name map.
     return
+end
+
+function MOI.set(
+    ::AbstractModel,
+    attr::MOI.ConstraintName,
+    ci::MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet},
+    ::String,
+)
+    return throw(MOI.SingleVariableConstraintNameError())
 end
 
 function MOI.get(model::AbstractModel, ::MOI.ConstraintName, ci::CI)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -251,14 +251,6 @@ end
 
 MOI.supports(model::AbstractModel, ::MOI.ConstraintName, ::Type{<:CI}) = true
 
-function MOI.supports(
-    ::AbstractModel,
-    ::MOI.ConstraintName,
-    ::Type{<:MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
-)
-    return false
-end
-
 function MOI.set(
     model::AbstractModel,
     ::MOI.ConstraintName,
@@ -270,10 +262,18 @@ function MOI.set(
     return
 end
 
+function MOI.supports(
+    ::AbstractModel,
+    ::MOI.ConstraintName,
+    ::Type{<:MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
+)
+    return throw(MOI.SingleVariableConstraintNameError())
+end
+
 function MOI.set(
     ::AbstractModel,
-    attr::MOI.ConstraintName,
-    ci::MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet},
+    ::MOI.ConstraintName,
+    ::MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet},
     ::String,
 )
     return throw(MOI.SingleVariableConstraintNameError())

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -494,6 +494,24 @@ function MOI.set(
     end
     return
 end
+
+function MOI.supports(
+    ::UniversalFallback,
+    ::MOI.ConstraintName,
+    ::Type{MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
+)
+    return false
+end
+
+function MOI.set(
+    ::UniversalFallback,
+    ::MOI.ConstraintName,
+    ::CI{MOI.SingleVariable,<:MOI.AbstractScalarSet},
+    ::String,
+)
+    return throw(MOI.SingleVariableConstraintNameError())
+end
+
 function MOI.get(
     uf::UniversalFallback,
     attr::MOI.ConstraintName,

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -500,7 +500,7 @@ function MOI.supports(
     ::MOI.ConstraintName,
     ::Type{<:MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
 )
-    return false
+    return throw(MOI.SingleVariableConstraintNameError())
 end
 
 function MOI.set(

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -498,7 +498,7 @@ end
 function MOI.supports(
     ::UniversalFallback,
     ::MOI.ConstraintName,
-    ::Type{MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
+    ::Type{<:MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet}},
 )
     return false
 end
@@ -506,7 +506,7 @@ end
 function MOI.set(
     ::UniversalFallback,
     ::MOI.ConstraintName,
-    ::CI{MOI.SingleVariable,<:MOI.AbstractScalarSet},
+    ::MOI.ConstraintIndex{MOI.SingleVariable,<:MOI.AbstractScalarSet},
     ::String,
 )
     return throw(MOI.SingleVariableConstraintNameError())

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -217,6 +217,14 @@ function supports(
     return false
 end
 
+function supports(
+    ::ModelLike,
+    ::ConstraintName,
+    ::Type{ConstraintIndex{SingleVariable,S}},
+) where {S}
+    return throw(SingleVariableConstraintNameError())
+end
+
 """
     get(optimizer::AbstractOptimizer, attr::AbstractOptimizerAttribute)
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1132,10 +1132,17 @@ struct ListOfConstraintAttributesSet{F,S} <: AbstractModelAttribute end
 """
     ConstraintName()
 
-A constraint attribute for a string identifying the constraint. It is *valid*
-for constraints variables to have the same name; however, constraints with
-duplicate names cannot be looked up using [`get`](@ref) regardless of if they
-have the same `F`-in-`S` type. It has a default value of `""` if not set.
+A constraint attribute for a string identifying the constraint.
+
+It is *valid* for constraints variables to have the same name; however,
+constraints with duplicate names cannot be looked up using [`get`](@ref),
+regardless of whether they have the same `F`-in-`S` type.
+
+`ConstraintName` has a default value of `""` if not set.
+
+## Notes
+
+You should _not_ implement `ConstraintName` for `SingleVariable` constraints.
 """
 struct ConstraintName <: AbstractConstraintAttribute end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1147,6 +1147,19 @@ You should _not_ implement `ConstraintName` for `SingleVariable` constraints.
 struct ConstraintName <: AbstractConstraintAttribute end
 
 """
+    SingleVariableConstraintNameError()
+
+An error to be thrown when the user tries to set `ConstraintName` on a
+`SingleVariable` constraint.
+"""
+function SingleVariableConstraintNameError()
+    return UnsupportedAttribute(
+        MOI.ConstraintName(),
+        "ConstraintNames are not supported for SingleVariable constraints",
+    )
+end
+
+"""
     ConstraintPrimalStart()
 
 A constraint attribute for the initial assignment to some constraint's primal value(s) that the optimizer may use to warm-start the solve. May be a number or `nothing` (unset).

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1154,7 +1154,7 @@ An error to be thrown when the user tries to set `ConstraintName` on a
 """
 function SingleVariableConstraintNameError()
     return UnsupportedAttribute(
-        MOI.ConstraintName(),
+        ConstraintName(),
         "ConstraintNames are not supported for SingleVariable constraints",
     )
 end

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -185,7 +185,12 @@ list of attributes set obtained by `ListOf...AttributesSet`.
 """
 function supports end
 supports(::ModelLike, ::AbstractSubmittable) = false
-function supports(
+
+function supports(model::ModelLike, attr::AnyAttribute, args...)
+    return supports_fallback(model, attr, args...)
+end
+
+function supports_fallback(
     ::ModelLike,
     attr::Union{AbstractModelAttribute,AbstractOptimizerAttribute},
 )
@@ -200,7 +205,8 @@ function supports(
     end
     return false
 end
-function supports(
+
+function supports_fallback(
     ::ModelLike,
     attr::Union{AbstractVariableAttribute,AbstractConstraintAttribute},
     ::Type{<:Index},
@@ -1159,7 +1165,7 @@ function SingleVariableConstraintNameError()
     )
 end
 
-function supports(
+function supports_fallback(
     ::ModelLike,
     ::ConstraintName,
     ::Type{ConstraintIndex{SingleVariable,S}},

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -217,14 +217,6 @@ function supports(
     return false
 end
 
-function supports(
-    ::ModelLike,
-    ::ConstraintName,
-    ::Type{ConstraintIndex{SingleVariable,S}},
-) where {S}
-    return throw(SingleVariableConstraintNameError())
-end
-
 """
     get(optimizer::AbstractOptimizer, attr::AbstractOptimizerAttribute)
 
@@ -1165,6 +1157,14 @@ function SingleVariableConstraintNameError()
         ConstraintName(),
         "`ConstraintName`s are not supported for `SingleVariable` constraints.",
     )
+end
+
+function supports(
+    ::ModelLike,
+    ::ConstraintName,
+    ::Type{ConstraintIndex{SingleVariable,S}},
+) where {S}
+    return throw(SingleVariableConstraintNameError())
 end
 
 """

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1155,7 +1155,7 @@ An error to be thrown when the user tries to set `ConstraintName` on a
 function SingleVariableConstraintNameError()
     return UnsupportedAttribute(
         ConstraintName(),
-        "ConstraintNames are not supported for SingleVariable constraints",
+        "`ConstraintName`s are not supported for `SingleVariable` constraints.",
     )
 end
 

--- a/test/Bridges/Constraint/indicator_sos.jl
+++ b/test/Bridges/Constraint/indicator_sos.jl
@@ -255,7 +255,7 @@ end
         model,
         var_names,
         ["sos1", "ineq"],
-        [("w", MOI.LessThan{Float64}), ("z", MOI.ZeroOne)],
+        [("w", MOI.LessThan{Float64}(0.0)), ("z", MOI.ZeroOne())],
     )
 
     test_delete_bridge(
@@ -284,7 +284,7 @@ end
         model,
         ["z", "x"],
         String[],
-        [("z", MOI.ZeroOne)],
+        [("z", MOI.ZeroOne())],
     )
 end
 

--- a/test/Bridges/Constraint/indicator_sos.jl
+++ b/test/Bridges/Constraint/indicator_sos.jl
@@ -194,7 +194,6 @@ end
     )
     (z, bin_cons) = MOI.add_constrained_variable(bridged_mock, MOI.ZeroOne())
     MOI.set(bridged_mock, MOI.VariableName(), z, "z")
-    MOI.set(mock, MOI.ConstraintName(), bin_cons, "bin_cons")
     x = MOI.add_variable(bridged_mock)
     MOI.set(bridged_mock, MOI.VariableName(), x, "x")
     var_names = ["z", "x", "w"]
@@ -225,7 +224,6 @@ end
         MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.LessThan{Float64}}(),
     )
     @test length(single_less_cons) == 1
-    MOI.set(mock, MOI.ConstraintName(), single_less_cons[1], "wless")
 
     inequality_list = MOI.get(
         mock,
@@ -252,7 +250,13 @@ end
     """
     model = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model, s)
-    MOIU.test_models_equal(mock, model, var_names, ["sos1", "ineq"])
+    MOIU.test_models_equal(
+        mock,
+        model,
+        var_names,
+        ["sos1", "ineq"],
+        [("w", MOI.LessThan{Float64}), ("z", MOI.ZeroOne)],
+    )
 
     test_delete_bridge(
         bridged_mock,
@@ -275,7 +279,13 @@ end
     maxobjective: z
     """
     MOIU.loadfromstring!(model, sbridged)
-    MOIU.test_models_equal(bridged_mock, model, ["z", "x"], String[])
+    MOIU.test_models_equal(
+        bridged_mock,
+        model,
+        ["z", "x"],
+        String[],
+        [("z", MOI.ZeroOne)],
+    )
 end
 
 @testset "Getting primal attributes" begin

--- a/test/Bridges/Constraint/indicator_sos.jl
+++ b/test/Bridges/Constraint/indicator_sos.jl
@@ -245,9 +245,9 @@ end
     s = """
     variables: z, x, w
     sos1: [w, z] in MathOptInterface.SOS1([0.4, 0.6])
-    wless: w <= 0.0
+    w <= 0.0
     ineq: x + w <= 8.0
-    bin_cons: z in MathOptInterface.ZeroOne()
+    z in MathOptInterface.ZeroOne()
     maxobjective: z
     """
     model = MOIU.Model{Float64}()
@@ -256,7 +256,7 @@ end
         mock,
         model,
         var_names,
-        ["sos1", "wless", "ineq", "bin_cons"],
+        ["sos1", "ineq"],
     )
 
     test_delete_bridge(
@@ -276,11 +276,11 @@ end
     model = MOIU.Model{Float64}()
     sbridged = """
     variables: x, z
-    bin_cons: z in MathOptInterface.ZeroOne()
+    z in MathOptInterface.ZeroOne()
     maxobjective: z
     """
     MOIU.loadfromstring!(model, sbridged)
-    MOIU.test_models_equal(bridged_mock, model, ["z", "x"], ["bin_cons"])
+    MOIU.test_models_equal(bridged_mock, model, ["z", "x"], String[])
 end
 
 @testset "Getting primal attributes" begin

--- a/test/Bridges/Constraint/indicator_sos.jl
+++ b/test/Bridges/Constraint/indicator_sos.jl
@@ -252,12 +252,7 @@ end
     """
     model = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model, s)
-    MOIU.test_models_equal(
-        mock,
-        model,
-        var_names,
-        ["sos1", "ineq"],
-    )
+    MOIU.test_models_equal(mock, model, var_names, ["sos1", "ineq"])
 
     test_delete_bridge(
         bridged_mock,

--- a/test/Bridges/Constraint/semi_to_binary.jl
+++ b/test/Bridges/Constraint/semi_to_binary.jl
@@ -152,17 +152,17 @@ config = MOIT.TestConfig()
 
     s = """
     variables: x, y
-    cy: y == 4.0
-    cx: x in Semiinteger(2.0, 3.0)
+    y == 4.0
+    x in Semiinteger(2.0, 3.0)
     minobjective: x
     """
     model = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model, s)
     sb = """
     variables: x, y, z
-    cy: y == 4.0
-    bin: z in ZeroOne()
-    int: x in Integer()
+    y == 4.0
+    z in ZeroOne()
+    x in Integer()
     clo: x + -2.0z >= 0.0
     cup: x + -3.0z <= 0.0
     minobjective: x

--- a/test/Bridges/Constraint/semi_to_binary.jl
+++ b/test/Bridges/Constraint/semi_to_binary.jl
@@ -173,7 +173,13 @@ config = MOIT.TestConfig()
     MOI.empty!(bridged_mock)
     @test MOI.is_empty(bridged_mock)
     MOIU.loadfromstring!(bridged_mock, s)
-    MOIU.test_models_equal(bridged_mock, model, ["x", "y"], ["cy", "cx"])
+    MOIU.test_models_equal(
+        bridged_mock,
+        model,
+        ["x", "y"],
+        String[],
+        [("x", MOI.Semiinteger{Float64}), ("y", MOI.EqualTo{Float64})],
+    )
 
     # setting names on mock
     ci = first(
@@ -182,7 +188,6 @@ config = MOIT.TestConfig()
             MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.ZeroOne}(),
         ),
     )
-    MOI.set(mock, MOI.ConstraintName(), ci, "bin")
     z = MOI.VariableIndex(ci.value)
     MOI.set(mock, MOI.VariableName(), z, "z")
     ci = first(
@@ -191,7 +196,6 @@ config = MOIT.TestConfig()
             MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.Integer}(),
         ),
     )
-    MOI.set(mock, MOI.ConstraintName(), ci, "int")
     ci = first(
         MOI.get(
             mock,
@@ -217,6 +221,7 @@ config = MOIT.TestConfig()
         mock,
         modelb,
         ["x", "y", "z"],
-        ["cy", "bin", "int", "clo", "cup"],
+        ["clo", "cup"],
+        [("x", MOI.Integer), ("y", MOI.EqualTo{Float64}), ("z", MOI.ZeroOne)],
     )
 end

--- a/test/Bridges/Constraint/semi_to_binary.jl
+++ b/test/Bridges/Constraint/semi_to_binary.jl
@@ -178,7 +178,10 @@ config = MOIT.TestConfig()
         model,
         ["x", "y"],
         String[],
-        [("x", MOI.Semiinteger{Float64}), ("y", MOI.EqualTo{Float64})],
+        [
+            ("x", MOI.Semiinteger{Float64}(2.0, 3.0)),
+            ("y", MOI.EqualTo{Float64}(4.0)),
+        ],
     )
 
     # setting names on mock
@@ -222,6 +225,10 @@ config = MOIT.TestConfig()
         modelb,
         ["x", "y", "z"],
         ["clo", "cup"],
-        [("x", MOI.Integer), ("y", MOI.EqualTo{Float64}), ("z", MOI.ZeroOne)],
+        [
+            ("x", MOI.Integer()),
+            ("y", MOI.EqualTo{Float64}(4.0)),
+            ("z", MOI.ZeroOne()),
+        ],
     )
 end

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -114,7 +114,7 @@ config = MOIT.TestConfig()
         model,
         ["x", "y"],
         String[],
-        [("y", MOI.EqualTo{Float64}), ("x", MOI.ZeroOne)],
+        [("y", MOI.EqualTo{Float64}(1.0)), ("x", MOI.ZeroOne())],
     )
     MOIU.test_models_equal(
         mock,
@@ -122,9 +122,9 @@ config = MOIT.TestConfig()
         ["x", "y"],
         String[],
         [
-            ("y", MOI.EqualTo{Float64}),
-            ("x", MOI.Integer),
-            ("x", MOI.Interval{Float64}),
+            ("y", MOI.EqualTo{Float64}(4.0)),
+            ("x", MOI.Integer()),
+            ("x", MOI.Interval{Float64}(0.0, 1.0)),
         ],
     )
 end

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -110,25 +110,5 @@ config = MOIT.TestConfig()
     @test MOI.is_empty(bridged_mock)
     MOIU.loadfromstring!(bridged_mock, s)
     MOIU.test_models_equal(bridged_mock, model, ["x", "y"], ["cy", "cx"])
-
-    # setting names on mock
-    ci = first(
-        MOI.get(
-            mock,
-            MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.Integer}(),
-        ),
-    )
-    MOI.set(mock, MOI.ConstraintName(), ci, "intg")
-    ci = first(
-        MOI.get(
-            mock,
-            MOI.ListOfConstraintIndices{
-                MOI.SingleVariable,
-                MOI.Interval{Float64},
-            }(),
-        ),
-    )
-    MOI.set(mock, MOI.ConstraintName(), ci, "intv")
-
-    MOIU.test_models_equal(mock, modelb, ["x", "y"], ["cy", "intg", "intv"])
+    MOIU.test_models_equal(mock, modelb, ["x", "y"], ["cy"])
 end

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -109,6 +109,22 @@ config = MOIT.TestConfig()
     MOI.empty!(bridged_mock)
     @test MOI.is_empty(bridged_mock)
     MOIU.loadfromstring!(bridged_mock, s)
-    MOIU.test_models_equal(bridged_mock, model, ["x", "y"], ["cy", "cx"])
-    MOIU.test_models_equal(mock, modelb, ["x", "y"], ["cy"])
+    MOIU.test_models_equal(
+        bridged_mock,
+        model,
+        ["x", "y"],
+        String[],
+        [("y", MOI.EqualTo{Float64}), ("x", MOI.ZeroOne)],
+    )
+    MOIU.test_models_equal(
+        mock,
+        modelb,
+        ["x", "y"],
+        String[],
+        [
+            ("y", MOI.EqualTo{Float64}),
+            ("x", MOI.Integer),
+            ("x", MOI.Interval{Float64}),
+        ],
+    )
 end

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -90,17 +90,17 @@ config = MOIT.TestConfig()
 
     s = """
     variables: x, y
-    cy: y == 1.0
-    cx: x in ZeroOne()
+    y == 1.0
+    x in ZeroOne()
     minobjective: x
     """
     model = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model, s)
     sb = """
     variables: x, y
-    cy: y == 1.0
-    intg: x in Integer()
-    intv: x in Interval(0.0,1.0)
+    y == 1.0
+    x in Integer()
+    x in Interval(0.0,1.0)
     minobjective: x
     """
     modelb = MOIU.Model{Float64}()

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -122,7 +122,7 @@ config = MOIT.TestConfig()
         ["x", "y"],
         String[],
         [
-            ("y", MOI.EqualTo{Float64}(4.0)),
+            ("y", MOI.EqualTo{Float64}(1.0)),
             ("x", MOI.Integer()),
             ("x", MOI.Interval{Float64}(0.0, 1.0)),
         ],

--- a/test/Bridges/Objective/slack.jl
+++ b/test/Bridges/Objective/slack.jl
@@ -86,7 +86,10 @@ end
             model,
             [var_names; "s"],
             ["quad"],
-            [("x", MOI.GreaterThan{Float64}), ("y", MOI.GreaterThan{Float64})],
+            [
+                ("x", MOI.GreaterThan{Float64}(1.0)),
+                ("y", MOI.GreaterThan{Float64}(2.0)),
+            ],
         )
     end
 
@@ -105,7 +108,10 @@ end
             model,
             var_names,
             String[],
-            [("x", MOI.GreaterThan{Float64}), ("y", MOI.GreaterThan{Float64})],
+            [
+                ("x", MOI.GreaterThan{Float64}(1.0)),
+                ("y", MOI.GreaterThan{Float64}(2.0)),
+            ],
         )
     end
 
@@ -159,7 +165,10 @@ end
             model,
             [var_names; "s"],
             ["quad"],
-            [("x", MOI.GreaterThan{Float64}), ("y", MOI.GreaterThan{Float64})],
+            [
+                ("x", MOI.GreaterThan{Float64}(1.0)),
+                ("y", MOI.GreaterThan{Float64}(2.0)),
+            ],
         )
     end
 
@@ -177,7 +186,10 @@ end
             model,
             var_names,
             String[],
-            [("x", MOI.GreaterThan{Float64}), ("y", MOI.GreaterThan{Float64})],
+            [
+                ("x", MOI.GreaterThan{Float64}(1.0)),
+                ("y", MOI.GreaterThan{Float64}(2.0)),
+            ],
         )
     end
 

--- a/test/Bridges/Objective/slack.jl
+++ b/test/Bridges/Objective/slack.jl
@@ -56,16 +56,6 @@ end
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
     ]
 
-    con_names = ["cx", "cy"]
-    cxcy = MOI.get(
-        bridged_mock,
-        MOI.ListOfConstraintIndices{
-            MOI.SingleVariable,
-            MOI.GreaterThan{Float64},
-        }(),
-    )
-    MOI.set(bridged_mock, MOI.ConstraintName(), cxcy, con_names)
-
     var_names = ["x", "y"]
     xy = MOI.get(bridged_mock, MOI.ListOfVariableIndices())
     MOI.set(bridged_mock, MOI.VariableName(), xy, var_names)
@@ -84,8 +74,8 @@ end
 
         s = """
         variables: x, y, s
-        cx: x >= 1.0
-        cy: y >= 2.0
+        x >= 1.0
+        y >= 2.0
         quad: 1.0 * x * x + 1.0 * x * y + 1.0 * y * y + -1.0 * s <= 0.0
         minobjective: s
         """
@@ -95,7 +85,8 @@ end
             mock,
             model,
             [var_names; "s"],
-            [con_names; "quad"],
+            ["quad"],
+            [("x", MOI.GreaterThan{Float64}), ("y", MOI.GreaterThan{Float64})],
         )
     end
 
@@ -103,13 +94,19 @@ end
     @testset "Test bridged model" begin
         s = """
         variables: x, y
-        cx: x >= 1.0
-        cy: y >= 2.0
+        x >= 1.0
+        y >= 2.0
         minobjective: 1.0 * x * x + 1.0 * x * y + 1.0 * y * y
         """
         model = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model, s)
-        MOIU.test_models_equal(bridged_mock, model, var_names, con_names)
+        MOIU.test_models_equal(
+            bridged_mock,
+            model,
+            var_names,
+            String[],
+            [("x", MOI.GreaterThan{Float64}), ("y", MOI.GreaterThan{Float64})],
+        )
     end
 
     err = ArgumentError(
@@ -150,8 +147,8 @@ end
 
         s = """
         variables: x, y, s
-        cx: x >= 1.0
-        cy: y >= 2.0
+        x >= 1.0
+        y >= 2.0
         quad: 1.0 * x * x + 1.0 * x * y + 1.0 * y * y + -1.0 * s >= 0.0
         maxobjective: s
         """
@@ -161,20 +158,27 @@ end
             mock,
             model,
             [var_names; "s"],
-            [con_names; "quad"],
+            ["quad"],
+            [("x", MOI.GreaterThan{Float64}), ("y", MOI.GreaterThan{Float64})],
         )
     end
 
     @testset "Test bridged model" begin
         s = """
         variables: x, y
-        cx: x >= 1.0
-        cy: y >= 2.0
+        x >= 1.0
+        y >= 2.0
         maxobjective: 1.0 * x * x + 1.0 * x * y + 1.0 * y * y
         """
         model = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model, s)
-        MOIU.test_models_equal(bridged_mock, model, var_names, con_names)
+        MOIU.test_models_equal(
+            bridged_mock,
+            model,
+            var_names,
+            String[],
+            [("x", MOI.GreaterThan{Float64}), ("y", MOI.GreaterThan{Float64})],
+        )
     end
 
     test_delete_objective(

--- a/test/Bridges/Variable/rsoc_to_psd.jl
+++ b/test/Bridges/Variable/rsoc_to_psd.jl
@@ -153,7 +153,6 @@ end
             }(),
         )
         @test length(off_diag) == 1
-        MOI.set(mock, MOI.ConstraintName(), off_diag[1], "off_diag23")
         diag = MOI.get(
             mock,
             MOI.ListOfConstraintIndices{
@@ -176,7 +175,7 @@ end
         s = """
         variables: Q11, Q12, Q13, Q22, Q23, Q33
         psd: [Q11, Q12, Q22, Q13, Q23, Q33] in MathOptInterface.PositiveSemidefiniteConeTriangle(3)
-        off_diag23: Q23 == 0.0
+        Q23 == 0.0
         diag33: Q22 + -1.0Q33 == 0.0
         c: Q11 + 0.5Q22 <= 2.0
         maxobjective: Q12 + Q13
@@ -187,7 +186,8 @@ end
             mock,
             model,
             var_names,
-            ["psd", "off_diag23", "diag33", "c"],
+            ["psd", "diag33", "c"],
+            [("Q23", MOI.EqualTo{Float64})],
         )
     end
 

--- a/test/Bridges/Variable/rsoc_to_psd.jl
+++ b/test/Bridges/Variable/rsoc_to_psd.jl
@@ -187,7 +187,7 @@ end
             model,
             var_names,
             ["psd", "diag33", "c"],
-            [("Q23", MOI.EqualTo{Float64})],
+            [("Q23", MOI.EqualTo{Float64}(0.0))],
         )
     end
 

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -69,7 +69,7 @@ bridged_mock = MOIB.Variable.Vectorize{Float64}(mock)
             model,
             ["x"],
             ["c"],
-            [("x", MOI.GreaterThan{Float64})],
+            [("x", MOI.GreaterThan{Float64}(1.0))],
         )
     end
 end

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -205,7 +205,6 @@ end
     end
     @testset "Bridged model" begin
         MOI.set(bridged_mock, MOI.VariableName(), y, "y")
-        MOI.set(bridged_mock, MOI.ConstraintName(), yc, "yc")
         s = """
         variables: x, y
         y <= 5.0
@@ -219,7 +218,7 @@ end
             model,
             ["x", "y"],
             ["xc", "ec"],
-            [("y", MOI.LessThan{Float64})]
+            [("y", MOI.LessThan{Float64})],
         )
     end
 

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -218,7 +218,7 @@ end
             model,
             ["x", "y"],
             ["xc", "ec"],
-            [("y", MOI.LessThan{Float64})],
+            [("y", MOI.LessThan{Float64}(5.0))],
         )
     end
 

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -64,7 +64,13 @@ bridged_mock = MOIB.Variable.Vectorize{Float64}(mock)
         """
         model = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model, s)
-        MOIU.test_models_equal(bridged_mock, model, ["x"], ["c"])
+        MOIU.test_models_equal(
+            bridged_mock,
+            model,
+            ["x"],
+            ["c"],
+            [("x", MOI.GreaterThan{Float64})],
+        )
     end
 end
 
@@ -202,7 +208,7 @@ end
         MOI.set(bridged_mock, MOI.ConstraintName(), yc, "yc")
         s = """
         variables: x, y
-        yc: y <= 5.0
+        y <= 5.0
         xc: 2.0x <= 4.0
         ec: [x, 1.0, y] in MathOptInterface.ExponentialCone()
         """
@@ -212,7 +218,8 @@ end
             bridged_mock,
             model,
             ["x", "y"],
-            ["yc", "xc", "ec"],
+            ["xc", "ec"],
+            [("y", MOI.LessThan{Float64})]
         )
     end
 

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -57,15 +57,14 @@ bridged_mock = MOIB.Variable.Vectorize{Float64}(mock)
     end
     @testset "Bridged model" begin
         MOI.set(bridged_mock, MOI.VariableName(), x, "x")
-        MOI.set(bridged_mock, MOI.ConstraintName(), cx, "cx")
         s = """
         variables: x
-        cx: x >= 1.0
+        x >= 1.0
         c: 2.0x >= 5.0
         """
         model = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model, s)
-        MOIU.test_models_equal(bridged_mock, model, ["x"], ["cx", "c"])
+        MOIU.test_models_equal(bridged_mock, model, ["x"], ["c"])
     end
 end
 

--- a/test/Bridges/Variable/zeros.jl
+++ b/test/Bridges/Variable/zeros.jl
@@ -45,7 +45,7 @@ end
         model,
         ["x", "y", "z"],
         ["cyz"],
-        [("x", MOI.GreaterThan{Float64})],
+        [("x", MOI.GreaterThan{Float64}(0.0))],
     )
 end
 
@@ -160,7 +160,7 @@ end
         model,
         ["x"],
         ["con1", "con2"],
-        [("x", MOI.GreaterThan{Float64})],
+        [("x", MOI.GreaterThan{Float64}(0.0))],
     )
 end
 

--- a/test/Bridges/Variable/zeros.jl
+++ b/test/Bridges/Variable/zeros.jl
@@ -15,7 +15,6 @@ bridged_mock = MOIB.Variable.Zeros{Float64}(mock)
 
 x, cx = MOI.add_constrained_variable(bridged_mock, MOI.GreaterThan(0.0))
 MOI.set(bridged_mock, MOI.VariableName(), x, "x")
-MOI.set(bridged_mock, MOI.ConstraintName(), cx, "cx")
 yz, cyz = MOI.add_constrained_variables(bridged_mock, MOI.Zeros(2))
 MOI.set(bridged_mock, MOI.VariableName(), yz, ["y", "z"])
 MOI.set(bridged_mock, MOI.ConstraintName(), cyz, "cyz")
@@ -35,13 +34,13 @@ end
 @testset "Test bridged model" begin
     s = """
     variables: x, y, z
-    cx: x >= 0.0
+    x >= 0.0
     cyz: [y, z] in MathOptInterface.Zeros(2)
     minobjective: x
     """
     model = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model, s)
-    MOIU.test_models_equal(bridged_mock, model, ["x", "y", "z"], ["cx", "cyz"])
+    MOIU.test_models_equal(bridged_mock, model, ["x", "y", "z"], ["cyz"])
 end
 
 c1, c2 = MOI.add_constraints(
@@ -143,14 +142,20 @@ end
 @testset "Test mock model" begin
     s = """
     variables: x
-    cx: x >= 0.0
+    x >= 0.0
     con1: x + 0.0 == 0.0
     con2: x + 0.0 >= 1.0
     minobjective: x
     """
     model = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model, s)
-    MOIU.test_models_equal(mock, model, ["x"], ["cx", "con1", "con2"])
+    MOIU.test_models_equal(
+        mock,
+        model,
+        ["x"],
+        ["con1", "con2"],
+        [("x", MOI.GreaterThan{Float64})],
+    )
 end
 
 @testset "Delete" begin

--- a/test/Bridges/Variable/zeros.jl
+++ b/test/Bridges/Variable/zeros.jl
@@ -40,7 +40,13 @@ end
     """
     model = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model, s)
-    MOIU.test_models_equal(bridged_mock, model, ["x", "y", "z"], ["cyz"])
+    MOIU.test_models_equal(
+        bridged_mock,
+        model,
+        ["x", "y", "z"],
+        ["cyz"],
+        [("x", MOI.GreaterThan{Float64})],
+    )
 end
 
 c1, c2 = MOI.add_constraints(

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -206,6 +206,7 @@ end
     c2 = MOI.get(bridged_mock, MOI.ConstraintIndex, "c")
     @test c1 == c2
     @test MOI.is_valid(
+        bridged_mock,
         MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value),
     )
 end

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -183,7 +183,7 @@ end
     variables: x
     maxobjective: 3.0x
     c: 2.0x in Interval(1.0, 4.0)
-    d: x in LessThan(1.5)
+    x in LessThan(1.5)
 """,
     )
     x = MOI.get(bridged_mock, MOI.VariableIndex, "x")
@@ -205,14 +205,9 @@ end
     )
     c2 = MOI.get(bridged_mock, MOI.ConstraintIndex, "c")
     @test c1 == c2
-    d1 = MOI.get(
-        bridged_mock,
-        MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}},
-        "d",
+    @test MOI.is_valid(
+        MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}}(x.value),
     )
-    @test isa(d1, MOI.ConstraintIndex{MOI.SingleVariable,MOI.LessThan{Float64}})
-    d2 = MOI.get(bridged_mock, MOI.ConstraintIndex, "d")
-    @test d1 == d2
 end
 
 MOI.empty!(bridged_mock)

--- a/test/FileFormats/CBF/CBF.jl
+++ b/test/FileFormats/CBF/CBF.jl
@@ -26,7 +26,7 @@ function _set_var_and_con_names(model::MOI.ModelLike)
     )
         idx += 1
         x = MOI.get(model, MOI.VariableName(), MOI.VariableIndex(i.value))
-        push!(single_variable_constraints, (x, MOI.Integer))
+        push!(single_variable_constraints, (x, MOI.Integer()))
     end
     for S in [
             MOI.Reals,

--- a/test/FileFormats/LP/LP.jl
+++ b/test/FileFormats/LP/LP.jl
@@ -19,16 +19,16 @@ function test_comprehensive_write()
         """
 variables: a, x, y, z
 minobjective: x
-c1: x >= -1.0
-c2: x <= 2.0
-c3: y == 3.0
-c4: z in Interval(4.0, 5.0)
+x >= -1.0
+x <= 2.0
+y == 3.0
+z in Interval(4.0, 5.0)
 c5: 1.1x + 0.0 <= 5.1
 c6: 1.3x + -1.4 >= -0.1
 c7: 1.5a + 1.6 == 0.2
 c8: 1.7a + 1.8 in Interval(0.3, 0.4)
-c9: x in ZeroOne()
-c10: y in Integer()
+x in ZeroOne()
+y in Integer()
 """,
     )
     MOI.write_to_file(model, LP_TEST_FILE)
@@ -205,8 +205,8 @@ function test_free_variables()
         """
 variables: x, y, z
 maxobjective: x
-c1: x in ZeroOne()
-c2: y in Integer()
+x in ZeroOne()
+y in Integer()
 """,
     )
     MOI.write_to_file(model, LP_TEST_FILE)

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -305,7 +305,7 @@ function test_Duplicate_constraint_name()
     c1 = MOI.add_constraint(model, f, MOI.LessThan(1.0))
     c2 = MOI.add_constraint(model, f, MOI.GreaterThan(0.0))
     MOI.set(model, MOI.ConstraintName(), c1, "c")
-s    MOI.set(model, MOI.ConstraintName(), c2, "c")
+    MOI.set(model, MOI.ConstraintName(), c2, "c")
     name_map = Dict(x => "x")
     @test MOF.moi_to_object(c1, model, name_map)["name"] == "c"
     @test MOF.moi_to_object(c2, model, name_map)["name"] == "c"
@@ -852,7 +852,7 @@ function runtests()
                 getfield(@__MODULE__, name)()
             end
         end
-    ends
+    end
     sleep(1.0)  # allow time for unlink to happen
     rm(TEST_MOF_FILE, force = true)
     rm(TEST_MOF_FILE * ".gz", force = true)

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -290,7 +290,8 @@ function test_Blank_constraint_name()
     model = MOF.Model()
     x = MOI.add_variable(model)
     MOI.set(model, MOI.VariableName(), x, "x")
-    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
+    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
+    c = MOI.add_constraint(model, f, MOI.ZeroOne())
     name_map = Dict(x => "x")
     MOI.FileFormats.create_unique_names(model, warn = true)
     @test MOF.moi_to_object(c, model, name_map)["name"] == "c1"
@@ -300,10 +301,11 @@ function test_Duplicate_constraint_name()
     model = MOF.Model()
     x = MOI.add_variable(model)
     MOI.set(model, MOI.VariableName(), x, "x")
-    c1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
-    c2 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
+    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
+    c1 = MOI.add_constraint(model, f, MOI.LessThan(1.0))
+    c2 = MOI.add_constraint(model, f, MOI.GreaterThan(0.0))
     MOI.set(model, MOI.ConstraintName(), c1, "c")
-    MOI.set(model, MOI.ConstraintName(), c2, "c")
+s    MOI.set(model, MOI.ConstraintName(), c2, "c")
     name_map = Dict(x => "x")
     @test MOF.moi_to_object(c1, model, name_map)["name"] == "c"
     @test MOF.moi_to_object(c2, model, name_map)["name"] == "c"
@@ -398,10 +400,10 @@ function test_singlevariable_in_lower()
         """
 variables: x
 minobjective: 1.2x + 0.5
-c1: x >= 1.0
+x >= 1.0
 """,
         ["x"],
-        ["c1"],
+        String[],
     )
 end
 
@@ -410,10 +412,10 @@ function test_singlevariable_in_upper()
         """
 variables: x
 maxobjective: 1.2x + 0.5
-c1: x <= 1.0
+x <= 1.0
 """,
         ["x"],
-        ["c1"],
+        String[],
         suffix = ".gz",
     )
 end
@@ -423,10 +425,10 @@ function test_singlevariable_in_interval()
         """
 variables: x
 minobjective: 1.2x + 0.5
-c1: x in Interval(1.0, 2.0)
+x in Interval(1.0, 2.0)
 """,
         ["x"],
-        ["c1"],
+        String[],
     )
 end
 
@@ -435,10 +437,10 @@ function test_singlevariable_in_equalto()
         """
 variables: x
 minobjective: 1.2x + 0.5
-c1: x == 1.0
+x == 1.0
 """,
         ["x"],
-        ["c1"],
+        String[],
     )
 end
 
@@ -447,10 +449,10 @@ function test_singlevariable_in_zeroone()
         """
 variables: x
 minobjective: 1.2x + 0.5
-c1: x in ZeroOne()
+x in ZeroOne()
 """,
         ["x"],
-        ["c1"],
+        String[],
     )
 end
 
@@ -459,10 +461,10 @@ function test_singlevariable_in_integer()
         """
 variables: x
 minobjective: 1.2x + 0.5
-c1: x in Integer()
+x in Integer()
 """,
         ["x"],
-        ["c1"],
+        String[],
     )
 end
 
@@ -471,10 +473,10 @@ function test_singlevariable_in_Semicontinuous()
         """
 variables: x
 minobjective: 1.2x + 0.5
-c1: x in Semicontinuous(1.0, 2.0)
+x in Semicontinuous(1.0, 2.0)
 """,
         ["x"],
-        ["c1"],
+        String[],
     )
 end
 
@@ -483,10 +485,10 @@ function test_singlevariable_in_Semiinteger()
         """
 variables: x
 minobjective: 1.2x + 0.5
-c1: x in Semiinteger(1.0, 2.0)
+x in Semiinteger(1.0, 2.0)
 """,
         ["x"],
-        ["c1"],
+        String[],
     )
 end
 
@@ -767,10 +769,9 @@ function test_IndicatorSet()
 variables: x, y
 minobjective: x
 c1: [x, y] in IndicatorSet{ACTIVATE_ON_ONE}(GreaterThan(1.0))
-c2: x >= 0.0
 """,
         ["x", "y"],
-        ["c1", "c2"],
+        ["c1"],
     )
 
     return _test_model_equality(
@@ -778,10 +779,9 @@ c2: x >= 0.0
 variables: x, y
 minobjective: x
 c1: [x, y] in IndicatorSet{ACTIVATE_ON_ZERO}(GreaterThan(1.0))
-c2: x >= 0.0
 """,
         ["x", "y"],
-        ["c1", "c2"],
+        ["c1"],
     )
 end
 
@@ -791,10 +791,9 @@ function test_NormOneCone()
 variables: x, y
 minobjective: x
 c1: [x, y] in NormOneCone(2)
-c2: x >= 0.0
 """,
         ["x", "y"],
-        ["c1", "c2"],
+        ["c1"],
     )
 end
 
@@ -804,10 +803,9 @@ function test_NormInfinityCone()
 variables: x, y
 minobjective: x
 c1: [x, y] in NormInfinityCone(2)
-c2: x >= 0.0
 """,
         ["x", "y"],
-        ["c1", "c2"],
+        ["c1"],
     )
 end
 
@@ -817,10 +815,9 @@ function test_RelativeEntropyCone()
 variables: x, y, z
 minobjective: x
 c1: [x, y, z] in RelativeEntropyCone(3)
-c2: x >= 0.0
 """,
         ["x", "y", "z"],
-        ["c1", "c2"],
+        ["c1"],
     )
 end
 
@@ -855,7 +852,7 @@ function runtests()
                 getfield(@__MODULE__, name)()
             end
         end
-    end
+    ends
     sleep(1.0)  # allow time for unlink to happen
     rm(TEST_MOF_FILE, force = true)
     rm(TEST_MOF_FILE * ".gz", force = true)

--- a/test/FileFormats/MOF/nlp.mof.json
+++ b/test/FileFormats/MOF/nlp.mof.json
@@ -203,7 +203,6 @@
       }
     },
     {
-      "name": "c1",
       "function": {
         "type": "SingleVariable",
         "variable": "var_1"
@@ -215,7 +214,6 @@
       }
     },
     {
-      "name": "c2",
       "function": {
         "type": "SingleVariable",
         "variable": "var_2"
@@ -227,7 +225,6 @@
       }
     },
     {
-      "name": "c3",
       "function": {
         "type": "SingleVariable",
         "variable": "var_3"
@@ -239,7 +236,6 @@
       }
     },
     {
-      "name": "c4",
       "function": {
         "type": "SingleVariable",
         "variable": "var_4"

--- a/test/FileFormats/MOF/v0.4.mof.json
+++ b/test/FileFormats/MOF/v0.4.mof.json
@@ -19,11 +19,9 @@
         },
         "set": {"head": "GreaterThan", "lower": 1.0}
     }, {
-        "name": "x ∈ [0, 1]",
         "function": {"head": "SingleVariable", "variable": "x"},
         "set": {"head": "Interval", "lower": 0.0, "upper": 1.0}
     }, {
-        "name": "y ∈ {0, 1}",
         "function": {"head": "SingleVariable", "variable": "y"},
         "set": {"head": "ZeroOne"}
     }]

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -141,7 +141,11 @@ z in ZeroOne()
         model_2,
         ["x", "y", "z"],
         ["con1", "con2", "con3", "con4"],
-        [("y", MOI.Integer), ("y", MOI.Interval{Float64}), ("z", MOI.ZeroOne)],
+        [
+            ("y", MOI.Integer()),
+            ("y", MOI.Interval{Float64}(1.0, 4.0)),
+            ("z", MOI.ZeroOne())
+        ],
     )
 end
 
@@ -163,7 +167,7 @@ x in Integer()
         model_2,
         ["x"],
         ["con1"],
-        [("x", MOI.Integer)],
+        [("x", MOI.Integer())],
     )
 end
 
@@ -432,7 +436,7 @@ end
 function runtests()
     for name in names(@__MODULE__, all = true)
         if startswith("$(name)", "test_")
-            @testset "name" begin
+            @testset "$name" begin
                 getfield(@__MODULE__, name)()
             end
         end

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -144,7 +144,7 @@ z in ZeroOne()
         [
             ("y", MOI.Integer()),
             ("y", MOI.Interval{Float64}(1.0, 4.0)),
-            ("z", MOI.ZeroOne())
+            ("z", MOI.ZeroOne()),
         ],
     )
 end

--- a/test/FileFormats/SDPA/SDPA.jl
+++ b/test/FileFormats/SDPA/SDPA.jl
@@ -26,7 +26,7 @@ function _set_var_and_con_names(model::MOI.ModelLike)
     )
         idx += 1
         x = MOI.get(model, MOI.VariableName(), MOI.VariableIndex(i.value))
-        push!(single_variable_constraints, (x, MOI.Integer))
+        push!(single_variable_constraints, (x, MOI.Integer()))
     end
     for i in Iterators.flatten((
         MOI.get(

--- a/test/FileFormats/SDPA/SDPA.jl
+++ b/test/FileFormats/SDPA/SDPA.jl
@@ -19,11 +19,16 @@ function _set_var_and_con_names(model::MOI.ModelLike)
 
     idx = 0
     constraint_names = String[]
+    single_variable_constraints = Tuple[]
+    for i in MOI.get(
+        model,
+        MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.Integer}(),
+    )
+        idx += 1
+        x = MOI.get(model, MOI.VariableName(), MOI.VariableIndex(i.value))
+        push!(single_variable_constraints, (x, MOI.Integer))
+    end
     for i in Iterators.flatten((
-        MOI.get(
-            model,
-            MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.Integer}(),
-        ),
         MOI.get(
             model,
             MOI.ListOfConstraintIndices{
@@ -45,13 +50,13 @@ function _set_var_and_con_names(model::MOI.ModelLike)
         MOI.set(model, MOI.ConstraintName(), i, con_name_i)
     end
 
-    return (variable_names, constraint_names)
+    return variable_names, constraint_names, single_variable_constraints
 end
 
 function _test_write_then_read(model_string::String)
     model1 = SDPA.Model()
     MOIU.loadfromstring!(model1, model_string)
-    (variable_names, constraint_names) = _set_var_and_con_names(model1)
+    args = _set_var_and_con_names(model1)
 
     MOI.write_to_file(model1, SDPA_TEST_FILE)
     model2 = SDPA.Model()
@@ -64,29 +69,17 @@ function _test_write_then_read(model_string::String)
         MOI.set(model2, attr, MOIU.operate(-, Float64, obj))
     end
 
-    return MOIU.test_models_equal(
-        model1,
-        model2,
-        variable_names,
-        constraint_names,
-    )
+    return MOIU.test_models_equal(model1, model2, args...)
 end
 
 function _test_read(filename::String, model_string::String)
     model1 = MOI.FileFormats.Model(filename = filename)
     MOIU.loadfromstring!(model1, model_string)
-    (variable_names, constraint_names) = _set_var_and_con_names(model1)
-
+    args = _set_var_and_con_names(model1)
     model2 = SDPA.Model()
     MOI.read_from_file(model2, filename)
     _set_var_and_con_names(model2)
-
-    return MOIU.test_models_equal(
-        model1,
-        model2,
-        variable_names,
-        constraint_names,
-    )
+    return MOIU.test_models_equal(model1, model2, args...)
 end
 
 function test_show()
@@ -288,9 +281,9 @@ const _EXAMPLE_MODELS = [
     c1: [1x, 1y, 1z] in PositiveSemidefiniteConeTriangle(2)
     c2: [1z, 1x, 2.1] in PositiveSemidefiniteConeTriangle(2)
     c3: [1x + 1y + 1z + -1, -1x + -1y + -1z + 8] in Nonnegatives(2)
-    c4: x in Integer()
-    c5: y in Integer()
-    c6: z in Integer()
+    x in Integer()
+    y in Integer()
+    z in Integer()
 """,
     ),
 ]

--- a/test/FileFormats/SDPA/SDPA.jl
+++ b/test/FileFormats/SDPA/SDPA.jl
@@ -107,7 +107,7 @@ function test_support()
         model_string = """
         variables: x
         minobjective: 1x
-        c: x in $set
+        x in $set
         """
         model = SDPA.Model()
         @test !MOI.supports_constraint(model, MOI.SingleVariable, typeof(set))

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -96,7 +96,7 @@ end
             model2,
             ["x"],
             String[],
-            [("x", MOI.GreaterThan{Float64})],
+            [("x", MOI.GreaterThan{Float64}(1.0))],
         )
     end
 

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -78,7 +78,7 @@ end
     @testset "one variable" begin
         s = """
         variables: x
-        bound: x >= 1.0
+        x >= 1.0
         """
         model = MOIU.Model{Float64}()
         x = MOI.add_variable(model)
@@ -88,11 +88,10 @@ end
             MOI.SingleVariable(x),
             MOI.GreaterThan(1.0),
         )
-        MOI.set(model, MOI.ConstraintName(), bound, "bound")
 
         model2 = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model2, s)
-        MOIU.test_models_equal(model, model2, ["x"], ["bound"])
+        MOIU.test_models_equal(model, model2, ["x"], String[])
     end
 
     @testset "linear constraints" begin
@@ -250,7 +249,7 @@ end
     @testset "Invalid variable name" begin
         s = """
         variables: x
-        bound: y >= 1.0
+        y >= 1.0
         """
         model = MOIU.Model{Float64}()
         err = ErrorException("Invalid variable name y.")

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -91,7 +91,13 @@ end
 
         model2 = MOIU.Model{Float64}()
         MOIU.loadfromstring!(model2, s)
-        MOIU.test_models_equal(model, model2, ["x"], String[])
+        MOIU.test_models_equal(
+            model,
+            model2,
+            ["x"],
+            String[],
+            [("x", MOI.GreaterThan{Float64})],
+        )
     end
 
     @testset "linear constraints" begin

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -117,6 +117,29 @@ function test_attributes_integration_compute_conflict_2()
     @test_throws ArgumentError MOI.get(model, MOI.ConstraintConflictStatus(), c)
 end
 
+struct _NoConstraintName <: MOI.AbstractOptimizer end
+
+function test_no_constraint_name()
+    model = _NoConstraintName()
+    @test_throws(
+        MOI.SingleVariableConstraintNameError(),
+        MOI.supports(
+            model,
+            MOI.ConstraintName(),
+            MOI.ConstraintIndex{MOI.SingleVariable,MOI.ZeroOne},
+        ),
+    )
+    @test_throws(
+        MOI.SingleVariableConstraintNameError(),
+        MOI.set(
+            model,
+            MOI.ConstraintName(),
+            MOI.ConstraintIndex{MOI.SingleVariable,MOI.ZeroOne}(1),
+            "name",
+        ),
+    )
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if startswith("$name", "test_")


### PR DESCRIPTION
Started work on https://github.com/jump-dev/MathOptInterface.jl/issues/832, but I'm not sure it's worth it. It just adds lots of breakage and a special case for limited upside.

What might be more useful is a utility to manage the lookup rules constraint names for solvers: https://github.com/jump-dev/MathOptInterface.jl/issues/674

Closes #832 