### PR TITLE
[bridges] unify IndexInVector

### DIFF
--- a/src/Bridges/Constraint/bridge.jl
+++ b/src/Bridges/Constraint/bridge.jl
@@ -7,15 +7,6 @@ bridges.
 abstract type AbstractBridge <: MOIB.AbstractBridge end
 
 """
-    IndexInVector
-
-Index of variable in vector of variables.
-"""
-struct IndexInVector
-    value::Int
-end
-
-"""
     bridge_constraint(
         BT::Type{<:AbstractBridge},
         model::MOI.ModelLike,

--- a/src/Bridges/Constraint/bridge.jl
+++ b/src/Bridges/Constraint/bridge.jl
@@ -6,7 +6,6 @@ bridges.
 """
 abstract type AbstractBridge <: MOIB.AbstractBridge end
 
-# TODO [breaking] merge with `Bridges.Variable.IndexInVector` into `Bridges.IndexInVector`
 """
     IndexInVector
 

--- a/src/Bridges/Constraint/flip_sign.jl
+++ b/src/Bridges/Constraint/flip_sign.jl
@@ -32,7 +32,7 @@ end
 function MOI.delete(
     model::MOI.ModelLike,
     bridge::FlipSignBridge,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     func = MOI.get(model, MOI.ConstraintFunction(), bridge.constraint)
     idx = setdiff(1:MOI.output_dimension(func), i.value)

--- a/src/Bridges/Constraint/functionize.jl
+++ b/src/Bridges/Constraint/functionize.jl
@@ -171,7 +171,7 @@ end
 function MOI.delete(
     model::MOI.ModelLike,
     bridge::VectorFunctionizeBridge,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     func = MOI.get(model, MOI.ConstraintFunction(), bridge.constraint)
     idx = setdiff(1:MOI.output_dimension(func), i.value)

--- a/src/Bridges/Constraint/scalarize.jl
+++ b/src/Bridges/Constraint/scalarize.jl
@@ -79,7 +79,7 @@ end
 function MOI.delete(
     model::MOI.ModelLike,
     bridge::ScalarizeBridge,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     MOI.delete(model, bridge.scalar_constraints[i.value])
     deleteat!(bridge.scalar_constraints, i.value)

--- a/src/Bridges/Variable/bridge.jl
+++ b/src/Bridges/Variable/bridge.jl
@@ -7,15 +7,6 @@ bridges.
 abstract type AbstractBridge <: MOIB.AbstractBridge end
 
 """
-    IndexInVector
-
-Index of variable in vector of variables.
-"""
-struct IndexInVector
-    value::Int
-end
-
-"""
     bridge_constrained_variable(
         BT::Type{<:AbstractBridge},
         model::MOI.ModelLike,
@@ -56,7 +47,7 @@ end
         model::MOI.ModelLike,
         attr::MOI.AbstractVariableAttribute,
         bridge::AbstractBridge,
-        i::IndexInVector,
+        i::MOIB.IndexInVector,
     )
 
 Return the value of the attribute `attr` of the model `model` for the variable
@@ -66,7 +57,7 @@ function MOI.get(
     ::MOI.ModelLike,
     attr::MOI.AbstractVariableAttribute,
     bridge::AbstractBridge,
-    ::IndexInVector,
+    ::MOIB.IndexInVector,
 )
     return throw(
         ArgumentError(
@@ -98,7 +89,7 @@ end
         attr::MOI.AbstractVariableAttribute,
         bridge::AbstractBridge,
         value[,
-        ::IndexInVector],
+        ::MOIB.IndexInVector],
     )
 
 Return the value of the attribute `attr` of the model `model` for the variable
@@ -109,7 +100,7 @@ function MOI.set(
     attr::MOI.AbstractVariableAttribute,
     bridge::AbstractBridge,
     value,
-    ::IndexInVector...,
+    ::MOIB.IndexInVector...,
 )
     if MOI.is_copyable(attr) && !MOI.supports(model, attr, typeof(bridge))
         throw(MOI.UnsupportedAttribute(attr))
@@ -271,7 +262,7 @@ the following method for every variable of `vis`.
     unbridged_map(
         bridge::MOI.Bridges.Variable.AbstractBridge,
         vi::MOI.VariableIndex,
-        i::IndexInVector,
+        i::MOIB.IndexInVector,
     )
 
 For a bridged variable in a vector set, return a tuple of pairs mapping the
@@ -287,7 +278,7 @@ function unbridged_map end
 function unbridged_map(bridge::AbstractBridge, vis::Vector{MOI.VariableIndex})
     mappings = Pair{MOI.VariableIndex,MOI.AbstractScalarFunction}[]
     for (i, vi) in enumerate(vis)
-        vi_mappings = unbridged_map(bridge, vi, IndexInVector(i))
+        vi_mappings = unbridged_map(bridge, vi, MOIB.IndexInVector(i))
         if vi_mappings === nothing
             return
         end

--- a/src/Bridges/Variable/flip_sign.jl
+++ b/src/Bridges/Variable/flip_sign.jl
@@ -58,7 +58,7 @@ end
 function MOI.delete(
     model::MOI.ModelLike,
     bridge::FlipSignBridge,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     MOI.delete(model, bridge.flipped_variables[i.value])
     deleteat!(bridge.flipped_variables, i.value)
@@ -86,14 +86,14 @@ function MOI.get(
     model::MOI.ModelLike,
     attr::Union{MOI.VariablePrimal,MOI.VariablePrimalStart},
     bridge::FlipSignBridge,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     return -MOI.get(model, attr, bridge.flipped_variables[i.value])
 end
 
 function MOIB.bridged_function(
     bridge::FlipSignBridge{T},
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 ) where {T}
     func = MOI.SingleVariable(bridge.flipped_variables[i.value])
     return MOIU.operate(-, T, func)
@@ -102,7 +102,7 @@ end
 function unbridged_map(
     bridge::FlipSignBridge{T},
     vi::MOI.VariableIndex,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 ) where {T}
     func = MOIU.operate(-, T, MOI.SingleVariable(vi))
     return (bridge.flipped_variables[i.value] => func,)
@@ -121,7 +121,7 @@ function MOI.set(
     attr::MOI.VariablePrimalStart,
     bridge::FlipSignBridge,
     value,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     MOI.set(model, attr, bridge.flipped_variables[i.value], -value)
     return

--- a/src/Bridges/Variable/free.jl
+++ b/src/Bridges/Variable/free.jl
@@ -62,7 +62,11 @@ function MOI.delete(model::MOI.ModelLike, bridge::FreeBridge)
     return
 end
 
-function MOI.delete(model::MOI.ModelLike, bridge::FreeBridge, i::MOIB.IndexInVector)
+function MOI.delete(
+    model::MOI.ModelLike,
+    bridge::FreeBridge,
+    i::MOIB.IndexInVector,
+)
     n = div(length(bridge.variables), 2)
     MOI.delete(model, bridge.variables[i.value])
     MOI.delete(model, bridge.variables[n+i.value])

--- a/src/Bridges/Variable/free.jl
+++ b/src/Bridges/Variable/free.jl
@@ -62,7 +62,7 @@ function MOI.delete(model::MOI.ModelLike, bridge::FreeBridge)
     return
 end
 
-function MOI.delete(model::MOI.ModelLike, bridge::FreeBridge, i::IndexInVector)
+function MOI.delete(model::MOI.ModelLike, bridge::FreeBridge, i::MOIB.IndexInVector)
     n = div(length(bridge.variables), 2)
     MOI.delete(model, bridge.variables[i.value])
     MOI.delete(model, bridge.variables[n+i.value])
@@ -101,7 +101,7 @@ function MOI.get(
     model::MOI.ModelLike,
     attr::Union{MOI.VariablePrimal,MOI.VariablePrimalStart},
     bridge::FreeBridge{T},
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 ) where {T}
     n = div(length(bridge.variables), 2)
     return MOI.get(model, attr, bridge.variables[i.value]) -
@@ -110,7 +110,7 @@ end
 
 function MOIB.bridged_function(
     bridge::FreeBridge{T},
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 ) where {T}
     n = div(length(bridge.variables), 2)
     return MOIU.operate(
@@ -126,7 +126,7 @@ end
 function unbridged_map(
     bridge::FreeBridge{T},
     vi::MOI.VariableIndex,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 ) where {T}
     sv = MOI.SingleVariable(vi)
     # `unbridged_map` is required to return a `MOI.ScalarAffineFunction`.
@@ -149,7 +149,7 @@ function MOI.set(
     attr::MOI.VariablePrimalStart,
     bridge::FreeBridge,
     value,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     if value < 0
         nonneg = zero(value)

--- a/src/Bridges/Variable/map.jl
+++ b/src/Bridges/Variable/map.jl
@@ -261,12 +261,12 @@ function length_of_vector_of_variables(map::Map, vi::MOI.VariableIndex)
 end
 
 """
-    index_in_vector_of_variables(map::Map, vi::MOI.VariableIndex)::IndexInVector
+    index_in_vector_of_variables(map::Map, vi::MOI.VariableIndex)::MOIB.IndexInVector
 
 Return the index of `vi` in the vector of variables in which it was bridged.
 """
 function index_in_vector_of_variables(map::Map, vi::MOI.VariableIndex)
-    return IndexInVector(map.index_in_vector[-vi.value])
+    return MOIB.IndexInVector(map.index_in_vector[-vi.value])
 end
 
 """

--- a/src/Bridges/Variable/rsoc_to_psd.jl
+++ b/src/Bridges/Variable/rsoc_to_psd.jl
@@ -169,7 +169,7 @@ function trimap(i::Integer, j::Integer)
     end
 end
 
-function _variable_map(bridge::RSOCtoPSDBridge, i::IndexInVector)
+function _variable_map(bridge::RSOCtoPSDBridge, i::MOIB.IndexInVector)
     if bridge.psd isa
        MOI.ConstraintIndex{MOI.VectorOfVariables,MOI.Nonnegatives}
         return i.value
@@ -182,7 +182,7 @@ function _variable_map(bridge::RSOCtoPSDBridge, i::IndexInVector)
     end
 end
 
-function _variable(bridge::RSOCtoPSDBridge, i::IndexInVector)
+function _variable(bridge::RSOCtoPSDBridge, i::MOIB.IndexInVector)
     return bridge.variables[_variable_map(bridge, i)]
 end
 
@@ -193,7 +193,7 @@ function MOI.get(
 )
     values = MOI.get(model, attr, bridge.psd)
     n = MOI.dimension(MOI.get(model, MOI.ConstraintSet(), bridge))
-    mapped = [values[_variable_map(bridge, IndexInVector(i))] for i in 1:n]
+    mapped = [values[_variable_map(bridge, MOIB.IndexInVector(i))] for i in 1:n]
     if length(mapped) >= 2
         mapped[2] /= 2
     end
@@ -207,7 +207,7 @@ function MOI.get(
 )
     dual = MOI.get(model, attr, bridge.psd)
     n = MOI.dimension(MOI.get(model, MOI.ConstraintSet(), bridge))
-    mapped = [dual[_variable_map(bridge, IndexInVector(i))] for i in 1:n]
+    mapped = [dual[_variable_map(bridge, MOIB.IndexInVector(i))] for i in 1:n]
     for ci in bridge.diag
         mapped[2] += MOI.get(model, attr, ci)
     end
@@ -224,7 +224,7 @@ function MOI.get(
     model::MOI.ModelLike,
     attr::MOI.VariablePrimal,
     bridge::RSOCtoPSDBridge,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     value = MOI.get(model, attr, _variable(bridge, i))
     if i.value == 2
@@ -236,7 +236,7 @@ end
 
 function MOIB.bridged_function(
     bridge::RSOCtoPSDBridge{T},
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 ) where {T}
     func = MOI.SingleVariable(_variable(bridge, i))
     if i.value == 2
@@ -249,7 +249,7 @@ end
 function unbridged_map(
     bridge::RSOCtoPSDBridge{T},
     vi::MOI.VariableIndex,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 ) where {T}
     sv = MOI.SingleVariable(vi)
     if i.value == 2

--- a/src/Bridges/Variable/rsoc_to_soc.jl
+++ b/src/Bridges/Variable/rsoc_to_soc.jl
@@ -13,7 +13,7 @@ function rotate_result(
     model,
     attr::MOI.VariablePrimal,
     variables,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     if i.value == 1 || i.value == 2
         t, u = MOI.get(model, attr, variables[1:2])
@@ -29,7 +29,7 @@ function rotate_result(
     end
 end
 
-function rotate_bridged_function(T::Type, variables, i::IndexInVector)
+function rotate_bridged_function(T::Type, variables, i::MOIB.IndexInVector)
     s2 = √T(2)
     if i.value == 1 || i.value == 2
         t = MOIU.operate(/, T, MOI.SingleVariable(variables[1]), s2)
@@ -154,14 +154,14 @@ function MOI.get(
     model::MOI.ModelLike,
     attr::MOI.VariablePrimal,
     bridge::RSOCtoSOCBridge,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     return rotate_result(model, attr, bridge.variables, i)
 end
 
 function MOIB.bridged_function(
     bridge::RSOCtoSOCBridge{T},
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 ) where {T}
     return rotate_bridged_function(T, bridge.variables, i)
 end

--- a/src/Bridges/Variable/soc_to_rsoc.jl
+++ b/src/Bridges/Variable/soc_to_rsoc.jl
@@ -92,14 +92,14 @@ function MOI.get(
     model::MOI.ModelLike,
     attr::MOI.VariablePrimal,
     bridge::SOCtoRSOCBridge,
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 )
     return rotate_result(model, attr, bridge.variables, i)
 end
 
 function MOIB.bridged_function(
     bridge::SOCtoRSOCBridge{T},
-    i::IndexInVector,
+    i::MOIB.IndexInVector,
 ) where {T}
     return rotate_bridged_function(T, bridge.variables, i)
 end

--- a/src/Bridges/Variable/zeros.jl
+++ b/src/Bridges/Variable/zeros.jl
@@ -76,4 +76,6 @@ function MOIB.bridged_function(::ZerosBridge{T}, ::MOIB.IndexInVector) where {T}
     return zero(MOI.ScalarAffineFunction{T})
 end
 
-unbridged_map(::ZerosBridge, ::MOI.VariableIndex, ::MOIB.IndexInVector) = nothing
+function unbridged_map(::ZerosBridge, ::MOI.VariableIndex, ::MOIB.IndexInVector)
+    return nothing
+end

--- a/src/Bridges/Variable/zeros.jl
+++ b/src/Bridges/Variable/zeros.jl
@@ -67,13 +67,13 @@ function MOI.get(
     ::MOI.ModelLike,
     ::MOI.VariablePrimal,
     ::ZerosBridge{T},
-    ::IndexInVector,
+    ::MOIB.IndexInVector,
 ) where {T}
     return zero(T)
 end
 
-function MOIB.bridged_function(::ZerosBridge{T}, ::IndexInVector) where {T}
+function MOIB.bridged_function(::ZerosBridge{T}, ::MOIB.IndexInVector) where {T}
     return zero(MOI.ScalarAffineFunction{T})
 end
 
-unbridged_map(::ZerosBridge, ::MOI.VariableIndex, ::IndexInVector) = nothing
+unbridged_map(::ZerosBridge, ::MOI.VariableIndex, ::MOIB.IndexInVector) = nothing

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -20,6 +20,15 @@ the bridge so they should be implemented by the bridge.
 abstract type AbstractBridge end
 
 """
+    IndexInVector
+
+Index of variable in vector of variables.
+"""
+struct IndexInVector
+    value::Int
+end
+
+"""
     MOI.get(b::AbstractBridge, ::MOI.NumberOfConstraints{F, S}) where {F, S}
 
 The number of constraints of the type `F`-in-`S` created by the bridge `b` in

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -440,7 +440,7 @@ function _delete_variables_in_vector_of_variables_constraint(
                         b,
                         ci,
                         bridge ->
-                            MOI.delete(b, bridge, Constraint.IndexInVector(i)),
+                            MOI.delete(b, bridge, IndexInVector(i)),
                     )
                 else
                     MOIU.throw_delete_variable_in_vov(vi)

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -439,8 +439,7 @@ function _delete_variables_in_vector_of_variables_constraint(
                     call_in_context(
                         b,
                         ci,
-                        bridge ->
-                            MOI.delete(b, bridge, IndexInVector(i)),
+                        bridge -> MOI.delete(b, bridge, IndexInVector(i)),
                     )
                 else
                     MOIU.throw_delete_variable_in_vov(vi)

--- a/test/Bridges/Variable/bridge.jl
+++ b/test/Bridges/Variable/bridge.jl
@@ -13,7 +13,7 @@ struct DummyVariableBridge <: MOIB.Variable.AbstractBridge end
     bridge = DummyVariableBridge()
     attr = MOI.VariablePrimalStart()
     @test !MOI.supports(model, attr, typeof(bridge))
-    i = MOIB.Variable.IndexInVector(1)
+    i = MOIB.IndexInVector(1)
     @test_throws MOI.UnsupportedAttribute(attr) MOI.set(
         model,
         attr,

--- a/test/Bridges/Variable/map.jl
+++ b/test/Bridges/Variable/map.jl
@@ -65,7 +65,7 @@ v2, c2 = MOIB.Variable.add_keys_for_bridge(map, () -> b2, set2)
         @test MOIB.Variable.constrained_set(map, v2[i]) == S2
         @test MOIB.Variable.length_of_vector_of_variables(map, v2[i]) == 4
         @test MOIB.Variable.index_in_vector_of_variables(map, v2[i]) ==
-              MOIB.Variable.IndexInVector(i)
+              MOIB.IndexInVector(i)
     end
     @test MOIB.Variable.number_with_set(map, S2) == 1
     @test MOIB.Variable.constraints_with_set(map, S2) == [c2]
@@ -155,7 +155,7 @@ end
         @test MOIB.Variable.constrained_set(map, v2[i]) == S2
         @test MOIB.Variable.length_of_vector_of_variables(map, v2[i]) == 3
         @test MOIB.Variable.index_in_vector_of_variables(map, v2[i]) ==
-              MOIB.Variable.IndexInVector(j)
+              MOIB.IndexInVector(j)
     end
     @test MOIB.Variable.function_for(map, c2) == MOI.VectorOfVariables(v2[left])
 
@@ -189,7 +189,7 @@ end
         @test MOIB.Variable.constrained_set(map, v2[i]) == S2
         @test MOIB.Variable.length_of_vector_of_variables(map, v2[i]) == 2
         @test MOIB.Variable.index_in_vector_of_variables(map, v2[i]) ==
-              MOIB.Variable.IndexInVector(j)
+              MOIB.IndexInVector(j)
     end
     @test MOIB.Variable.function_for(map, c2) == MOI.VectorOfVariables(v2[left])
 

--- a/test/Bridges/Variable/zeros.jl
+++ b/test/Bridges/Variable/zeros.jl
@@ -58,12 +58,12 @@ MOI.set(bridged_mock, MOI.ObjectiveFunction{typeof(obj)}(), obj)
 @test MOIB.Variable.unbridged_map(
     MOIB.bridge(bridged_mock, y),
     y,
-    MOIB.Variable.IndexInVector(1),
+    MOIB.IndexInVector(1),
 ) === nothing
 @test MOIB.Variable.unbridged_map(
     MOIB.bridge(bridged_mock, z),
     z,
-    MOIB.Variable.IndexInVector(2),
+    MOIB.IndexInVector(2),
 ) === nothing
 
 err = ErrorException(


### PR DESCRIPTION
I don't think we need to do this. I tried it out and it actually makes things slightly less readable, because the Variable and Constraint modules need to have `MOIB.IndexInVector`. It's a trivial type that isn't the source of our problems, and the difference isn't even really measurable.