### PR TITLE
Allow changing default cache for instantiate

### DIFF
--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -60,6 +60,7 @@ AbstractOptimizer
 OptimizerWithAttributes
 optimize!
 instantiate
+default_cache
 ```
 
 ## Optimizer attributes

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -203,6 +203,7 @@ errors can be thrown.
 """
 function attach_optimizer(model::CachingOptimizer)
     @assert model.state == EMPTY_OPTIMIZER
+    final_touch(model, nothing)
     indexmap = MOI.copy_to(model.optimizer, model.model_cache)::IndexMap
     model.state = ATTACHED_OPTIMIZER
     model.model_to_optimizer_map = indexmap

--- a/src/instantiate.jl
+++ b/src/instantiate.jl
@@ -121,9 +121,22 @@ function instantiate(
         return optimizer
     end
     if !supports_incremental_interface(optimizer)
-        universal_fallback =
-            Utilities.UniversalFallback(Utilities.Model{with_bridge_type}())
-        optimizer = Utilities.CachingOptimizer(universal_fallback, optimizer)
+        cache = default_cache(optimizer, with_bridge_type)
+        optimizer = Utilities.CachingOptimizer(cache, optimizer)
     end
     return Bridges.full_bridge_optimizer(optimizer, with_bridge_type)
+end
+
+"""
+    default_cache(optimizer::ModelLike, ::Type{T}) where {T}
+
+Return a new instance of the default model type to be used as cache for
+`optimizer` in a [`Utilities.CachingOptimizer`](@ref) for holding constraints
+of coefficient type `T`. By default, this returns
+`Utilities.UniversalFallback(Utilities.Model{T}())`. If copying from a instance
+of a given model type is faster for `optimizer` then a new method returning
+an instance of this model type should be defined.
+"""
+function default_cache(::ModelLike, ::Type{T}) where {T}
+    return Utilities.UniversalFallback(Utilities.Model{T}())
 end

--- a/test/instantiate.jl
+++ b/test/instantiate.jl
@@ -6,6 +6,9 @@ const MOI = MathOptInterface
 
 struct DummyOptimizer <: MOI.AbstractOptimizer end
 MOI.is_empty(::DummyOptimizer) = true
+function MOI.default_cache(::DummyOptimizer, ::Type{T}) where {T}
+    return MOI.Utilities.Model{T}()
+end
 
 function _test_instantiate(T)
     function f()
@@ -37,12 +40,8 @@ function _test_instantiate(T)
     @test optimizer isa DummyOptimizer
     optimizer = MOI.instantiate(optimizer_constructor, with_bridge_type = T)
     @test optimizer isa MOI.Bridges.LazyBridgeOptimizer{
-        MOI.Utilities.CachingOptimizer{
-            DummyOptimizer,
-            MOI.Utilities.UniversalFallback{MOI.Utilities.Model{T}},
-        },
+        MOI.Utilities.CachingOptimizer{DummyOptimizer,MOI.Utilities.Model{T}},
     }
-
     err = ErrorException(
         "The provided `optimizer_constructor` returned a non-empty optimizer.",
     )


### PR DESCRIPTION
The main use case for this is that once a solver defines a fast `copy_to` method with a `MatrixOfConstraint` model, then it can use it as cache directly to avoid having to store an extra cache. As `instantiate` is used by JuMP, this will be what's used by default in JuMP.