### PR TITLE
Fix index mapping of MatrixOfConstraints

### DIFF
--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -80,11 +80,8 @@ end
         coefficients::AT
         constants::BT
         sets::ST
-        caches::Union{Nothing,Vector}
-        are_indices_mapped::Union{Nothing,Vector{BitSet}}
-        function MatrixOfConstraints{T,AT,BT,ST}() where {T,AT,BT,ST}
-            return new{T,AT,BT,ST}(AT(), BT(), ST(), BitSet(), nothing)
-        end
+        caches::Vector
+        are_indices_mapped::Vector{BitSet}
     end
 
 Represents affine constraints in a matrix form where the linear coefficients
@@ -124,10 +121,10 @@ mutable struct MatrixOfConstraints{T,AT,BT,ST} <: MOI.ModelLike
     coefficients::AT
     constants::BT
     sets::ST
-    caches::Union{Nothing,Vector}
-    are_indices_mapped::Union{Nothing,Vector{BitSet}}
+    caches::Vector
+    are_indices_mapped::Vector{BitSet}
     function MatrixOfConstraints{T,AT,BT,ST}() where {T,AT,BT,ST}
-        return new{T,AT,BT,ST}(AT(), BT(), ST(), nothing, nothing)
+        return new{T,AT,BT,ST}(AT(), BT(), ST(), [], BitSet[])
     end
 end
 
@@ -318,7 +315,7 @@ function final_touch(model::MatrixOfConstraints, index_map)
     end
 
     final_touch(model.coefficients)
-    model.caches = nothing
-    model.are_indices_mapped = nothing
+    empty!(model.caches)
+    empty!(model.are_indices_mapped)
     return
 end

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -497,7 +497,7 @@ function MOI.get(
 end
 function MOI.get(
     mock::MockOptimizer,
-    attr::MOI.ConstraintFunction,
+    attr::Union{MOI.CanonicalConstraintFunction,MOI.ConstraintFunction},
     idx::MOI.ConstraintIndex,
 )
     # If it is thrown by `mock.inner_model`, the index will be xor'ed.

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -497,6 +497,18 @@ function MOI.get(
 end
 function MOI.get(
     mock::MockOptimizer,
+    attr::MOI.CanonicalConstraintFunction,
+    idx::MOI.ConstraintIndex,
+)
+    # If it is thrown by `mock.inner_model`, the index will be xor'ed.
+    MOI.throw_if_not_valid(mock, idx)
+    # After xoring the indices, the order might not be respected anymore
+    return canonical(
+        xor_indices(MOI.get(mock.inner_model, attr, xor_index(idx))),
+    )
+end
+function MOI.get(
+    mock::MockOptimizer,
     attr::Union{MOI.CanonicalConstraintFunction,MOI.ConstraintFunction},
     idx::MOI.ConstraintIndex,
 )

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -66,8 +66,12 @@ function _test(
     @test _b(_inner(optimizer)) == b
     query_test(_inner(optimizer))
 
+    # Use mock to have xor indices to check that they are mapped
+    cache = MOIU.MockOptimizer(MOIU.Model{Float64}())
+
+    MOI.empty!(cache)
     MOI.empty!(optimizer)
-    model = MOIU.CachingOptimizer(MOIU.Model{Float64}(), optimizer)
+    model = MOIU.CachingOptimizer(cache, optimizer)
     model.mode = MOIU.MANUAL
     MOIU.reset_optimizer(model)
     @test MOIU.state(model) == MOIU.EMPTY_OPTIMIZER
@@ -77,9 +81,10 @@ function _test(
     @test _b(_inner(model)) == b
     query_test(_inner(optimizer))
 
+    MOI.empty!(cache)
     MOI.empty!(optimizer)
     model = MOIU.CachingOptimizer(
-        MOIU.Model{Float64}(),
+        cache,
         MOIU.MockOptimizer(MOIU.UniversalFallback(optimizer)),
     )
     model.mode = MOIU.MANUAL
@@ -92,9 +97,10 @@ function _test(
     query_test(_inner(optimizer))
 
     if !bridged
+        MOI.empty!(cache)
         MOI.empty!(optimizer)
         model = MOIU.CachingOptimizer(
-            MOIU.Model{Float64}(),
+            cache,
             MOI.Bridges.full_bridge_optimizer(
                 MOIU.CachingOptimizer(optimizer, MOIU.MANUAL),
                 Float64,
@@ -110,9 +116,10 @@ function _test(
         @test _b(inner) == b
         query_test(inner)
 
+        MOI.empty!(cache)
         MOI.empty!(optimizer)
         model = MOIU.CachingOptimizer(
-            MOIU.Model{Float64}(),
+            cache,
             MOI.Bridges.full_bridge_optimizer(optimizer, Float64),
         )
         model.mode = MOIU.MANUAL

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -215,7 +215,12 @@ end
         MOI.get(mock, MOI.CanonicalConstraintFunction(), cx),
     )
     @test !MOIU.is_canonical(MOI.get(mock, MOI.ConstraintFunction(), c))
-    @test MOIU.is_canonical(MOI.get(mock, MOI.CanonicalConstraintFunction(), c))
+    func = MOI.get(mock, MOI.CanonicalConstraintFunction(), c)
+    @test MOIU.is_canonical(func)
+    # Check that indices have been xored
+    for term in func.terms
+        @test MOI.is_valid(mock, term.variable)
+    end
 end
 
 @testset "Conflict access" begin


### PR DESCRIPTION
`are_indices_mapped` was storing the index of the set, not the index of the constraint in the cache so that wasn't working.
It was passing the tests because the mapping was always the identity so I now use `MockOptimizer` to make the mapping nontrivial.

Closes https://github.com/jump-dev/MathOptInterface.jl/pull/1360