### PR TITLE
Ensure bridges return vectors that can be modified by the user

### DIFF
--- a/src/Bridges/Constraint/det.jl
+++ b/src/Bridges/Constraint/det.jl
@@ -255,7 +255,7 @@ function MOI.get(
         MOI.ExponentialCone,
     },
 ) where {T}
-    return b.lcindex
+    return copy(b.lcindex)
 end
 
 function MOI.get(
@@ -409,7 +409,7 @@ end
 # Attributes, Bridge acting as a model
 MOI.get(b::RootDetBridge, ::MOI.NumberOfVariables) = length(b.Δ)
 
-MOI.get(b::RootDetBridge, ::MOI.ListOfVariableIndices) = b.Δ
+MOI.get(b::RootDetBridge, ::MOI.ListOfVariableIndices) = copy(b.Δ)
 
 function MOI.get(
     ::RootDetBridge{T},

--- a/src/Bridges/Constraint/geomean.jl
+++ b/src/Bridges/Constraint/geomean.jl
@@ -170,7 +170,7 @@ end
 # Attributes, Bridge acting as a model
 MOI.get(b::GeoMeanBridge, ::MOI.NumberOfVariables) = length(b.xij)
 
-MOI.get(b::GeoMeanBridge, ::MOI.ListOfVariableIndices) = b.xij
+MOI.get(b::GeoMeanBridge, ::MOI.ListOfVariableIndices) = copy(b.xij)
 
 function MOI.get(
     ::GeoMeanBridge{T,F},
@@ -204,7 +204,7 @@ function MOI.get(
     b::GeoMeanBridge{T,F,G},
     ::MOI.ListOfConstraintIndices{G,MOI.RotatedSecondOrderCone},
 ) where {T,F,G}
-    return b.socrc
+    return copy(b.socrc)
 end
 
 function MOI.get(

--- a/src/Bridges/Constraint/norm_to_lp.jl
+++ b/src/Bridges/Constraint/norm_to_lp.jl
@@ -144,7 +144,7 @@ end
 
 # Attributes, Bridge acting as a model
 MOI.get(b::NormOneBridge, ::MOI.NumberOfVariables) = length(b.y)
-MOI.get(b::NormOneBridge, ::MOI.ListOfVariableIndices) = b.y
+MOI.get(b::NormOneBridge, ::MOI.ListOfVariableIndices) = copy(b.y)
 function MOI.get(
     b::NormOneBridge{T,F},
     ::MOI.NumberOfConstraints{F,MOI.Nonnegatives},

--- a/src/Bridges/Constraint/relentr_to_exp.jl
+++ b/src/Bridges/Constraint/relentr_to_exp.jl
@@ -84,7 +84,11 @@ end
 function MOI.get(bridge::RelativeEntropyBridge, ::MOI.NumberOfVariables)
     return length(bridge.y)
 end
-MOI.get(bridge::RelativeEntropyBridge, ::MOI.ListOfVariableIndices) = bridge.y
+
+function MOI.get(bridge::RelativeEntropyBridge, ::MOI.ListOfVariableIndices)
+    return copy(bridge.y)
+end
+
 function MOI.get(
     bridge::RelativeEntropyBridge{T,F},
     ::MOI.NumberOfConstraints{F,MOI.GreaterThan{T}},
@@ -110,7 +114,7 @@ function MOI.get(
     bridge::RelativeEntropyBridge{T,F,G},
     ::MOI.ListOfConstraintIndices{G,MOI.ExponentialCone},
 ) where {T,F,G}
-    return bridge.exp_indices
+    return copy(bridge.exp_indices)
 end
 
 # References

--- a/src/Bridges/Constraint/scalarize.jl
+++ b/src/Bridges/Constraint/scalarize.jl
@@ -66,7 +66,7 @@ function MOI.get(
     bridge::ScalarizeBridge{T,F,S},
     ::MOI.ListOfConstraintIndices{F,S},
 ) where {T,F,S}
-    return bridge.scalar_constraints
+    return copy(bridge.scalar_constraints)
 end
 
 # References

--- a/src/Bridges/Constraint/slack.jl
+++ b/src/Bridges/Constraint/slack.jl
@@ -313,7 +313,7 @@ end
 
 # Attributes, Bridge acting as a model
 MOI.get(b::VectorSlackBridge, ::MOI.NumberOfVariables) = length(b.slack)
-MOI.get(b::VectorSlackBridge, ::MOI.ListOfVariableIndices) = b.slack
+MOI.get(b::VectorSlackBridge, ::MOI.ListOfVariableIndices) = copy(b.slack)
 
 # Attributes, Bridge acting as a constraint
 function MOI.set(

--- a/src/Bridges/Constraint/soc_to_nonconvex_quad.jl
+++ b/src/Bridges/Constraint/soc_to_nonconvex_quad.jl
@@ -200,7 +200,7 @@ function MOI.get(
         MOI.GreaterThan{T},
     },
 ) where {T}
-    return bridge.var_pos
+    return copy(bridge.var_pos)
 end
 
 # References

--- a/src/Bridges/Variable/flip_sign.jl
+++ b/src/Bridges/Variable/flip_sign.jl
@@ -32,7 +32,7 @@ function MOI.get(bridge::FlipSignBridge, ::MOI.NumberOfVariables)
 end
 
 function MOI.get(bridge::FlipSignBridge, ::MOI.ListOfVariableIndices)
-    return bridge.flipped_variables
+    return copy(bridge.flipped_variables)
 end
 
 function MOI.get(

--- a/src/Bridges/Variable/free.jl
+++ b/src/Bridges/Variable/free.jl
@@ -39,7 +39,7 @@ function MOI.get(bridge::FreeBridge, ::MOI.NumberOfVariables)
 end
 
 function MOI.get(bridge::FreeBridge, ::MOI.ListOfVariableIndices)
-    return vcat(bridge.variables)
+    return copy(bridge.variables)
 end
 
 function MOI.get(

--- a/src/Bridges/Variable/rsoc_to_psd.jl
+++ b/src/Bridges/Variable/rsoc_to_psd.jl
@@ -91,7 +91,7 @@ function MOI.get(bridge::RSOCtoPSDBridge, ::MOI.NumberOfVariables)
 end
 
 function MOI.get(bridge::RSOCtoPSDBridge, ::MOI.ListOfVariableIndices)
-    return bridge.variables
+    return copy(bridge.variables)
 end
 
 function MOI.get(
@@ -123,7 +123,7 @@ function MOI.get(
     bridge::RSOCtoPSDBridge{T},
     ::MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.EqualTo{T}},
 ) where {T}
-    return bridge.off_diag
+    return copy(bridge.off_diag)
 end
 
 function MOI.get(
@@ -137,7 +137,7 @@ function MOI.get(
     bridge::RSOCtoPSDBridge{T},
     ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
 ) where {T}
-    return bridge.diag
+    return copy(bridge.diag)
 end
 
 # References

--- a/src/Bridges/Variable/rsoc_to_soc.jl
+++ b/src/Bridges/Variable/rsoc_to_soc.jl
@@ -109,7 +109,7 @@ function MOI.get(bridge::RSOCtoSOCBridge, ::MOI.NumberOfVariables)
 end
 
 function MOI.get(bridge::RSOCtoSOCBridge, ::MOI.ListOfVariableIndices)
-    return bridge.variables
+    return copy(bridge.variables)
 end
 
 function MOI.get(

--- a/src/Bridges/Variable/soc_to_rsoc.jl
+++ b/src/Bridges/Variable/soc_to_rsoc.jl
@@ -44,7 +44,7 @@ function MOI.get(bridge::SOCtoRSOCBridge, ::MOI.NumberOfVariables)
 end
 
 function MOI.get(bridge::SOCtoRSOCBridge, ::MOI.ListOfVariableIndices)
-    return bridge.variables
+    return copy(bridge.variables)
 end
 
 function MOI.get(

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -632,7 +632,8 @@ function get_all_including_bridged(
 )
     list = MOI.get(b.model, attr)
     if !isempty(Variable.bridges(b))
-        return vcat(list, keys(Variable.bridges(b)))
+        # The conversion from `keys` into a `Vector` happens inside `append!`.
+        append!(list, keys(Variable.bridges(b)))
     end
     return list
 end

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -632,8 +632,7 @@ function get_all_including_bridged(
 )
     list = MOI.get(b.model, attr)
     if !isempty(Variable.bridges(b))
-        # TODO(odow): Fix this!
-        list = append!(copy(list), keys(Variable.bridges(b)))
+        return vcat(list, keys(Variable.bridges(b)))
     end
     return list
 end


### PR DESCRIPTION
Closes #1346 

The current behavior was ripe for introducing bugs. 

In addition, the `copy(list)` in `bridge_optimizer` was unnecessary for most bridges, which just return `[variable]`, so removing it avoids an unnecessary copy in those cases, and maintains the same number of copies for the ones modified here.