### PR TITLE
Fix an inference issue in Bridges

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -20,12 +20,12 @@ include("lazy_bridge_optimizer.jl")
 include("debug.jl")
 
 """
-    full_bridge_optimizer(model::MOI.ModelLike, ::Type{T}) where T
+    full_bridge_optimizer(model::MOI.ModelLike, ::Type{T}) where {T}
 
 Returns a `LazyBridgeOptimizer` bridging `model` for every bridge defined in
 this package and for the coefficient type `T`.
 """
-function full_bridge_optimizer(model::MOI.ModelLike, T::Type)
+function full_bridge_optimizer(model::MOI.ModelLike, ::Type{T}) where {T}
     bridged_model = LazyBridgeOptimizer(model)
     Variable.add_all_bridges(bridged_model, T)
     Constraint.add_all_bridges(bridged_model, T)

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -92,7 +92,7 @@ include("zero_one.jl")
 const ZeroOne{T,OT<:MOI.ModelLike} = SingleBridgeOptimizer{ZeroOneBridge{T},OT}
 
 """
-    add_all_bridges(bridged_model, ::Type{T})
+    add_all_bridges(bridged_model, ::Type{T}) where {T}
 
 Add all bridges defined in the `Bridges.Constraint` submodule to
 `bridged_model`. The coefficient type used is `T`.

--- a/src/Bridges/Objective/Objective.jl
+++ b/src/Bridges/Objective/Objective.jl
@@ -22,12 +22,12 @@ include("slack.jl")
 const Slack{T,OT<:MOI.ModelLike} = SingleBridgeOptimizer{SlackBridge{T},OT}
 
 """
-    add_all_bridges(bridged_model, T::Type)
+    add_all_bridges(bridged_model, ::Type{T}) where {T}
 
 Add all bridges defined in the `Bridges.Objective` submodule to `bridged_model`.
 The coefficient type used is `T`.
 """
-function add_all_bridges(bridged_model, T::Type)
+function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOIB.add_bridge(bridged_model, FunctionizeBridge{T})
     MOIB.add_bridge(bridged_model, SlackBridge{T})
     return

--- a/src/Bridges/Variable/Variable.jl
+++ b/src/Bridges/Variable/Variable.jl
@@ -49,12 +49,12 @@ const RSOCtoPSD{T,OT<:MOI.ModelLike} =
     SingleBridgeOptimizer{RSOCtoPSDBridge{T},OT}
 
 """
-    add_all_bridges(bridged_model, T::Type)
+    add_all_bridges(bridged_model, ::Type{T}) where {T}
 
 Add all bridges defined in the `Bridges.Variable` submodule to `bridged_model`.
 The coefficient type used is `T`.
 """
-function add_all_bridges(bridged_model, T::Type)
+function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOIB.add_bridge(bridged_model, ZerosBridge{T})
     MOIB.add_bridge(bridged_model, FreeBridge{T})
     MOIB.add_bridge(bridged_model, NonposToNonnegBridge{T})


### PR DESCRIPTION
Before
```Julia

julia> using SnoopCompile

julia> using GLPK

julia> f() = GLPK.MOI.Bridges.full_bridge_optimizer(GLPK.Optimizer(), Float64)
f (generic function with 1 method)

julia> tinf = @snoopi_deep f()
InferenceTimingNode: 0.480379/1.063381 on InferenceFrameInfo for Core.Compiler.Timings.ROOT() with 5 direct children

julia> itrigs = inference_triggers(tinf)
5-element Vector{InferenceTrigger}:
 Inference triggered to call MethodInstance for f() from eval (./boot.jl:360) inlined into MethodInstance for eval_user_input(::Any, ::REPL.REPLBackend) (/Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:139)
 Inference triggered to call MethodInstance for add_all_bridges(::MathOptInterface.Bridges.LazyBridgeOptimizer{GLPK.Optimizer}, ::Type) from full_bridge_optimizer (/Users/oscar/.julia/dev/MathOptInterface/src/Bridges/Bridges.jl:30) inlined into MethodInstance for f() (./REPL[3]:1)
 Inference triggered to call MethodInstance for (::Base.Fix2{typeof(isequal), DataType})(::Type) from findnext (./array.jl:1855) with specialization MethodInstance for findnext(::Base.Fix2{typeof(isequal), DataType}, ::Vector{Any}, ::Int64)
 Inference triggered to call MethodInstance for (::Base.Fix2{typeof(isequal), UnionAll})(::Type) from findnext (./array.jl:1855) with specialization MethodInstance for findnext(::Base.Fix2{typeof(isequal), UnionAll}, ::Vector{Any}, ::Int64)
 Inference triggered to call MethodInstance for add_all_bridges(::MathOptInterface.Bridges.LazyBridgeOptimizer{GLPK.Optimizer}, ::Type) from full_bridge_optimizer (/Users/oscar/.julia/dev/MathOptInterface/src/Bridges/Bridges.jl:32) inlined into MethodInstance for f() (./REPL[3]:1)
```

After 

```Julia
julia> using SnoopCompile

julia> using GLPK

julia> f() = GLPK.MOI.Bridges.full_bridge_optimizer(GLPK.Optimizer(), Float64)
f (generic function with 1 method)

julia> tinf = @snoopi_deep f()
InferenceTimingNode: 0.423174/0.902199 on InferenceFrameInfo for Core.Compiler.Timings.ROOT() with 3 direct children

julia> itrigs = inference_triggers(tinf)
3-element Vector{InferenceTrigger}:
 Inference triggered to call MethodInstance for f() from eval (./boot.jl:360) inlined into MethodInstance for eval_user_input(::Any, ::REPL.REPLBackend) (/Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:139)
 Inference triggered to call MethodInstance for (::Base.Fix2{typeof(isequal), DataType})(::Type) from findnext (./array.jl:1855) with specialization MethodInstance for findnext(::Base.Fix2{typeof(isequal), DataType}, ::Vector{Any}, ::Int64)
 Inference triggered to call MethodInstance for (::Base.Fix2{typeof(isequal), UnionAll})(::Type) from findnext (./array.jl:1855) with specialization MethodInstance for findnext(::Base.Fix2{typeof(isequal), UnionAll}, ::Vector{Any}, ::Int64)
```