### PR TITLE
WIP: Refactor copy.jl

### DIFF
--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -60,6 +60,9 @@ Utilities.automatic_copy_to
 Utilities.default_copy_to
 Utilities.IndexMap
 Utilities.identity_index_map
+Utilities.pass_model_attributes
+Utilities.pass_variable_attributes
+Utilities.pass_constraint_attributes
 ```
 
 ### [Allocate-Load API](@id allocate_load_api_ref)

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -428,8 +428,9 @@ end
 function _bridge_cost(dest, ::Type{F}, ::Type{S}) where {F,S}
     # We give priority for sets such that there is a big cost reduction
     # constraining the variable on creation.
-    cost = MOI.get(dest, MOI.VariableBridgingCost{S}()) -
-           MOI.get(dest, MOI.ConstraintBridgingCost{F,S}())
+    cost =
+        MOI.get(dest, MOI.VariableBridgingCost{S}()) -
+        MOI.get(dest, MOI.ConstraintBridgingCost{F,S}())
     # In case of ties, we give priority to vector sets. See issue #987.
     return cost, F === MOI.SingleVariable
 end

--- a/src/Utilities/copy/allocate_load.jl
+++ b/src/Utilities/copy/allocate_load.jl
@@ -347,7 +347,7 @@ function _load_cache(
     dest::MOI.ModelLike,
     src::MOI.ModelLike,
     index_map::IndexMap,
-    cache::_VariableConstraintCache{MOI.SingleVariable,S}
+    cache::_VariableConstraintCache{MOI.SingleVariable,S},
 ) where {S}
     load_single_variable(
         dest,
@@ -362,7 +362,7 @@ function _load_cache(
     dest::MOI.ModelLike,
     src::MOI.ModelLike,
     index_map::IndexMap,
-    cache::_VariableConstraintCache{MOI.VectorOfVariables,S}
+    cache::_VariableConstraintCache{MOI.VectorOfVariables,S},
 ) where {S}
     load_vector_of_variables(
         dest,
@@ -404,7 +404,7 @@ function allocate_load(
         index_map,
         allocate_constrained_variables,
         allocate_constrained_variable,
-        filter_constraints
+        filter_constraints,
     )
     _pass_free_variables(dest, index_map, variables, allocate_variables)
     _pass_variable_attributes(
@@ -415,13 +415,7 @@ function allocate_load(
         variables,
         allocate,
     )
-    _pass_model_attributes(
-        dest,
-        src,
-        copy_names,
-        index_map,
-        allocate,
-    )
+    _pass_model_attributes(dest, src, copy_names, index_map, allocate)
     _pass_constraints(
         dest,
         src,

--- a/src/Utilities/copy/allocate_load.jl
+++ b/src/Utilities/copy/allocate_load.jl
@@ -407,7 +407,7 @@ function allocate_load(
         filter_constraints,
     )
     _pass_free_variables(dest, index_map, variables, allocate_variables)
-    _pass_variable_attributes(
+    pass_variable_attributes(
         dest,
         src,
         copy_names,
@@ -415,7 +415,7 @@ function allocate_load(
         variables,
         allocate,
     )
-    _pass_model_attributes(dest, src, copy_names, index_map, allocate)
+    pass_model_attributes(dest, src, copy_names, index_map, allocate)
     _pass_constraints(
         dest,
         src,
@@ -431,8 +431,8 @@ function allocate_load(
     for cache in variable_constraint_cache
         _load_cache(dest, src, index_map, cache)
     end
-    _pass_variable_attributes(dest, src, copy_names, index_map, variables, load)
-    _pass_model_attributes(dest, src, copy_names, index_map, load)
+    pass_variable_attributes(dest, src, copy_names, index_map, variables, load)
+    pass_model_attributes(dest, src, copy_names, index_map, load)
     _pass_constraints(
         dest,
         src,

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -642,75 +642,75 @@ end
     ) == 0
 end
 
-# We create a `OnlyCopyConstraints` that don't implement `add_constraint` but
-# implements `pass_nonvariable_constraints` to check that this is passed accross
-# all layers without falling back to `pass_nonvariable_constraints_fallback`
-# which calls `add_constraint`.
+# # We create a `OnlyCopyConstraints` that don't implement `add_constraint` but
+# # implements `pass_nonvariable_constraints` to check that this is passed accross
+# # all layers without falling back to `pass_nonvariable_constraints_fallback`
+# # which calls `add_constraint`.
 
-struct OnlyCopyConstraints{F,S} <: MOI.ModelLike
-    constraints::MOIU.VectorOfConstraints{F,S}
-    function OnlyCopyConstraints{F,S}() where {F,S}
-        return new{F,S}(MOIU.VectorOfConstraints{F,S}())
-    end
-end
-MOI.empty!(model::OnlyCopyConstraints) = MOI.empty!(model.constraints)
-function MOI.supports_constraint(
-    model::OnlyCopyConstraints,
-    F::Type{<:MOI.AbstractFunction},
-    S::Type{<:MOI.AbstractSet},
-)
-    return MOI.supports_constraint(model.constraints, F, S)
-end
-function MOIU.pass_nonvariable_constraints(
-    dest::OnlyCopyConstraints,
-    src::MOI.ModelLike,
-    idxmap::MOIU.IndexMap,
-    constraint_types,
-    pass_cons;
-    filter_constraints::Union{Nothing,Function} = nothing,
-)
-    return MOIU.pass_nonvariable_constraints(
-        dest.constraints,
-        src,
-        idxmap,
-        constraint_types,
-        pass_cons;
-        filter_constraints = filter_constraints,
-    )
-end
+# struct OnlyCopyConstraints{F,S} <: MOI.ModelLike
+#     constraints::MOIU.VectorOfConstraints{F,S}
+#     function OnlyCopyConstraints{F,S}() where {F,S}
+#         return new{F,S}(MOIU.VectorOfConstraints{F,S}())
+#     end
+# end
+# MOI.empty!(model::OnlyCopyConstraints) = MOI.empty!(model.constraints)
+# function MOI.supports_constraint(
+#     model::OnlyCopyConstraints,
+#     F::Type{<:MOI.AbstractFunction},
+#     S::Type{<:MOI.AbstractSet},
+# )
+#     return MOI.supports_constraint(model.constraints, F, S)
+# end
+# function MOIU.pass_nonvariable_constraints(
+#     dest::OnlyCopyConstraints,
+#     src::MOI.ModelLike,
+#     idxmap::MOIU.IndexMap,
+#     constraint_types,
+#     pass_cons;
+#     filter_constraints::Union{Nothing,Function} = nothing,
+# )
+#     return MOIU.pass_nonvariable_constraints(
+#         dest.constraints,
+#         src,
+#         idxmap,
+#         constraint_types,
+#         pass_cons;
+#         filter_constraints = filter_constraints,
+#     )
+# end
 
-function test_pass_copy(::Type{T}) where {T}
-    F = MOI.ScalarAffineFunction{T}
-    S = MOI.EqualTo{T}
-    S2 = MOI.GreaterThan{T}
-    src = MOIU.Model{T}()
-    x = MOI.add_variable(src)
-    fx = MOI.SingleVariable(x)
-    MOI.add_constraint(src, T(1) * fx, MOI.EqualTo(T(1)))
-    MOI.add_constraint(src, T(2) * fx, MOI.EqualTo(T(2)))
-    MOI.add_constraint(src, T(3) * fx, MOI.GreaterThan(T(3)))
-    MOI.add_constraint(src, T(4) * fx, MOI.GreaterThan(T(4)))
-    dest = MOIU.CachingOptimizer(
-        MOI.Bridges.full_bridge_optimizer(
-            MOIU.UniversalFallback(
-                MOIU.GenericOptimizer{T,OnlyCopyConstraints{F,S}}(),
-            ),
-            T,
-        ),
-        MOIU.AUTOMATIC,
-    )
-    MOI.copy_to(dest, src)
-    voc = dest.model_cache.model.model.constraints.constraints
-    @test MOI.get(voc, MOI.NumberOfConstraints{F,S}()) == 2
-    @test !haskey(dest.model_cache.model.constraints, (F, S))
-    @test MOI.get(dest, MOI.NumberOfConstraints{F,S2}()) == 2
-    @test haskey(dest.model_cache.model.constraints, (F, S2))
-end
+# function test_pass_copy(::Type{T}) where {T}
+#     F = MOI.ScalarAffineFunction{T}
+#     S = MOI.EqualTo{T}
+#     S2 = MOI.GreaterThan{T}
+#     src = MOIU.Model{T}()
+#     x = MOI.add_variable(src)
+#     fx = MOI.SingleVariable(x)
+#     MOI.add_constraint(src, T(1) * fx, MOI.EqualTo(T(1)))
+#     MOI.add_constraint(src, T(2) * fx, MOI.EqualTo(T(2)))
+#     MOI.add_constraint(src, T(3) * fx, MOI.GreaterThan(T(3)))
+#     MOI.add_constraint(src, T(4) * fx, MOI.GreaterThan(T(4)))
+#     dest = MOIU.CachingOptimizer(
+#         MOI.Bridges.full_bridge_optimizer(
+#             MOIU.UniversalFallback(
+#                 MOIU.GenericOptimizer{T,OnlyCopyConstraints{F,S}}(),
+#             ),
+#             T,
+#         ),
+#         MOIU.AUTOMATIC,
+#     )
+#     MOI.copy_to(dest, src)
+#     voc = dest.model_cache.model.model.constraints.constraints
+#     @test MOI.get(voc, MOI.NumberOfConstraints{F,S}()) == 2
+#     @test !haskey(dest.model_cache.model.constraints, (F, S))
+#     @test MOI.get(dest, MOI.NumberOfConstraints{F,S2}()) == 2
+#     @test haskey(dest.model_cache.model.constraints, (F, S2))
+# end
 
-@testset "copy of constraints passed as copy accross layers" begin
-    test_pass_copy(Int)
-    test_pass_copy(Float64)
-end
+# @testset "copy of constraints passed as copy accross layers" begin
+#     test_pass_copy(Int)
+#     test_pass_copy(Float64)
+# end
 
 @testset "identity_index_map" begin
     identity_index_map_test(Int)


### PR DESCRIPTION
Still WIP because I hoped this would be easier to precompile, but it's essentially the same, so I'll keep attacking.

Breaking changes
 - [ ] `pass_attributes` renamed to `pass_model_attributes`, `pass_variable_attributes` and `pass_constraint_attributes`. Needs deprecations.
 - [ ] `pass_nonvariable_constraints` was removed.
 - [ ] Lots of other functions renamed to make private.