### PR TITLE
Lazily create storage in StructOfConstraints

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -957,7 +957,7 @@ macro model(
             sets = vector_sets
         end
         voc = map(sets) do set
-            return :(VectorOfConstraints{$(_typedfun(funs[i])),$(_typedset(set))})
+            return :(VectorOfConstraints{$(_typed(funs[i])),$(_typed(set))})
         end
         return _struct_of_constraints_type(cname, voc, true)
     end

--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -2,8 +2,12 @@ abstract type StructOfConstraints <: MOI.ModelLike end
 
 function _throw_if_cannot_delete(model::StructOfConstraints, vis, fast_in_vis)
     broadcastcall(model) do constrs
-        return _throw_if_cannot_delete(constrs, vis, fast_in_vis)
+        if constrs !== nothing
+            _throw_if_cannot_delete(constrs, vis, fast_in_vis)
+        end
+        return
     end
+    return
 end
 function _deleted_constraints(
     callback::Function,
@@ -11,24 +15,23 @@ function _deleted_constraints(
     vi,
 )
     broadcastcall(model) do constrs
-        return _deleted_constraints(callback, constrs, vi)
+        if constrs !== nothing
+            _deleted_constraints(callback, constrs, vi)
+        end
+        return
     end
+    return
 end
 
 function MOI.add_constraint(
     model::StructOfConstraints,
-    func::MOI.AbstractFunction,
-    set::MOI.AbstractSet,
-)
-    if MOI.supports_constraint(model, typeof(func), typeof(set))
-        return MOI.add_constraint(
-            constraints(model, typeof(func), typeof(set)),
-            func,
-            set,
-        )
-    else
-        throw(MOI.UnsupportedConstraint{typeof(func),typeof(set)}())
+    func::F,
+    set::S,
+) where {F<:MOI.AbstractFunction,S<:MOI.AbstractSet}
+    if !MOI.supports_constraint(model, F, S)
+        throw(MOI.UnsupportedConstraint{F,S}())
     end
+    return MOI.add_constraint(constraints(model, F, S), func, set)
 end
 
 function constraints(
@@ -49,18 +52,18 @@ function MOI.get(
 end
 
 function MOI.delete(model::StructOfConstraints, ci::MOI.ConstraintIndex)
-    return MOI.delete(constraints(model, ci), ci)
+    MOI.delete(constraints(model, ci), ci)
+    return
 end
 
 function MOI.is_valid(
     model::StructOfConstraints,
     ci::MOI.ConstraintIndex{F,S},
 ) where {F,S}
-    if MOI.supports_constraint(model, F, S)
-        return MOI.is_valid(constraints(model, ci), ci)
-    else
+    if !MOI.supports_constraint(model, F, S)
         return false
     end
+    return MOI.is_valid(constraints(model, ci), ci)
 end
 
 function MOI.modify(
@@ -68,7 +71,8 @@ function MOI.modify(
     ci::MOI.ConstraintIndex,
     change::MOI.AbstractFunctionModification,
 )
-    return MOI.modify(constraints(model, ci), ci, change)
+    MOI.modify(constraints(model, ci), ci, change)
+    return
 end
 
 function MOI.set(
@@ -77,45 +81,55 @@ function MOI.set(
     ci::MOI.ConstraintIndex,
     func_or_set,
 )
-    return MOI.set(constraints(model, ci), attr, ci, func_or_set)
+    MOI.set(constraints(model, ci), attr, ci, func_or_set)
+    return
 end
 
 function MOI.get(
     model::StructOfConstraints,
-    loc::MOI.ListOfConstraintTypesPresent,
-) where {T}
-    return broadcastvcat(model) do v
-        return MOI.get(v, loc)
+    attr::MOI.ListOfConstraintTypesPresent,
+)
+    return broadcastvcat(model) do constrs
+        if constrs === nothing
+            return Tuple{DataType,DataType}[]
+        end
+        return MOI.get(constrs, attr)
     end
 end
 
 function MOI.get(
     model::StructOfConstraints,
-    noc::MOI.NumberOfConstraints{F,S},
+    attr::MOI.NumberOfConstraints{F,S},
 ) where {F,S}
-    if MOI.supports_constraint(model, F, S)
-        return MOI.get(constraints(model, F, S), noc)
-    else
+    if !MOI.supports_constraint(model, F, S)
         return 0
     end
+    return MOI.get(constraints(model, F, S), attr)
 end
 
 function MOI.get(
     model::StructOfConstraints,
-    loc::MOI.ListOfConstraintIndices{F,S},
+    attr::MOI.ListOfConstraintIndices{F,S},
 ) where {F,S}
-    if MOI.supports_constraint(model, F, S)
-        return MOI.get(constraints(model, F, S), loc)
-    else
+    if !MOI.supports_constraint(model, F, S)
         return MOI.ConstraintIndex{F,S}[]
     end
+    return MOI.get(constraints(model, F, S), attr)
 end
 
 function MOI.is_empty(model::StructOfConstraints)
-    return mapreduce_constraints(MOI.is_empty, &, model, true)
+    return mapreduce_constraints(&, model, true) do constrs
+        return constrs === nothing || MOI.is_empty(constrs)
+    end
 end
 function MOI.empty!(model::StructOfConstraints)
-    return broadcastcall(MOI.empty!, model)
+    broadcastcall(model) do constrs
+        if constrs !== nothing
+            MOI.empty!(constrs)
+        end
+        return
+    end
+    return
 end
 
 # Can be used to access constraints of a model
@@ -178,33 +192,13 @@ end
 
 # (MOI, :Zeros) -> :(MOI.Zeros)
 # (:Zeros) -> :(MOI.Zeros)
-_set(s::SymbolSet) = esc(s.s)
-_fun(s::SymbolFun) = esc(s.s)
-function _typedset(s::SymbolSet)
-    if s.typed
-        T = esc(:T)
-        :($(_set(s)){$T})
-    else
-        _set(s)
-    end
-end
-function _typedfun(s::SymbolFun)
-    if s.typed
-        T = esc(:T)
-        :($(_fun(s)){$T})
-    else
-        _fun(s)
-    end
-end
+_typedset(s::SymbolSet) = s.typed ? Expr(:curly, esc(s.s), esc(:T)) : esc(s.s)
+_typedfun(s::SymbolFun) = s.typed ? Expr(:curly, esc(s.s), esc(:T)) : esc(s.s)
 
 # Base.lowercase is moved to Unicode.lowercase in Julia v0.7
 using Unicode
 
 _field(s::SymbolFS) = Symbol(replace(lowercase(string(s.s)), "." => "_"))
-
-_getC(s::SymbolSet) = :(VectorOfConstraints{F,$(_typedset(s))})
-_getC(s::SymbolFun) = _typedfun(s)
-
 _callfield(f, s::SymbolFS) = :($f(model.$(_field(s))))
 _broadcastfield(b, s::SymbolFS) = :($b(f, model.$(_field(s))))
 _mapreduce_field(s::SymbolFS) = :(cur = op(cur, f(model.$(_field(s)))))
@@ -223,62 +217,61 @@ If `types` is vector of `SymbolFun` (resp. `SymbolSet`) then the constraints
 of that function (resp. set) type are stored in the corresponding field.
 """
 function struct_of_constraint_code(struct_name, types, field_types = nothing)
-    esc_struct_name = struct_name
     T = esc(:T)
-    typed_struct = :($(esc_struct_name){$T})
+    typed_struct = :($(struct_name){$T})
     type_parametrized = field_types === nothing
     if type_parametrized
         field_types = [Symbol("C$i") for i in eachindex(types)]
         append!(typed_struct.args, field_types)
     end
+    struct_def = :(mutable struct $typed_struct <: StructOfConstraints end)
 
-    struct_def = :(struct $typed_struct <: StructOfConstraints end)
-
-    for (t, field_type) in zip(types, field_types)
-        field = _field(t)
-        push!(struct_def.args[3].args, :($field::$field_type))
-    end
     code = quote
-        function $MOIU.broadcastcall(f::Function, model::$esc_struct_name)
-            return $(Expr(:block, _callfield.(Ref(:f), types)...))
+        function $MOIU.broadcastcall(f::Function, model::$struct_name)
+            $(Expr(:block, _callfield.(Ref(:f), types)...))
+            return
         end
-        function $MOIU.broadcastvcat(f::Function, model::$esc_struct_name)
+
+        function $MOIU.broadcastvcat(f::Function, model::$struct_name)
             return vcat($(_callfield.(Ref(:f), types)...))
         end
+
         function $MOIU.mapreduce_constraints(
             f::Function,
             op::Function,
-            model::$esc_struct_name,
+            model::$struct_name,
             cur,
         )
             return $(Expr(:block, _mapreduce_field.(types)...))
         end
     end
 
-    for t in types
-        if t isa SymbolFun
-            fun = _fun(t)
-            set = :(MOI.AbstractSet)
-        else
-            fun = :(MOI.AbstractFunction)
-            set = _set(t)
-        end
+    for (t, field_type) in zip(types, field_types)
         field = _field(t)
-        code = quote
-            $code
+        push!(struct_def.args[3].args, :($field::Union{Nothing,$field_type}))
+        fun = t isa SymbolFun ? esc(t.s) : :(MOI.AbstractFunction)
+        set = t isa SymbolFun ? :(MOI.AbstractSet) : esc(t.s)
+        constraints_code = :(
             function $MOIU.constraints(
-                model::$esc_struct_name,
+                model::$typed_struct,
                 ::Type{<:$fun},
                 ::Type{<:$set},
-            )
+            ) where {$T}
+                if model.$field === nothing
+                    model.$field = $(field_type)()
+                end
                 return model.$field
             end
+        )
+        if type_parametrized
+            append!(constraints_code.args[1].args, field_types)
         end
+        push!(code.args, constraints_code)
     end
     supports_code = if eltype(types) <: SymbolFun
         quote
             function $MOI.supports_constraint(
-                model::$esc_struct_name{$T},
+                model::$struct_name{$T},
                 ::Type{F},
                 ::Type{S},
             ) where {
@@ -293,7 +286,7 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
         @assert eltype(types) <: SymbolSet
         quote
             function $MOI.supports_constraint(
-                model::$esc_struct_name{$T},
+                model::$struct_name{$T},
                 ::Type{F},
                 ::Type{S},
             ) where {
@@ -307,7 +300,8 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
     end
     expr = Expr(:block, struct_def, supports_code, code)
     if !isempty(field_types)
-        constructors = [:($field_type()) for field_type in field_types]
+        constructors = [:(nothing) for field_type in field_types]
+        # constructors = [:($field_type()) for field_type in field_types]
         # If there is no field type, the default constructor is sufficient and
         # adding this constructor will make a `StackOverflow`.
         constructor_code = :(function $typed_struct() where {$T}

--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -184,21 +184,16 @@ struct SymbolSet <: SymbolFS
     typed::Bool
 end
 
-# QuoteNode prevents s from being interpolated and keeps it as a symbol
-# Expr(:., MOI, s) would be MOI.s
-# Expr(:., MOI, $s) would be Expr(:., MOI, EqualTo)
-# Expr(:., MOI, :($s)) would be Expr(:., MOI, :EqualTo)
-# Expr(:., MOI, :($(QuoteNode(s)))) is Expr(:., MOI, :(:EqualTo)) <- what we want
-
-# (MOI, :Zeros) -> :(MOI.Zeros)
-# (:Zeros) -> :(MOI.Zeros)
 _typedset(s::SymbolSet) = s.typed ? Expr(:curly, esc(s.s), esc(:T)) : esc(s.s)
 _typedfun(s::SymbolFun) = s.typed ? Expr(:curly, esc(s.s), esc(:T)) : esc(s.s)
 
 # Base.lowercase is moved to Unicode.lowercase in Julia v0.7
-using Unicode
+import Unicode
 
-_field(s::SymbolFS) = Symbol(replace(lowercase(string(s.s)), "." => "_"))
+function _field(s::SymbolFS)
+    return Symbol(replace(Unicode.lowercase(string(s.s)), "." => "_"))
+end
+
 _callfield(f, s::SymbolFS) = :($f(model.$(_field(s))))
 _broadcastfield(b, s::SymbolFS) = :($b(f, model.$(_field(s))))
 _mapreduce_field(s::SymbolFS) = :(cur = op(cur, f(model.$(_field(s)))))

--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -243,7 +243,7 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
                 model::$typed_struct,
                 ::Type{<:$fun},
                 ::Type{<:$set},
-            ) where {$T}
+            )::$(field_type) where {$T}
                 if model.$field === nothing
                     model.$field = $(field_type)()
                 end

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -249,9 +249,6 @@ function _delete_variables(
         end
         return !del
     end
-    if length(cons) == 0
-        MOI.empty!(v)
-    end
     return
 end
 
@@ -263,8 +260,7 @@ function _deleted_constraints(
     if MOI.is_empty(v)
         return
     end
-    vis = [vi]
-    _delete_variables(callback, v, vis)
+    _delete_variables(callback, v, [vi])
     _remove_variable(v, vi)
     return
 end

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -142,7 +142,7 @@ function MOI.get(
     v::VectorOfConstraints{F,S},
     ::MOI.ListOfConstraintTypesPresent,
 )::Vector{Tuple{DataType,DataType}} where {F,S}
-    return MOI.is_empty(v) ? [] : [(F, S)]
+    return (MOI.is_empty(v) || length(_constraints(v)) == 0) ? [] : [(F, S)]
 end
 
 function MOI.get(

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -259,7 +259,7 @@ function _deleted_constraints(
     callback::Function,
     v::VectorOfConstraints,
     vi::MOI.VariableIndex,
-)s
+)
     if MOI.is_empty(v)
         return
     end

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -172,19 +172,16 @@ end
 
 # Deletion of variables in vector of variables
 
+"This function assumes that v.constraints is not nothing."
 function _remove_variable(v::VectorOfConstraints, vi::MOI.VariableIndex)
-    if MOI.is_empty(v)
-        return
-    end
     CleverDicts.map_values!(_constraints(v)) do (f, s)
         return remove_variable(f, s, vi)
     end
     return
 end
+
+"This function assumes that v.constraints is not nothing."
 function _filter_variables(keep::Function, v::VectorOfConstraints)
-    if MOI.is_empty(v)
-        return
-    end
     CleverDicts.map_values!(_constraints(v)) do (f, s)
         return filter_variables(keep, f, s)
     end
@@ -233,14 +230,12 @@ function _delete_variables(
     return  # Nothing to do as it's not `VectorOfVariables` constraints
 end
 
+"This function assumes that v.constraints is not nothing."
 function _delete_variables(
-    callback::F,
+    callback::Function,
     v::VectorOfConstraints{MOI.VectorOfVariables,<:MOI.AbstractVectorSet},
     vis::Vector{MOI.VariableIndex},
-) where {F<:Function}
-    if MOI.is_empty(v)
-        return
-    end
+)
     cons = _constraints(v)
     filter!(cons) do p
         f = p.second[1]
@@ -261,10 +256,13 @@ function _delete_variables(
 end
 
 function _deleted_constraints(
-    callback::F,
+    callback::Function,
     v::VectorOfConstraints,
     vi::MOI.VariableIndex,
-) where {F<:Function}
+)s
+    if MOI.is_empty(v)
+        return
+    end
     vis = [vi]
     _delete_variables(callback, v, vis)
     _remove_variable(v, vi)
@@ -272,10 +270,13 @@ function _deleted_constraints(
 end
 
 function _deleted_constraints(
-    callback::F,
+    callback::Function,
     v::VectorOfConstraints,
     vis::Vector{MOI.VariableIndex},
-) where {F<:Function}
+)
+    if MOI.is_empty(v)
+        return
+    end
     removed = Set(vis)
     _delete_variables(callback, v, vis)
     _filter_variables(vi -> !(vi in removed), v)

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -348,6 +348,7 @@ end
             push!(loc2, (F, S))
         end
     end
+    _pushloc(::Nothing) = nothing
     function _pushloc(model::MOI.Utilities.StructOfConstraints)
         return MOIU.broadcastcall(_pushloc, model)
     end


### PR DESCRIPTION
Part of https://github.com/jump-dev/MathOptInterface.jl/issues/1313

Calling `MOIU.Model{Float64}()` does a lot of work. It has to create 97 different `CleverDict`s to store all the constraints in! Even though most users only use a small fraction of the possible constraint types. 

This PR uses a small `Union{Nothing,X}` to avoid creating the dictionaries, instead it lazily creates them on the first call to `add_constraint`.

Before
```
(base) oscar@Oscars-MBP auto-cache % ~/julia --project=. bench.jl clp
 21.929698 seconds (54.74 M allocations: 3.082 GiB, 6.57% gc time, 34.33% compilation time)
  0.001764 seconds (6.02 k allocations: 538.508 KiB)
(base) oscar@Oscars-MBP auto-cache % ~/julia --project=. bench.jl clp --no-bridge
 11.345386 seconds (19.50 M allocations: 1.112 GiB, 4.68% gc time, 98.00% compilation time)
  0.001040 seconds (3.05 k allocations: 309.961 KiB)
(base) oscar@Oscars-MBP auto-cache % ~/julia --project=. bench.jl glpk           
 16.459349 seconds (34.09 M allocations: 1.955 GiB, 6.23% gc time, 52.33% compilation time)
  0.000730 seconds (3.27 k allocations: 251.531 KiB)
(base) oscar@Oscars-MBP auto-cache % ~/julia --project=. bench.jl glpk --no-bridge
 12.485400 seconds (20.88 M allocations: 1.194 GiB, 4.43% gc time, 99.97% compilation time)
  0.000660 seconds (2.55 k allocations: 234.750 KiB)
```

After
```
Running: clp 
 18.193627 seconds (42.68 M allocations: 2.395 GiB, 7.23% gc time, 19.00% compilation time)
  0.001554 seconds (3.85 k allocations: 396.117 KiB)
Running: clp --no-bridge
  5.388487 seconds (7.22 M allocations: 424.453 MiB, 3.97% gc time, 92.45% compilation time)
  0.000915 seconds (1.90 k allocations: 238.125 KiB)
Running: glpk 
  9.581772 seconds (21.91 M allocations: 1.263 GiB, 5.77% gc time, 34.16% compilation time)
  0.000766 seconds (2.15 k allocations: 180.867 KiB)
Running: glpk --no-bridge
  6.361546 seconds (8.79 M allocations: 520.060 MiB, 3.72% gc time, 99.96% compilation time)
  0.000524 seconds (1.48 k allocations: 164.852 KiB)```