### PR TITLE
Remove is_empty assertion in CachingOptimizer

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -90,7 +90,6 @@ function CachingOptimizer(
     model_cache::MOI.ModelLike,
     optimizer::MOI.AbstractOptimizer,
 )
-    @assert MOI.is_empty(model_cache)
     @assert MOI.is_empty(optimizer)
     return CachingOptimizer{typeof(optimizer),typeof(model_cache)}(
         optimizer,

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -519,7 +519,7 @@ end
         MOI.add_variable(model)
         @test !MOI.is_empty(model)
         @test MOI.is_empty(s)
-        @test_throws AssertionError MOIU.CachingOptimizer(model, s)
+        @test MOIU.CachingOptimizer(model, s) isa MOIU.CachingOptimizer
     end
 end
 


### PR DESCRIPTION
There is no reason that the `model_cache` field has to be empty when creating a `CachingOptimizer`. (And it isn't checked in the other method.)

This is also needed for an upcoming PR to JuMP.