### PR TITLE
Add VariableBasisStatus

### DIFF
--- a/docs/src/reference/variables.md
+++ b/docs/src/reference/variables.md
@@ -36,4 +36,5 @@ AbstractVariableAttribute
 VariableName
 VariablePrimalStart
 VariablePrimal
+VariableBasisStatus
 ```

--- a/src/Bridges/Constraint/slack.jl
+++ b/src/Bridges/Constraint/slack.jl
@@ -224,13 +224,29 @@ MOI.get(b::ScalarSlackBridge, ::MOI.ListOfVariableIndices) = [b.slack]
 function MOI.get(
     model::MOI.ModelLike,
     ::MOI.ConstraintBasisStatus,
-    bridge::ScalarSlackBridge,
-)
+    bridge::ScalarSlackBridge{T,F,S},
+) where {T,F,S<:MOI.Interval}
     return MOI.get(
         model,
         MOI.VariableBasisStatus(),
         MOI.VariableIndex(bridge.slack_in_set.value),
     )
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    ::MOI.ConstraintBasisStatus,
+    bridge::ScalarSlackBridge,
+)
+    status = MOI.get(
+        model,
+        MOI.VariableBasisStatus(),
+        MOI.VariableIndex(bridge.slack_in_set.value),
+    )
+    if status == MOI.NONBASIC_AT_LOWER || status == MOI.NONBASIC_AT_UPPER
+        return MOI.NONBASIC
+    end
+    return status
 end
 
 function MOI.set(

--- a/src/Bridges/Constraint/slack.jl
+++ b/src/Bridges/Constraint/slack.jl
@@ -226,7 +226,11 @@ function MOI.get(
     ::MOI.ConstraintBasisStatus,
     bridge::ScalarSlackBridge,
 )
-    return MOI.get(model, MOI.ConstraintBasisStatus(), bridge.slack_in_set)
+    return MOI.get(
+        model,
+        MOI.VariableBasisStatus(),
+        MOI.VariableIndex(bridge.slack_in_set.value),
+    )
 end
 
 function MOI.set(

--- a/src/Test/config.jl
+++ b/src/Test/config.jl
@@ -53,7 +53,7 @@ struct Config{T<:Real}
      * `optimal_status = MOI.OPTIMAL`: Set to `MOI.LOCALLY_SOLVED` if the solver
        cannot prove global optimality.
      * `basis::Bool = false`: Set to `true` if the solver supports
-       [`MOI.ConstraintBasisStatus`](@ref)
+       [`MOI.ConstraintBasisStatus`](@ref) and [`MOI.VariableBasisStatus`](@ref).
     """
     function Config{T}(;
         atol::Real = Base.rtoldefault(T),

--- a/src/Test/contlinear.jl
+++ b/src/Test/contlinear.jl
@@ -708,9 +708,9 @@ function linear2test(model::MOI.ModelLike, config::Config{T}) where {T}
         end
 
         if config.basis
-            @test MOI.get(model, MOI.ConstraintBasisStatus(), vc1) == MOI.BASIC
-            @test MOI.get(model, MOI.ConstraintBasisStatus(), vc2) ==
-                  MOI.NONBASIC
+            @test MOI.get(model, MOI.VariableBasisStatus(), x) == MOI.BASIC
+            @test MOI.get(model, MOI.VariableBasisStatus(), y) ==
+                  MOI.NONBASIC_AT_LOWER
             @test MOI.get(model, MOI.ConstraintBasisStatus(), c) == MOI.NONBASIC
         end
     end
@@ -797,7 +797,7 @@ function linear3test(model::MOI.ModelLike, config::Config{T}) where {T}
             rtol
 
         if config.basis
-            @test MOI.get(model, MOI.ConstraintBasisStatus(), vc) == MOI.BASIC
+            @test MOI.get(model, MOI.VariableBasisStatus(), x) == MOI.BASIC
             @test MOI.get(model, MOI.ConstraintBasisStatus(), c) == MOI.NONBASIC
         end
     end
@@ -858,8 +858,8 @@ function linear3test(model::MOI.ModelLike, config::Config{T}) where {T}
             rtol
 
         if config.basis
-            @test MOI.get(model, MOI.ConstraintBasisStatus(), vc) ==
-                  MOI.NONBASIC
+            @test MOI.get(model, MOI.VariableBasisStatus(), x) ==
+                  MOI.NONBASIC_AT_UPPER
             @test MOI.get(model, MOI.ConstraintBasisStatus(), c) == MOI.BASIC
         end
     end
@@ -1780,10 +1780,8 @@ function linear9test(model::MOI.ModelLike, config::Config{T}) where {T}
             rtol
 
         if config.basis
-            @test MOI.get(model, MOI.ConstraintBasisStatus(), vc12[1]) ==
-                  MOI.BASIC
-            @test MOI.get(model, MOI.ConstraintBasisStatus(), vc12[2]) ==
-                  MOI.BASIC
+            @test MOI.get(model, MOI.VariableBasisStatus(), x) == MOI.BASIC
+            @test MOI.get(model, MOI.VariableBasisStatus(), y) == MOI.BASIC
             @test MOI.get(model, MOI.ConstraintBasisStatus(), c1[1]) ==
                   MOI.BASIC
             @test MOI.get(model, MOI.ConstraintBasisStatus(), c23[1]) ==
@@ -1875,9 +1873,8 @@ function linear10test(model::MOI.ModelLike, config::Config{T}) where {T}
         if config.basis
             # There are multiple optimal bases. Either x or y can be in the optimal basis.
             @test (
-                MOI.get(model, MOI.ConstraintBasisStatus(), vc[1]) ==
-                MOI.BASIC ||
-                MOI.get(model, MOI.ConstraintBasisStatus(), vc[2]) == MOI.BASIC
+                MOI.get(model, MOI.VariableBasisStatus(), x) == MOI.BASIC ||
+                MOI.get(model, MOI.VariableBasisStatus(), y) == MOI.BASIC
             )
             @test MOI.get(model, MOI.ConstraintBasisStatus(), c) ==
                   MOI.NONBASIC_AT_UPPER
@@ -1918,9 +1915,8 @@ function linear10test(model::MOI.ModelLike, config::Config{T}) where {T}
         if config.basis
             # There are multiple optimal bases. Either x or y can be in the optimal basis."
             @test (
-                MOI.get(model, MOI.ConstraintBasisStatus(), vc[1]) ==
-                MOI.BASIC ||
-                MOI.get(model, MOI.ConstraintBasisStatus(), vc[2]) == MOI.BASIC
+                MOI.get(model, MOI.VariableBasisStatus(), x) == MOI.BASIC ||
+                MOI.get(model, MOI.VariableBasisStatus(), y) == MOI.BASIC
             )
             @test MOI.get(model, MOI.ConstraintBasisStatus(), c) ==
                   MOI.NONBASIC_AT_LOWER
@@ -1951,9 +1947,8 @@ function linear10test(model::MOI.ModelLike, config::Config{T}) where {T}
         if config.basis
             # There are multiple optimal bases. Either x or y can be in the optimal basis.
             @test (
-                MOI.get(model, MOI.ConstraintBasisStatus(), vc[1]) ==
-                MOI.BASIC ||
-                MOI.get(model, MOI.ConstraintBasisStatus(), vc[2]) == MOI.BASIC
+                MOI.get(model, MOI.VariableBasisStatus(), x) == MOI.BASIC ||
+                MOI.get(model, MOI.VariableBasisStatus(), y) == MOI.BASIC
             )
             @test MOI.get(model, MOI.ConstraintBasisStatus(), c) ==
                   MOI.NONBASIC_AT_LOWER
@@ -1990,9 +1985,8 @@ function linear10test(model::MOI.ModelLike, config::Config{T}) where {T}
         if config.basis
             # There are multiple optimal bases. Either x or y can be in the optimal basis.
             @test (
-                MOI.get(model, MOI.ConstraintBasisStatus(), vc[1]) ==
-                MOI.BASIC ||
-                MOI.get(model, MOI.ConstraintBasisStatus(), vc[2]) == MOI.BASIC
+                MOI.get(model, MOI.VariableBasisStatus(), x) == MOI.BASIC ||
+                MOI.get(model, MOI.VariableBasisStatus(), y) == MOI.BASIC
             )
             @test MOI.get(model, MOI.ConstraintBasisStatus(), c) ==
                   MOI.NONBASIC_AT_UPPER
@@ -2080,12 +2074,12 @@ function linear10btest(model::MOI.ModelLike, config::Config{T}) where {T}
 
         if config.basis
             @test (
-                MOI.get(model, MOI.ConstraintBasisStatus(), vc[1]) ==
-                MOI.NONBASIC
+                MOI.get(model, MOI.VariableBasisStatus(), x) ==
+                MOI.NONBASIC_AT_LOWER
             )
             @test (
-                MOI.get(model, MOI.ConstraintBasisStatus(), vc[1]) ==
-                MOI.NONBASIC
+                MOI.get(model, MOI.VariableBasisStatus(), y) ==
+                MOI.NONBASIC_AT_LOWER
             )
             @test MOI.get(model, MOI.ConstraintBasisStatus(), c) == MOI.BASIC
         end
@@ -2493,14 +2487,11 @@ function linear14test(model::MOI.ModelLike, config::Config{T}) where {T}
                 rtol
 
             if config.basis
-                @test MOI.get(model, MOI.ConstraintBasisStatus(), clbx) ==
-                      MOI.NONBASIC
-                @test MOI.get(model, MOI.ConstraintBasisStatus(), clby) ==
-                      MOI.BASIC
-                @test MOI.get(model, MOI.ConstraintBasisStatus(), clbz) ==
-                      MOI.BASIC
-                @test MOI.get(model, MOI.ConstraintBasisStatus(), cubz) ==
-                      MOI.NONBASIC
+                @test MOI.get(model, MOI.VariableBasisStatus(), x) ==
+                      MOI.NONBASIC_AT_LOWER
+                @test MOI.get(model, MOI.VariableBasisStatus(), y) == MOI.BASIC
+                @test MOI.get(model, MOI.VariableBasisStatus(), z) ==
+                      MOI.NONBASIC_AT_UPPER
                 @test MOI.get(model, MOI.ConstraintBasisStatus(), c) ==
                       MOI.NONBASIC
             end

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1286,6 +1286,18 @@ struct ConstraintBasisStatus <: AbstractConstraintAttribute
     ConstraintBasisStatus(result_index::Int = 1) = new(result_index)
 end
 
+function get_fallback(
+    ::ModelLike,
+    ::ConstraintBasisStatus,
+    ::ConstraintIndex{SingleVariable,<:AbstractScalarSet},
+)
+    error(
+        "Querying the basis status of a `SingleVariable` constraint is not ",
+        "supported. Use [`VariableBasisStatus`](@ref) instead.",
+    )
+end
+
+
 """
     CanonicalConstraintFunction()
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1114,8 +1114,9 @@ is_set_by_optimize(::CallbackVariablePrimal) = true
 """
     BasisStatusCode
 
-An Enum of possible values for the `ConstraintBasisStatus` attribute, explaining
-the status of a given element with respect to an optimal solution basis.
+An Enum of possible values for the [`ConstraintBasisStatus`](@ref) and
+[`VariableBasisStatus`](@ref) attributes, explaining the status of a given
+element with respect to an optimal solution basis.
 
 Possible values are:
 
@@ -1126,7 +1127,7 @@ Possible values are:
 * `SUPER_BASIC`: element is not in the basis but is also not at one of its
   bounds
 
-Notes
+## Notes
 
 * `NONBASIC_AT_LOWER` and `NONBASIC_AT_UPPER` should be used only for
   constraints with the `Interval` set. In this case, they are necessary to
@@ -1134,9 +1135,8 @@ Notes
   (e.g., `LessThan` and `GreaterThan`) should use `NONBASIC` instead of the
   `NONBASIC_AT_*` values.
 
-* In general, `SUPER_BASIC` usually occurs when the problem is nonlinear. For
-  linear programs, `SUPER_BASIC` variables only occur if the solver returns a
-  solution that is not at a vertex of the feasible region.
+* In linear programs, `SUPER_BASIC` occurs when a variable with no bounds is not
+  in the basis.
 """
 @enum(
     BasisStatusCode,
@@ -1146,6 +1146,17 @@ Notes
     NONBASIC_AT_UPPER,
     SUPER_BASIC
 )
+
+"""
+    VariableBasisStatus(result_index::Int = 1)
+
+A variable attribute for the `BasisStatusCode` of a variable in result
+`result_index`, with respect to an available optimal solution basis.
+"""
+struct VariableBasisStatus <: AbstractVariableAttribute
+    result_index::Int
+    VariableBasisStatus(result_index::Int = 1) = new(result_index)
+end
 
 ## Constraint attributes
 
@@ -1260,8 +1271,7 @@ A constraint attribute for the `BasisStatusCode` of some constraint in result
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 
-**For the basis status of a variable, query the corresponding `SingleVariable`
-constraint that enforces the variable's bounds.**
+For the basis status of a variable, query [`VariableBasisStatus`](@ref).
 """
 struct ConstraintBasisStatus <: AbstractConstraintAttribute
     result_index::Int
@@ -1667,6 +1677,7 @@ function is_set_by_optimize(
         ConstraintPrimal,
         ConstraintDual,
         ConstraintBasisStatus,
+        VariableBasisStatus,
     },
 )
     return true

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1291,12 +1291,11 @@ function get_fallback(
     ::ConstraintBasisStatus,
     ::ConstraintIndex{SingleVariable,<:AbstractScalarSet},
 )
-    error(
+    return error(
         "Querying the basis status of a `SingleVariable` constraint is not ",
         "supported. Use [`VariableBasisStatus`](@ref) instead.",
     )
 end
-
 
 """
     CanonicalConstraintFunction()

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1273,7 +1273,13 @@ A constraint attribute for the `BasisStatusCode` of some constraint in result
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 
+## Notes
+
 For the basis status of a variable, query [`VariableBasisStatus`](@ref).
+
+`ConstraintBasisStatus` does not apply to `SingleVariable` constraints. You
+can infer the basis status of a [`SingleVariable`](@ref) constraint by looking
+at the result of [`VariableBasisStatus`](@ref).
 """
 struct ConstraintBasisStatus <: AbstractConstraintAttribute
     result_index::Int

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1133,7 +1133,9 @@ Possible values are:
   constraints with the `Interval` set. In this case, they are necessary to
   distinguish which side of the constraint is active. One-sided constraints
   (e.g., `LessThan` and `GreaterThan`) should use `NONBASIC` instead of the
-  `NONBASIC_AT_*` values.
+  `NONBASIC_AT_*` values. This restriction does not apply to [`VariableBasisStatus`](@ref),
+  which should return `NONBASIC_AT_*` regardless of whether the alternative
+  bound exists.
 
 * In linear programs, `SUPER_BASIC` occurs when a variable with no bounds is not
   in the basis.

--- a/test/Bridges/Constraint/functionize.jl
+++ b/test/Bridges/Constraint/functionize.jl
@@ -67,6 +67,7 @@ config_with_basis = MOIT.Config(basis = true)
                         MOI.GreaterThan{Float64},
                     ) => [MOI.BASIC, MOI.NONBASIC],
                 ],
+                var_basis = [MOI.BASIC, MOI.NONBASIC_AT_LOWER],
             ),
         )
         MOIT.linear2test(bridged_mock, config_with_basis)

--- a/test/Bridges/Constraint/interval.jl
+++ b/test/Bridges/Constraint/interval.jl
@@ -42,9 +42,8 @@ end
             con_basis = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.BASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.NONBASIC],
-                (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                    [MOI.BASIC, MOI.BASIC],
             ],
+            var_basis = [MOI.BASIC, MOI.BASIC],
             (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) =>
                 [0],
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
@@ -56,9 +55,8 @@ end
             con_basis = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.NONBASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.BASIC],
-                (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                    [MOI.BASIC, MOI.BASIC],
             ],
+            var_basis = [MOI.BASIC, MOI.BASIC],
             (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) =>
                 [1],
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
@@ -74,9 +72,8 @@ end
             con_basis = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.NONBASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.BASIC],
-                (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                    [MOI.BASIC, MOI.BASIC],
             ],
+            var_basis = [MOI.BASIC, MOI.BASIC],
         ),
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
@@ -84,9 +81,8 @@ end
             con_basis = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.BASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.NONBASIC],
-                (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                    [MOI.BASIC, MOI.BASIC],
             ],
+            var_basis = [MOI.BASIC, MOI.BASIC],
         ),
     )
     MOIT.linear10test(bridged_mock, config_with_basis)
@@ -102,9 +98,8 @@ end
             con_basis = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.BASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.BASIC],
-                (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                    [MOI.NONBASIC, MOI.NONBASIC],
             ],
+            var_basis = [MOI.NONBASIC_AT_LOWER, MOI.NONBASIC_AT_LOWER],
             (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) =>
                 [0],
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>

--- a/test/Bridges/Constraint/slack.jl
+++ b/test/Bridges/Constraint/slack.jl
@@ -86,10 +86,11 @@ config = MOIT.Config()
             con_basis = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}) =>
                     [MOI.NONBASIC],
-                (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                    [MOI.BASIC, MOI.NONBASIC],
-                (MOI.SingleVariable, MOI.LessThan{Float64}) =>
-                    [MOI.NONBASIC],
+            ],
+            var_basis = [
+                MOI.BASIC,
+                MOI.NONBASIC_AT_LOWER,
+                MOI.NONBASIC_AT_UPPER,
             ],
         ),
     )

--- a/test/Test/contlinear.jl
+++ b/test/Test/contlinear.jl
@@ -56,9 +56,8 @@ MOIU.set_mock_optimize!(
         con_basis = [
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [MOI.NONBASIC],
-            (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                [MOI.BASIC, MOI.NONBASIC],
         ],
+        var_basis = [MOI.BASIC, MOI.NONBASIC_AT_LOWER],
     ),
 )
 MOIT.linear2test(mock, config)
@@ -70,8 +69,8 @@ MOIU.set_mock_optimize!(
         con_basis = [
             (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) =>
                 [MOI.NONBASIC],
-            (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [MOI.BASIC],
         ],
+        var_basis = [MOI.BASIC],
     ),
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
@@ -79,8 +78,8 @@ MOIU.set_mock_optimize!(
         con_basis = [
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [MOI.BASIC],
-            (MOI.SingleVariable, MOI.LessThan{Float64}) => [MOI.NONBASIC],
         ],
+        var_basis = [MOI.NONBASIC_AT_UPPER],
     ),
 )
 MOIT.linear3test(mock, config)
@@ -178,9 +177,8 @@ MOIU.set_mock_optimize!(
                 [MOI.NONBASIC, MOI.NONBASIC],
             (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) =>
                 [MOI.BASIC],
-            (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                [MOI.BASIC, MOI.BASIC],
         ],
+        var_basis = [MOI.BASIC, MOI.BASIC],
     ),
 )
 MOIT.linear9test(mock, config)
@@ -192,9 +190,8 @@ MOIU.set_mock_optimize!(
         con_basis = [
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [MOI.NONBASIC_AT_UPPER],
-            (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                [MOI.BASIC, MOI.BASIC],
         ],
+        var_basis = [MOI.BASIC, MOI.BASIC],
         (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [-1],
     ),
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
@@ -203,9 +200,8 @@ MOIU.set_mock_optimize!(
         con_basis = [
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [MOI.NONBASIC_AT_LOWER],
-            (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                [MOI.BASIC, MOI.BASIC],
         ],
+        var_basis = [MOI.BASIC, MOI.BASIC],
         (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [1],
     ),
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
@@ -215,9 +211,8 @@ MOIU.set_mock_optimize!(
         con_basis = [
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [MOI.NONBASIC_AT_LOWER],
-            (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                [MOI.BASIC, MOI.BASIC],
         ],
+        var_basis = [MOI.BASIC, MOI.BASIC],
     ),
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
@@ -226,9 +221,8 @@ MOIU.set_mock_optimize!(
         con_basis = [
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [MOI.NONBASIC_AT_UPPER],
-            (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                [MOI.BASIC, MOI.BASIC],
         ],
+        var_basis = [MOI.BASIC, MOI.BASIC],
     ),
 )
 MOIT.linear10test(mock, config)
@@ -240,9 +234,8 @@ MOIU.set_mock_optimize!(
         con_basis = [
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [MOI.BASIC],
-            (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                [MOI.NONBASIC, MOI.NONBASIC],
         ],
+        var_basis = [MOI.NONBASIC_AT_LOWER, MOI.NONBASIC_AT_LOWER],
         (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [0],
     ),
 )
@@ -289,10 +282,8 @@ MOIU.set_mock_optimize!(
         con_basis = [
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [MOI.NONBASIC],
-            (MOI.SingleVariable, MOI.GreaterThan{Float64}) =>
-                [MOI.NONBASIC, MOI.BASIC, MOI.BASIC],
-            (MOI.SingleVariable, MOI.LessThan{Float64}) => [MOI.NONBASIC],
         ],
+        var_basis = [MOI.NONBASIC_AT_LOWER, MOI.BASIC, MOI.NONBASIC_AT_UPPER],
         (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1],
         (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [2, 0, 0],
         (MOI.SingleVariable, MOI.LessThan{Float64}) => [-2],

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -141,11 +141,15 @@ function test_no_constraint_name()
 end
 
 function test_ConstraintBasisStatus_fallback()
-    model = DummyModel()
-    x = MOI.add_variable(model)
-    c = MOI.add_constriant(model, MOI.SingleVariable(x), MOI.GreaterThan(1.0))
-    MOI.optimize!(model)
-    @test_throws ErrorException MOI.get(model, MOI.ConstraintBasisStatus(), c)
+    model = DummyModelWithAdd()
+    c = MOI.ConstraintIndex{MOI.SingleVariable,MOI.EqualTo{Float64}}(1)
+    @test_throws(
+        ErrorException(
+            "Querying the basis status of a `SingleVariable` constraint is " *
+            "not supported. Use [`VariableBasisStatus`](@ref) instead.",
+        ),
+        MOI.get(model, MOI.ConstraintBasisStatus(), c),
+    )
 end
 
 function runtests()

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -140,6 +140,14 @@ function test_no_constraint_name()
     )
 end
 
+function test_ConstraintBasisStatus_fallback()
+    model = DummyModel()
+    x = MOI.add_variable(model)
+    c = MOI.add_constriant(model, MOI.SingleVariable(x), MOI.GreaterThan(1.0))
+    MOI.optimize!(model)
+    @test_throws ErrorException MOI.get(model, MOI.ConstraintBasisStatus(), c)
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if startswith("$name", "test_")


### PR DESCRIPTION
I started to implement this, but it needs some discussion.

- [x] Do we need to worry about mapping it through bridges? I guess not. This is likely only a problem for models created using variable bridges, which won't really be MILP solvers.
- [x] Do we leave `ConstraintBasisStatus{SingleVariable,S}` in place? It seems like we should remove it, but then this is another special case of "an attribute that isn't supported for bounds" (c.f. https://github.com/jump-dev/MathOptInterface.jl/pull/1312). That's starting to feel like our abstraction is wrong/incomplete.

Really, the only thing we're missing is "is a variable with no constraints in the basis?" The only answers can be `BASIC` or `SUPERBASIC`.

I'd vote for my previous suggestion of:
```julia
"""
    VariableInBasis(result_index::Int = 1)

A variable attribute which indicates `true` or `false` if some variable in
result `result_index` is in the corresponding optimal solution basis.
"""
struct VariableInBasis <: AbstractVariableAttribute 
    result_index::Int
    VariableInBasis(result_index::Int = 1) = new(result_index0
end
```

Closes #1297