### PR TITLE
Fix case typo in Tests doc

### DIFF
--- a/docs/src/submodules/Test/overview.md
+++ b/docs/src/submodules/Test/overview.md
@@ -26,7 +26,7 @@ on the value of `supports`).
 
 ```julia
 # ============================ /test/MOI_wrapper.jl ============================
-module TestFoobar
+module TestFooBar
 
 import FooBar
 using MathOptInterface


### PR DESCRIPTION
It doesn't match the inside of the module nor the `end # module TestFooBar` at  the end.