### PR TITLE
Get Clp tests passing

### DIFF
--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -272,11 +272,11 @@ function _load_constraints(
 )
     for i in eachindex(func_sets)
         func, set = func_sets[i]
-        if i in dest.are_indices_mapped
+        # if i in dest.are_indices_mapped
             load_terms(dest.coefficients, index_map, func, offset)
-        else
-            load_terms(dest.coefficients, IdentityMap(), func, offset)
-        end
+        # else
+        #     load_terms(dest.coefficients, IdentityMap(), func, offset)
+        # end
         _load_constants(dest.constants, offset, func, set)
         offset += MOI.output_dimension(func)
     end


### PR DESCRIPTION
@blegat I don't understand `.are_indices_mapped`. (Even after I read the docstring in `MatrixOfConstraints`.)

Clp passes tests if I remove this line.

Was it just meant as an optimization to skip the `index_map` if the constraints are not bridged? If indices are deleted, it's no longer the case that `IdentityMap` will work.

Perhaps we can just remove `.are_indices_mapped`?

Here's a case where it fails without this PR:
```Julia
using Clp
const MOI = Clp.MOI
src = MOI.Utilities.Model{Float64}()
x = MOI.add_variables(src, 2)
MOI.add_constraint(
    src,
    MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
    MOI.EqualTo(0.0),
)
MOI.delete(src, x[1])
dest = Clp.OptimizerCache()
MOI.Utilities.default_copy_to(dest, src, false, nothing)
```