### PR TITLE
Infinite default bounds for AbstractFloat

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -14,11 +14,17 @@ function MOI.get(model::AbstractModel, ::MOI.NumberOfVariables)::Int64
     end
 end
 
+# Use `-Inf` and `Inf` for `AbstractFloat` subtypes.
+_no_lower_bound(::Type{T}) where {T} = zero(T)
+_no_lower_bound(::Type{T}) where {T<:AbstractFloat} = typemin(T)
+_no_upper_bound(::Type{T}) where {T} = zero(T)
+_no_upper_bound(::Type{T}) where {T<:AbstractFloat} = typemax(T)
+
 function MOI.add_variable(model::AbstractModel{T}) where {T}
     vi = VI(model.num_variables_created += 1)
     push!(model.single_variable_mask, 0x0)
-    push!(model.lower_bound, zero(T))
-    push!(model.upper_bound, zero(T))
+    push!(model.lower_bound, _no_lower_bound(T))
+    push!(model.upper_bound, _no_upper_bound(T))
     if model.variable_indices !== nothing
         push!(model.variable_indices, vi)
     end
@@ -527,11 +533,18 @@ function MOI.get(
 end
 
 function _delete_constraint(
-    model::AbstractModel,
+    model::AbstractModel{T},
     ci::MOI.ConstraintIndex{MOI.SingleVariable,S},
-) where {S}
+) where {T,S}
     MOI.throw_if_not_valid(model, ci)
-    model.single_variable_mask[ci.value] &= ~single_variable_flag(S)
+    flag = single_variable_flag(S)
+    model.single_variable_mask[ci.value] &= ~flag
+    if !iszero(flag & LOWER_BOUND_MASK)
+        model.lower_bound[ci.value] = _no_lower_bound(T)
+    end
+    if !iszero(flag & UPPER_BOUND_MASK)
+        model.upper_bound[ci.value] = _no_upper_bound(T)
+    end
     return
 end
 
@@ -1012,6 +1025,12 @@ for (loop_name, loop_super_type) in [
           [`MathOptInterface.ZeroOne`](@ref), [`MathOptInterface.Semicontinuous`](@ref)
           or [`MathOptInterface.Semiinteger`](@ref).
         * `F`-in-`S` constraints that are supported by `C`.
+
+        The lower (resp. upper) bound of a variable of index `VariableIndex(i)`
+        is at the `i`th index of the vector stored in the field `lower_bound`
+        (resp. `upper_bound`). When no lower (resp. upper) bound is set, it is
+        `typemin(T)` (resp. `typemax(T)`) if `T <: AbstractFloat` and `zero(T)`
+        otherwise.
         """
         mutable struct $name{T,C} <: $super_type{T}
             name::String

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -1029,8 +1029,7 @@ for (loop_name, loop_super_type) in [
         The lower (resp. upper) bound of a variable of index `VariableIndex(i)`
         is at the `i`th index of the vector stored in the field `lower_bound`
         (resp. `upper_bound`). When no lower (resp. upper) bound is set, it is
-        `typemin(T)` (resp. `typemax(T)`) if `T <: AbstractFloat` and `zero(T)`
-        otherwise.
+        `typemin(T)` (resp. `typemax(T)`) if `T <: AbstractFloat`.
         """
         mutable struct $name{T,C} <: $super_type{T}
             name::String

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -4,6 +4,56 @@ const MOI = MathOptInterface
 const MOIT = MOI.Test
 const MOIU = MOI.Utilities
 
+function bound_vectors_test(::Type{T}, nolb, noub) where {T}
+    model = MOIU.Model{T}()
+    @test model.lower_bound == T[]
+    @test model.upper_bound == T[]
+    x = MOI.add_variable(model)
+    fx = MOI.SingleVariable(x)
+    @test model.lower_bound == [nolb]
+    @test model.upper_bound == [noub]
+    ux = MOI.add_constraint(model, fx, MOI.LessThan(T(1)))
+    @test model.lower_bound == [nolb]
+    @test model.upper_bound == [T(1)]
+    y = MOI.add_variable(model)
+    fy = MOI.SingleVariable(y)
+    @test model.lower_bound == [nolb, nolb]
+    @test model.upper_bound == [T(1), noub]
+    cy = MOI.add_constraint(model, fy, MOI.Interval(T(2), T(3)))
+    @test model.lower_bound == [nolb, T(2)]
+    @test model.upper_bound == [T(1), T(3)]
+    lx = MOI.add_constraint(model, fx, MOI.GreaterThan(T(0)))
+    @test model.lower_bound == [T(0), T(2)]
+    @test model.upper_bound == [T(1), T(3)]
+    MOI.delete(model, lx)
+    @test model.lower_bound == [nolb, T(2)]
+    @test model.upper_bound == [T(1), T(3)]
+    MOI.delete(model, ux)
+    @test model.lower_bound == [nolb, T(2)]
+    @test model.upper_bound == [noub, T(3)]
+    cx = MOI.add_constraint(model, fx, MOI.Semicontinuous(T(3), T(4)))
+    @test model.lower_bound == [T(3), T(2)]
+    @test model.upper_bound == [T(4), T(3)]
+    MOI.delete(model, cy)
+    @test model.lower_bound == [T(3), nolb]
+    @test model.upper_bound == [T(4), noub]
+    sy = MOI.add_constraint(model, fy, MOI.Semiinteger(T(-2), T(-1)))
+    @test model.lower_bound == [T(3), T(-2)]
+    @test model.upper_bound == [T(4), T(-1)]
+    MOI.delete(model, sy)
+    @test model.lower_bound == [T(3), nolb]
+    @test model.upper_bound == [T(4), noub]
+    ey = MOI.add_constraint(model, fy, MOI.EqualTo(T(-3)))
+    @test model.lower_bound == [T(3), T(-3)]
+    @test model.upper_bound == [T(4), T(-3)]
+    MOI.delete(model, ey)
+    @test model.lower_bound == [T(3), nolb]
+    @test model.upper_bound == [T(4), noub]
+    MOI.delete(model, cx)
+    @test model.lower_bound == [nolb, nolb]
+    @test model.upper_bound == [noub, noub]
+end
+
 @testset "Basic constraint tests" begin
     model = MOIU.Model{Float64}()
     MOIT.basic_constraint_tests(model, MOIT.TestConfig())
@@ -537,4 +587,9 @@ end
         ArgumentError,
         MOI.set(model, MOI.ConstraintFunction(), c, MOI.SingleVariable(x)),
     )
+end
+
+@testset "Bound vector" begin
+    bound_vectors_test(Int, 0, 0)
+    bound_vectors_test(Float64, -Inf, Inf)
 end


### PR DESCRIPTION
Needed for https://github.com/jump-dev/Clp.jl/pull/111. With this PR, `lower_bound` and `upper_bound` are now part of the API since it's documented so Clp can use it directly.