### PR TITLE
Remove useless {S}

### DIFF
--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -270,7 +270,7 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
                 model::$esc_struct_name,
                 ::Type{<:$fun},
                 ::Type{<:$set},
-            ) where {S}
+            )
                 return model.$field
             end
         end


### PR DESCRIPTION
Noticed when investigating the benchmark of https://github.com/jump-dev/MathOptInterface.jl/pull/1287
Should also help with https://github.com/jump-dev/MathOptInterface.jl/issues/1313

On the benchmark of https://github.com/jump-dev/MathOptInterface.jl/pull/1287:
Before this PR:
```
  0.043870 seconds (123.85 k allocations: 17.192 MiB, 20.42% gc time)
  0.000315 seconds (178 allocations: 257.875 KiB)
```
After this PR:
```
  0.011613 seconds (3.72 k allocations: 1.152 MiB)
  0.000312 seconds (178 allocations: 257.875 KiB)
```