### PR TITLE
Enable CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - release-*
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
We now have a release-0.9 branch: https://github.com/jump-dev/MathOptInterface.jl/tree/release-0.9