### PR TITLE
inbounds for is_strictly_increasing

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -669,18 +669,21 @@ function is_strictly_sorted(x::Vector, by, filter)
     if isempty(x)
         return true
     end
-    if !filter(first(x))
+    current_x = first(x)
+    if !filter(current_x)
         return false
     end
-    for i in eachindex(x)[2:end]
-        prev = @inbounds(x[i-1])
-        cur = @inbounds(x[i])
-        if by(cur) <= by(prev)
+    current_fx = by(current_x)
+    @inbounds for i in eachindex(x)[2:end]
+        next_x = x[i]
+        if !filter(next_x)
             return false
         end
-        if !filter(cur)
+        next_fx = by(next_x)
+        if next_fx <= current_fx
             return false
         end
+        current_x, current_fx = next_x, next_fx
     end
     return true
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -660,12 +660,12 @@ function is_canonical(f::Union{SQF,VQF})
 end
 
 """
-    is_strictly_sorted(x::AbstractVector, by, filter)
+    is_strictly_sorted(x::Vector, by, filter)
 
 Returns `true` if `by(x[i]) < by(x[i + 1])` and `filter(x[i]) == true` for
 all indices i.
 """
-function is_strictly_sorted(x::AbstractVector, by, filter)
+function is_strictly_sorted(x::Vector, by, filter)
     if isempty(x)
         return true
     end
@@ -673,10 +673,12 @@ function is_strictly_sorted(x::AbstractVector, by, filter)
         return false
     end
     for i in eachindex(x)[2:end]
-        if by(x[i]) <= by(x[i-1])
+        prev = @inbounds(x[i-1])
+        cur = @inbounds(x[i])
+        if by(cur) <= by(prev)
             return false
         end
-        if !filter(x[i])
+        if !filter(cur)
             return false
         end
     end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -669,13 +669,13 @@ function is_strictly_sorted(x::Vector, by, filter)
     if isempty(x)
         return true
     end
-    current_x = first(x)
+    @inbounds current_x = first(x)
     if !filter(current_x)
         return false
     end
     current_fx = by(current_x)
-    @inbounds for i in eachindex(x)[2:end]
-        next_x = x[i]
+    for i in eachindex(x)[2:end]
+        @inbounds next_x = x[i]
         if !filter(next_x)
             return false
         end


### PR DESCRIPTION
As this is taking a non-negligeable time in https://github.com/jump-dev/MathOptInterface.jl/pull/1287, it is worth optimizing.
Consider the benchmark:
```julia
function bench(n)
    x = MOI.VariableIndex.(1:n)
    f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(ones(length(x)), x), 0.0)
    @btime MOI.Utilities.is_canonical($f)
end
```
Before:
```
julia> bench(10000)
  8.769 μs (0 allocations: 0 bytes)
```
Initial suggestion:
```
julia> bench(10000)
  6.477 μs (0 allocations: 0 bytes)
```
@odow improved implementation:
```
julia> bench(10000)
  5.808 μs (0 allocations: 0 bytes)
```