### PR TITLE
Improve type inference in Utilities

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -127,9 +127,9 @@ function reset_optimizer(m::CachingOptimizer, optimizer::MOI.AbstractOptimizer)
     for attr in MOI.get(m.model_cache, MOI.ListOfOptimizerAttributesSet())
         # Skip attributes which don't apply to the new optimizer.
         if attr isa MOI.RawParameter
-            # Even if the optimizer claims to `supports` `attr`, the value 
+            # Even if the optimizer claims to `supports` `attr`, the value
             # might have a different meaning (e.g., two solvers with `logLevel`
-            # as a RawParameter). To be on the safe side, just skip all raw 
+            # as a RawParameter). To be on the safe side, just skip all raw
             # parameters.
             continue
         elseif !MOI.is_copyable(attr) || !MOI.supports(m.optimizer, attr)
@@ -277,7 +277,8 @@ function MOI.add_variables(m::CachingOptimizer, n)
     if m.state == ATTACHED_OPTIMIZER
         if m.mode == AUTOMATIC
             try
-                vindices_optimizer = MOI.add_variables(m.optimizer, n)
+                vindices_optimizer =
+                    MOI.add_variables(m.optimizer, n)::Vector{MOI.VariableIndex}
             catch err
                 if err isa MOI.NotAllowedError
                     reset_optimizer(m)
@@ -286,7 +287,8 @@ function MOI.add_variables(m::CachingOptimizer, n)
                 end
             end
         else
-            vindices_optimizer = MOI.add_variables(m.optimizer, n)
+            vindices_optimizer =
+                MOI.add_variables(m.optimizer, n)::Vector{MOI.VariableIndex}
         end
     end
     vindices = MOI.add_variables(m.model_cache, n)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -614,12 +614,12 @@ function MOI.get(
     return MOI.get(model.constraints, noc)
 end
 
-function _add_contraint_type(
+function _add_constraint_type(
     list,
     model::AbstractModel,
     S::Type{<:MOI.AbstractScalarSet},
 )
-    flag = single_variable_flag(S)
+    flag = single_variable_flag(S)::UInt8
     if any(mask -> !iszero(flag & mask), model.single_variable_mask)
         push!(list, (MOI.SingleVariable, S))
     end
@@ -627,21 +627,17 @@ function _add_contraint_type(
 end
 function MOI.get(
     model::AbstractModel{T},
-    loc::MOI.ListOfConstraintTypesPresent,
+    attr::MOI.ListOfConstraintTypesPresent,
 ) where {T}
-    list = copy(MOI.get(model.constraints, loc))
-    for S in (
-        MOI.EqualTo{T},
-        MOI.GreaterThan{T},
-        MOI.LessThan{T},
-        MOI.Interval{T},
-        MOI.Semicontinuous{T},
-        MOI.Semiinteger{T},
-        MOI.Integer,
-        MOI.ZeroOne,
-    )
-        _add_contraint_type(list, model, S)
-    end
+    list = MOI.get(model.constraints, attr)::Vector{Tuple{DataType,DataType}}
+    _add_constraint_type(list, model, MOI.EqualTo{T})
+    _add_constraint_type(list, model, MOI.GreaterThan{T})
+    _add_constraint_type(list, model, MOI.LessThan{T})
+    _add_constraint_type(list, model, MOI.Interval{T})
+    _add_constraint_type(list, model, MOI.Semicontinuous{T})
+    _add_constraint_type(list, model, MOI.Semiinteger{T})
+    _add_constraint_type(list, model, MOI.Integer)
+    _add_constraint_type(list, model, MOI.ZeroOne)
     return list
 end
 

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -148,14 +148,14 @@ end
 # Deletion of variables in vector of variables
 
 function _remove_variable(v::VectorOfConstraints, vi::MOI.VariableIndex)
-    CleverDicts.map_values!(v.constraints) do func_set
-        return remove_variable(func_set..., vi)
+    CleverDicts.map_values!(v.constraints) do f, s
+        return remove_variable(f, s, vi)
     end
     return
 end
 function _filter_variables(keep::Function, v::VectorOfConstraints)
-    CleverDicts.map_values!(v.constraints) do func_set
-        return filter_variables(keep, func_set...)
+    CleverDicts.map_values!(v.constraints) do f, s
+        return filter_variables(keep, f, s)
     end
     return
 end

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -153,10 +153,7 @@ function _remove_variable(v::VectorOfConstraints, vi::MOI.VariableIndex)
     end
     return
 end
-function _filter_variables(
-    keep::F,
-    v::VectorOfConstraints,
-) where {F<:Function}
+function _filter_variables(keep::F, v::VectorOfConstraints) where {F<:Function}
     CleverDicts.map_values!(v.constraints) do f, s
         return filter_variables(keep, f, s)
     end

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -148,13 +148,13 @@ end
 # Deletion of variables in vector of variables
 
 function _remove_variable(v::VectorOfConstraints, vi::MOI.VariableIndex)
-    CleverDicts.map_values!(v.constraints) do f, s
+    CleverDicts.map_values!(v.constraints) do (f, s)
         return remove_variable(f, s, vi)
     end
     return
 end
 function _filter_variables(keep::F, v::VectorOfConstraints) where {F<:Function}
-    CleverDicts.map_values!(v.constraints) do f, s
+    CleverDicts.map_values!(v.constraints) do (f, s)
         return filter_variables(keep, f, s)
     end
     return

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -153,7 +153,10 @@ function _remove_variable(v::VectorOfConstraints, vi::MOI.VariableIndex)
     end
     return
 end
-function _filter_variables(keep::Function, v::VectorOfConstraints)
+function _filter_variables(
+    keep::F,
+    v::VectorOfConstraints,
+) where {F<:Function}
     CleverDicts.map_values!(v.constraints) do f, s
         return filter_variables(keep, f, s)
     end
@@ -203,10 +206,10 @@ function _delete_variables(
 end
 
 function _delete_variables(
-    callback::Function,
-    v::VectorOfConstraints{MOI.VectorOfVariables,S},
+    callback::F,
+    v::VectorOfConstraints{MOI.VectorOfVariables,<:MOI.AbstractVectorSet},
     vis::Vector{MOI.VariableIndex},
-) where {S<:MOI.AbstractVectorSet}
+) where {F<:Function}
     filter!(v.constraints) do p
         f = p.second[1]
         del = if length(f.variables) == 1
@@ -223,10 +226,10 @@ function _delete_variables(
 end
 
 function _deleted_constraints(
-    callback::Function,
+    callback::F,
     v::VectorOfConstraints,
     vi::MOI.VariableIndex,
-)
+) where {F<:Function}
     vis = [vi]
     _delete_variables(callback, v, vis)
     _remove_variable(v, vi)
@@ -234,10 +237,10 @@ function _deleted_constraints(
 end
 
 function _deleted_constraints(
-    callback::Function,
+    callback::F,
     v::VectorOfConstraints,
     vis::Vector{MOI.VariableIndex},
-)
+) where {F<:Function}
     removed = Set(vis)
     _delete_variables(callback, v, vis)
     _filter_variables(vi -> !(vi in removed), v)


### PR DESCRIPTION
Part of https://github.com/jump-dev/MathOptInterface.jl/issues/1313

This was stopping the `delete` from precompiling:

After
```
Running: clp 
 18.562974 seconds (38.47 M allocations: 2.200 GiB, 5.93% gc time, 43.03% compilation time)
  0.001416 seconds (5.95 k allocations: 534.227 KiB)
Running: clp --no-bridge
 10.577259 seconds (18.82 M allocations: 1.070 GiB, 5.15% gc time, 96.09% compilation time)
  0.001221 seconds (3.01 k allocations: 309.070 KiB)
Running: glpk 
 14.450203 seconds (33.37 M allocations: 1.910 GiB, 6.87% gc time, 53.09% compilation time)
  0.000738 seconds (3.17 k allocations: 249.656 KiB)
Running: glpk --no-bridge
 11.603105 seconds (20.37 M allocations: 1.163 GiB, 5.11% gc time, 99.98% compilation time)
  0.000591 seconds (2.52 k allocations: 233.828 KiB)
```

<img width="799" alt="image" src="https://user-images.githubusercontent.com/8177701/117110875-e4eac900-adda-11eb-949e-e24f5e031658.png">