### PR TITLE
Add conic test with starting values

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -630,7 +630,7 @@ function reduce_bridged(
     if variable_function && is_bridged(b, S) && is_variable_bridged(b, S)
         value = operate_variable_bridges!(value)
     end
-    # Even it it is not bridged, it may have been force-bridged because one of the
+    # Even if it is not bridged, it may have been force-bridged because one of the
     # variable in the function was bridged.
     if is_bridged(b, F, S) ||
        (variable_function && supports_constraint_bridges(b))

--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -520,7 +520,11 @@ Test combining the [`MOI.VariablePrimalStart`](@ref),
 attributes with a `MOI.VectorAffineFunction{T}`-in-`MOI.SecondOrderCone`.
 """
 function solve_start_soc(model::MOI.ModelLike, config::TestConfig{T}) where {T}
-    if !MOI.supports_constraint(model, MOI.VectorAffineFunction{T}, MOI.SecondOrderCone)
+    if !MOI.supports_constraint(
+        model,
+        MOI.VectorAffineFunction{T},
+        MOI.SecondOrderCone,
+    )
         return
     end
     MOI.empty!(model)

--- a/test/Test/unit.jl
+++ b/test/Test/unit.jl
@@ -53,6 +53,7 @@ end
                 "solve_zero_one_with_bounds_1",
                 "solve_zero_one_with_bounds_2",
                 "solve_zero_one_with_bounds_3",
+                "solve_start_soc",
                 "solve_unbounded_model",
                 "solve_single_variable_dual_min",
                 "solve_single_variable_dual_max",
@@ -445,6 +446,21 @@ end
         MOIT.solve_zero_one_with_bounds_1(mock, config)
         MOIT.solve_zero_one_with_bounds_2(mock, config)
         MOIT.solve_zero_one_with_bounds_3(mock, config)
+    end
+
+    @testset "solve_start_soc" begin
+        MOIU.set_mock_optimize!(
+            mock,
+            (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+                mock,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, [1.0]),
+                MOI.FEASIBLE_POINT,
+                (MOI.VectorAffineFunction{Float64}, MOI.SecondOrderCone) =>
+                    [[1.0, -1.0]],
+            ),
+        )
+        MOIT.solve_start_soc(mock, config)
     end
 
     @testset "solve_unbounded_model" begin


### PR DESCRIPTION
Add a test combining a conic constraint and starting values.
This would have caught https://github.com/jump-dev/MosekTools.jl/issues/66