### PR TITLE
Fix getting constraint by name with MatrixOfConstraints

### DIFF
--- a/src/Utilities/sparse_matrix.jl
+++ b/src/Utilities/sparse_matrix.jl
@@ -89,7 +89,7 @@ end
 function set_number_of_rows(A::MutableSparseMatrixCSC, num_rows)
     A.m = num_rows
     for i in 3:length(A.colptr)
-        A.colptr[i] += A.colptr[i - 1]
+        A.colptr[i] += A.colptr[i-1]
     end
     resize!(A.rowval, A.colptr[end])
     resize!(A.nzval, A.colptr[end])
@@ -98,7 +98,7 @@ end
 
 function final_touch(A::MutableSparseMatrixCSC)
     for i in length(A.colptr):-1:2
-        A.colptr[i] = _shift(A.colptr[i - 1], ZeroBasedIndexing(), A.indexing)
+        A.colptr[i] = _shift(A.colptr[i-1], ZeroBasedIndexing(), A.indexing)
     end
     A.colptr[1] = _first_index(A.indexing)
     return
@@ -113,7 +113,7 @@ function allocate_terms(
     func::Union{MOI.ScalarAffineFunction,MOI.VectorAffineFunction},
 )
     for term in func.terms
-        A.colptr[index_map[_variable(term)].value + 1] += 1
+        A.colptr[index_map[_variable(term)].value+1] += 1
     end
     return
 end

--- a/src/Utilities/sparse_matrix.jl
+++ b/src/Utilities/sparse_matrix.jl
@@ -70,26 +70,26 @@ mutable struct MutableSparseMatrixCSC{Tv,Ti<:Integer,I<:AbstractIndexing}
     end
 end
 
-function MOI.empty!(A::MutableSparseMatrixCSC)
+function MOI.empty!(A::MutableSparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
     A.m = 0
     A.n = 0
     resize!(A.colptr, 1)
-    A.colptr[1] = 0
+    A.colptr[1] = zero(Ti)
     empty!(A.rowval)
     empty!(A.nzval)
     return
 end
 
-function add_column(A::MutableSparseMatrixCSC)
+function add_column(A::MutableSparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
     A.n += 1
-    push!(A.colptr, 0)
+    push!(A.colptr, zero(Ti))
     return
 end
 
 function set_number_of_rows(A::MutableSparseMatrixCSC, num_rows)
     A.m = num_rows
     for i in 3:length(A.colptr)
-        A.colptr[i] += A.colptr[i-1]
+        A.colptr[i] += A.colptr[i - 1]
     end
     resize!(A.rowval, A.colptr[end])
     resize!(A.nzval, A.colptr[end])
@@ -98,7 +98,7 @@ end
 
 function final_touch(A::MutableSparseMatrixCSC)
     for i in length(A.colptr):-1:2
-        A.colptr[i] = _shift(A.colptr[i-1], ZeroBasedIndexing(), A.indexing)
+        A.colptr[i] = _shift(A.colptr[i - 1], ZeroBasedIndexing(), A.indexing)
     end
     A.colptr[1] = _first_index(A.indexing)
     return
@@ -113,7 +113,7 @@ function allocate_terms(
     func::Union{MOI.ScalarAffineFunction,MOI.VectorAffineFunction},
 )
     for term in func.terms
-        A.colptr[index_map[_variable(term)].value+1] += 1
+        A.colptr[index_map[_variable(term)].value + 1] += 1
     end
     return
 end

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -40,7 +40,8 @@ function _test(
     bridged::Bool,
     Indexing,
 )
-    optimizer = matrix_instance(Float64, ConstantsType, ProductOfSetsType, Indexing)
+    optimizer =
+        matrix_instance(Float64, ConstantsType, ProductOfSetsType, Indexing)
     _inner(model::MOI.Bridges.LazyBridgeOptimizer) = _inner(model.model)
     _inner(model::MOI.Utilities.CachingOptimizer) = _inner(model.optimizer)
     _inner(model::MOI.Utilities.MockOptimizer) = _inner(model.inner_model)
@@ -138,7 +139,12 @@ function _lp(model, ::MOI.Test.Config{T}) where {T}
     return MOI.add_constraint(model, 5fx - 4fy, MOI.Interval(T(6), T(7)))
 end
 
-function matrix_instance(T::Type, ConstantsType, ProductOfSetsType::Type, Indexing)
+function matrix_instance(
+    T::Type,
+    ConstantsType,
+    ProductOfSetsType::Type,
+    Indexing,
+)
     return MOIU.GenericOptimizer{
         T,
         MOIU.MatrixOfConstraints{
@@ -148,29 +154,6 @@ function matrix_instance(T::Type, ConstantsType, ProductOfSetsType::Type, Indexi
             ProductOfSetsType,
         },
     }()
-end
-
-function test_get_by_name(T::Type, SetsType::Type)
-    model = matrix_instance(T, MOI.Utilities.Box{T}, SetsType, MOI.Utilities.OneBasedIndexing)
-    MOI.empty!(model)
-    x = MOI.add_variable(model)
-    fx = MOI.SingleVariable(x)
-    c = MOI.add_constraint(model, one(T) * fx, MOI.EqualTo(one(T)))
-    MOI.set(model, MOI.ConstraintName(), c, "c")
-    @test "c" == MOI.get(model, MOI.ConstraintName(), c)
-    @test c == MOI.get(model, MOI.ConstraintIndex, "c")
-    @test c == MOI.get(model, typeof(c), "c")
-end
-function test_get_by_name()
-    for T in [Int, Float64]
-        for SetsType in [MixLP{T}, OrdLP{T}]
-            test_get_by_name(T, SetsType)
-        end
-    end
-end
-
-@testset "Get constraint by name" begin
-    test_get_by_name()
 end
 
 MOIU.@mix_of_scalar_sets(
@@ -358,4 +341,32 @@ MOIU.@product_of_sets(NonnegNonpos, MOI.Nonnegatives, MOI.Nonpositives)
     ) do optimizer
         return _lin3_query(optimizer, [(F, MOI.Nonnegatives)])
     end
+end
+
+function test_get_by_name(T::Type, SetsType::Type)
+    model = matrix_instance(
+        T,
+        MOI.Utilities.Box{T},
+        SetsType,
+        MOI.Utilities.OneBasedIndexing,
+    )
+    MOI.empty!(model)
+    x = MOI.add_variable(model)
+    fx = MOI.SingleVariable(x)
+    c = MOI.add_constraint(model, one(T) * fx, MOI.EqualTo(one(T)))
+    MOI.set(model, MOI.ConstraintName(), c, "c")
+    @test "c" == MOI.get(model, MOI.ConstraintName(), c)
+    @test c == MOI.get(model, MOI.ConstraintIndex, "c")
+    @test c == MOI.get(model, typeof(c), "c")
+end
+function test_get_by_name()
+    for T in [Int, Float64]
+        for SetsType in [MixLP{T}, OrdLP{T}]
+            test_get_by_name(T, SetsType)
+        end
+    end
+end
+
+@testset "Get constraint by name" begin
+    test_get_by_name()
 end

--- a/test/Utilities/product_of_sets.jl
+++ b/test/Utilities/product_of_sets.jl
@@ -262,13 +262,13 @@ function test_vector_ListOfConstraintIndices()
     VAF = MOI.VectorAffineFunction{Float64}
     @test MOI.get(sets, MOI.ListOfConstraintIndices{VAF,MOI.Zeros}()) ==
           MOI.ConstraintIndex{VAF,MOI.Zeros}[]
-    for (x, S) in zip([[0], [0, 2]], MOI.Utilities.set_types(sets)[1:2])
+    for (x, S) in zip([[1], [1, 3]], MOI.Utilities.set_types(sets)[1:2])
         ci = MOI.get(sets, MOI.ListOfConstraintIndices{VAF,S}())
         @test ci == MOI.ConstraintIndex{VAF,S}.(x)
     end
     F, S = MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}
     @test MOI.get(sets, MOI.ListOfConstraintIndices{F,S}()) ==
-          [MOI.ConstraintIndex{F,S}(0)]
+          [MOI.ConstraintIndex{F,S}(1)]
     return
 end
 
@@ -288,7 +288,7 @@ function test_vector_ListOfConstraintIndices2()
     S = MOI.Utilities.set_types(sets)[2]
     VAF = MOI.VectorAffineFunction{Float64}
     indices = MOI.get(sets, MOI.ListOfConstraintIndices{VAF,S}())
-    @test indices == MOI.ConstraintIndex{VAF,S}.([0, 2, 5, 7])
+    @test indices == MOI.ConstraintIndex{VAF,S}.([1, 3, 6, 8])
 end
 
 end


### PR DESCRIPTION
Zero index is used to determine whether there are duplicate names:
https://github.com/jump-dev/MathOptInterface.jl/blob/65924e39a438b8338cabf1fada461dc4a1abf3fd/src/Utilities/model.jl#L243
This was clashing with the fact that `MatrixOfConstraints` was returning zero indices. It turns out we don't really don't zero indices. In fact with this PR, `ci.value` corresponds to the row in the scalar case which is nice (and to the first row in the vector case). Before, it corresponded to the offset but it was zero for the first constraint.