### PR TITLE
Simplify ListOfConstraintTypesPresent in Bridges

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -700,19 +700,20 @@ function MOI.get(
     b::AbstractBridgeOptimizer,
     attr::MOI.ListOfConstraintTypesPresent,
 )
-    list_of_types = Set(MOI.get(b.model, attr))
+    list_of_types = MOI.get(b.model, attr)
     if Constraint.has_bridges(Constraint.bridges(b))
-        union!(
+        append!(
             list_of_types,
-            Constraint.list_of_key_types(Constraint.bridges(b))
+            Constraint.list_of_key_types(Constraint.bridges(b)),
         )
     end
     if Variable.has_bridges(Variable.bridges(b))
-        union!(
+        append!(
             list_of_types,
             Variable.list_of_constraint_types(Variable.bridges(b)),
         )
     end
+    unique!(list_of_types)
     # Some constraint types show up in `list_of_types` including when all the
     # constraints of that type have been created by bridges and not by the user.
     # The code in `NumberOfConstraints` takes care of removing these constraints
@@ -720,7 +721,7 @@ function MOI.get(
     filter!(list_of_types) do (F, S)
         return MOI.get(b, MOI.NumberOfConstraints{F,S}()) > 0
     end
-    return collect(list_of_types)
+    return list_of_types
 end
 
 # Model an optimizer attributes


### PR DESCRIPTION
Big reduction in the amount of compiled code and the elimination of a type instability (the compiler couldn't prove the type in `map` due to `FS...`. 

Before

```julia
julia> using MathOptInterface

julia> const MOI = MathOptInterface
MathOptInterface

julia> using GLPK

julia> model = MOI.Bridges.full_bridge_optimizer(GLPK.Optimizer(), Float64)
MOIB.LazyBridgeOptimizer{GLPK.Optimizer}
with 0 variable bridges
with 0 constraint bridges
with 0 objective bridges
with inner model A GLPK model

julia> @time MOI.get(model, MOI.ListOfConstraintTypesPresent())
  1.158660 seconds (3.68 M allocations: 215.417 MiB, 12.50% gc time)
Tuple{DataType, DataType}[]

julia> @time MOI.get(model, MOI.ListOfConstraintTypesPresent())
  0.000021 seconds (11 allocations: 1.016 KiB)
Tuple{DataType, DataType}[]
```

After

```Julia
julia> using MathOptInterface

julia> const MOI = MathOptInterface
MathOptInterface

julia> using GLPK

julia> model = MOI.Bridges.full_bridge_optimizer(GLPK.Optimizer(), Float64)
MOIB.LazyBridgeOptimizer{GLPK.Optimizer}
with 0 variable bridges
with 0 constraint bridges
with 0 objective bridges
with inner model A GLPK model

julia> @time MOI.get(model, MOI.ListOfConstraintTypesPresent())
  0.896201 seconds (2.82 M allocations: 162.893 MiB, 13.97% gc time)
Tuple{DataType, DataType}[]

julia> @time MOI.get(model, MOI.ListOfConstraintTypesPresent())
  0.000007 seconds (5 allocations: 688 bytes)
Tuple{DataType, DataType}[]
```

