### PR TITLE
Various improvements to MatrixOfConstraints

### DIFF
--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -108,8 +108,8 @@ Utilities.OneBasedIndexing
 
 ```@docs
 Utilities.load_constants
+Utilities.function_constants
 Utilities.set_from_constants
-Utilities.constants
 ```
 
 ```@docs

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -33,6 +33,8 @@ Utilities.UniversalFallback
 Utilities.@model
 Utilities.GenericModel
 Utilities.GenericOptimizer
+Utilities.@struct_of_constraints_by_function_types
+Utilities.@struct_of_constraints_by_set_types
 Utilities.struct_of_constraint_code
 ```
 

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -106,6 +106,8 @@ Utilities.OneBasedIndexing
 
 ```@docs
 Utilities.load_constants
+Utilities.set_from_constants
+Utilities.constants
 ```
 
 ```@docs

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -25,7 +25,7 @@ function default_status_test(model::MOI.ModelLike)
     @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
 end
 
-function nametest(model::MOI.ModelLike; delete::Bool=true)
+function nametest(model::MOI.ModelLike; delete::Bool = true)
     @testset "Variables" begin
         MOI.empty!(model)
         x = MOI.add_variables(model, 2)
@@ -288,7 +288,7 @@ function nametest(model::MOI.ModelLike; delete::Bool=true)
 end
 
 # Taken from https://github.com/jump-dev/MathOptInterfaceUtilities.jl/issues/41
-function validtest(model::MOI.ModelLike; delete::Bool=true)
+function validtest(model::MOI.ModelLike; delete::Bool = true)
     MOI.empty!(model)
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     v = MOI.add_variables(model, 2)

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -57,6 +57,7 @@ include("copy.jl")
 include("results.jl")
 include("variables.jl")
 
+include("box.jl")
 include("vector_of_constraints.jl")
 include("struct_of_constraints.jl")
 include("model.jl")

--- a/src/Utilities/box.jl
+++ b/src/Utilities/box.jl
@@ -29,7 +29,6 @@ const SUPPORTED_VARIABLE_SCALAR_SETS{T} = Union{
     MOI.Semiinteger{T},
 }
 
-
 """
     struct Box{T}
         lower::Vector{T}
@@ -101,13 +100,9 @@ function merge_bounds(b::Box, index, set)
     end
 end
 
-function add_constants_to_functions(::Box, index, ::MOI.ScalarAffineFunction) end
+constants(::Box{T}, row) where {T} = zero(T)
 
-function set_from_constants(
-    b::Box,
-    ::Type{<:MOI.EqualTo},
-    index,
-)
+function set_from_constants(b::Box, ::Type{<:MOI.EqualTo}, index)
     return MOI.EqualTo(b.lower[index])
 end
 function set_from_constants(
@@ -118,11 +113,7 @@ function set_from_constants(
     # Lower and upper bounds are equal for `EqualTo`, we can take either of them.
     return S(b.lower[index])
 end
-function set_from_constants(
-    b::Box,
-    S::Type{<:MOI.LessThan},
-    index,
-)
+function set_from_constants(b::Box, S::Type{<:MOI.LessThan}, index)
     return S(b.upper[index])
 end
 function set_from_constants(

--- a/src/Utilities/box.jl
+++ b/src/Utilities/box.jl
@@ -101,6 +101,8 @@ function merge_bounds(b::Box, index, set)
     end
 end
 
+function add_constants_to_functions(::Box, index, ::MOI.ScalarAffineFunction) end
+
 function set_from_constants(
     b::Box,
     ::Type{<:MOI.EqualTo},

--- a/src/Utilities/box.jl
+++ b/src/Utilities/box.jl
@@ -1,0 +1,139 @@
+# Sets setting lower bound:
+extract_lower_bound(set::MOI.EqualTo) = set.value
+function extract_lower_bound(
+    set::Union{MOI.GreaterThan,MOI.Interval,MOI.Semicontinuous,MOI.Semiinteger},
+)
+    return set.lower
+end
+# 0xcb = 0x80 | 0x40 | 0x8 | 0x2 | 0x1
+const LOWER_BOUND_MASK = 0xcb
+
+# Sets setting upper bound:
+extract_upper_bound(set::MOI.EqualTo) = set.value
+function extract_upper_bound(
+    set::Union{MOI.LessThan,MOI.Interval,MOI.Semicontinuous,MOI.Semiinteger},
+)
+    return set.upper
+end
+# 0xcd = 0x80 | 0x40 | 0x8 | 0x4 | 0x1
+const UPPER_BOUND_MASK = 0xcd
+
+const SUPPORTED_VARIABLE_SCALAR_SETS{T} = Union{
+    MOI.EqualTo{T},
+    MOI.GreaterThan{T},
+    MOI.LessThan{T},
+    MOI.Interval{T},
+    MOI.Integer,
+    MOI.ZeroOne,
+    MOI.Semicontinuous{T},
+    MOI.Semiinteger{T},
+}
+
+
+"""
+    struct Box{T}
+        lower::Vector{T}
+        upper::Vector{T}
+    end
+
+Stores the constants of scalar constraints with the lower bound of the set in
+`lower` and the upper bound in `upper`.
+"""
+struct Box{T}
+    lower::Vector{T}
+    upper::Vector{T}
+end
+
+Box{T}() where {T} = Box{T}(T[], T[])
+
+Base.:(==)(a::Box, b::Box) = a.lower == b.lower && a.upper == b.upper
+
+function Base.empty!(b::Box)
+    empty!(b.lower)
+    empty!(b.upper)
+    return b
+end
+
+function Base.resize!(b::Box, n)
+    resize!(b.lower, n)
+    resize!(b.upper, n)
+    return
+end
+
+function add_free(b::Box{T}) where {T}
+    push!(b.lower, _no_lower_bound(T))
+    push!(b.upper, _no_upper_bound(T))
+    return
+end
+
+# Use `-Inf` and `Inf` for `AbstractFloat` subtypes.
+_no_lower_bound(::Type{T}) where {T} = zero(T)
+_no_lower_bound(::Type{T}) where {T<:AbstractFloat} = typemin(T)
+_no_upper_bound(::Type{T}) where {T} = zero(T)
+_no_upper_bound(::Type{T}) where {T<:AbstractFloat} = typemax(T)
+
+function load_constants(
+    b::Box{T},
+    offset,
+    set::SUPPORTED_VARIABLE_SCALAR_SETS{T},
+) where {T}
+    flag = single_variable_flag(typeof(set))
+    if iszero(flag & LOWER_BOUND_MASK)
+        b.lower[offset+1] = _no_lower_bound(T)
+    else
+        b.lower[offset+1] = extract_lower_bound(set)
+    end
+    if iszero(flag & UPPER_BOUND_MASK)
+        b.upper[offset+1] = _no_upper_bound(T)
+    else
+        b.upper[offset+1] = extract_upper_bound(set)
+    end
+    return
+end
+
+function merge_bounds(b::Box, index, set)
+    flag = single_variable_flag(typeof(set))
+    if !iszero(flag & LOWER_BOUND_MASK)
+        b.lower[index] = extract_lower_bound(set)
+    end
+    if !iszero(flag & UPPER_BOUND_MASK)
+        b.upper[index] = extract_upper_bound(set)
+    end
+end
+
+function set_from_constants(
+    b::Box,
+    ::Type{<:MOI.EqualTo},
+    index,
+)
+    return MOI.EqualTo(b.lower[index])
+end
+function set_from_constants(
+    b::Box,
+    S::Type{<:Union{MOI.GreaterThan,MOI.EqualTo}},
+    index,
+)
+    # Lower and upper bounds are equal for `EqualTo`, we can take either of them.
+    return S(b.lower[index])
+end
+function set_from_constants(
+    b::Box,
+    S::Type{<:MOI.LessThan},
+    index,
+)
+    return S(b.upper[index])
+end
+function set_from_constants(
+    b::Box,
+    S::Type{<:Union{MOI.Interval,MOI.Semicontinuous,MOI.Semiinteger}},
+    index,
+)
+    return S(b.lower[index], b.upper[index])
+end
+function set_from_constants(
+    ::Box,
+    S::Type{<:Union{MOI.Integer,MOI.ZeroOne}},
+    index,
+)
+    return S()
+end

--- a/src/Utilities/box.jl
+++ b/src/Utilities/box.jl
@@ -100,7 +100,7 @@ function merge_bounds(b::Box, index, set)
     end
 end
 
-constants(::Box{T}, row) where {T} = zero(T)
+function_constants(::Box{T}, row) where {T} = zero(T)
 
 function set_from_constants(b::Box, ::Type{<:MOI.EqualTo}, index)
     return MOI.EqualTo(b.lower[index])

--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -61,7 +61,7 @@ The `.constants::BT` type must implement:
  * `Base.resize(::BT)`
  * [`MOI.Utilities.load_constants`](@ref)
  * [`MOI.Utilities.set_from_constants`](@ref)
- * [`MOI.Utilities.add_constants_to_functions`](@ref)
+ * [`MOI.Utilities.constants`](@ref)
 
 The `.sets::ST` type must implement:
 
@@ -475,11 +475,8 @@ function load_constants(
     copyto!(b, offset + 1, func.constants)
     return
 end
-function add_constants_to_functions(b::Vector, rows, func::MOI.VectorAffineFunction)
-    for (i, row) in enumerate(rows)
-        func.constants[i] = b[row]
-    end
-end
+constants(b::Vector, rows) = b[rows]
+
 # FIXME does not work for all sets
 set_from_constants(::Vector, ::Type{S}, rows) where {S} = S(length(rows))
 
@@ -491,9 +488,11 @@ function MOI.get(
     @assert model.final_touch
     MOI.throw_if_not_valid(model, ci)
     r = rows(model, ci)
-    func = extract_function(model.coefficients, r)
-    add_constants_to_functions(model.constants, r, func)
-    return func
+    return extract_function(
+        model.coefficients,
+        r,
+        constants(model.constants, r),
+    )
 end
 
 function MOI.get(
@@ -505,4 +504,3 @@ function MOI.get(
     MOI.throw_if_not_valid(model, ci)
     return set_from_constants(model.constants, S, rows(model, ci))
 end
-

--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -5,6 +5,7 @@
         sets::ST
         caches::Vector{Any}
         are_indices_mapped::Vector{BitSet}
+        final_touch::Bool
     end
 
 Represent `ScalarAffineFunction` and `VectorAffinefunction` constraints in a
@@ -59,6 +60,7 @@ The `.constants::BT` type must implement:
  * `Base.empty!(::BT)`
  * `Base.resize(::BT)`
  * [`MOI.Utilities.load_constants`](@ref)
+ * [`MOI.Utilities.set_from_constants`](@ref)
 
 The `.sets::ST` type must implement:
 
@@ -82,8 +84,11 @@ mutable struct MatrixOfConstraints{T,AT,BT,ST} <: MOI.ModelLike
     sets::ST
     caches::Vector{Any}
     are_indices_mapped::Vector{BitSet}
+    final_touch::Bool
     function MatrixOfConstraints{T,AT,BT,ST}() where {T,AT,BT,ST}
-        return new{T,AT,BT,ST}(AT(), BT(), ST(), Any[], BitSet[])
+        model = new{T,AT,BT,ST}(AT(), BT(), ST(), Any[], BitSet[], false)
+        MOI.empty!(model)
+        return model
     end
 end
 
@@ -168,6 +173,17 @@ The constants are loaded in three steps:
 """
 function load_constants end
 
+"""
+    set_from_constants(constants, S::Type, rows)::S
+
+This function returns an instance of the set `S` for which the constants where
+loaded with [`load_constants`](@ref) at the rows `rows`.
+
+This function should be implemented to be usable as storage of constants for
+[`MatrixOfConstraints`](@ref).
+"""
+function set_from_constants end
+
 ###
 ### Interface for the .sets field
 ###
@@ -227,6 +243,7 @@ function MOI.empty!(v::MatrixOfConstraints{T}) where {T}
     v.caches =
         [Tuple{_affine_function_type(T, S),S}[] for S in set_types(v.sets)]
     v.are_indices_mapped = [BitSet() for _ in eachindex(v.caches)]
+    v.final_touch = false
     return
 end
 
@@ -263,8 +280,11 @@ function MOI.supports_constraint(
     return F == _affine_function_type(T, S) && set_index(v.sets, S) !== nothing
 end
 
-function MOI.is_valid(v::MatrixOfConstraints, ci::MOI.ConstraintIndex)
-    return MOI.is_valid(v.sets, ci)
+function MOI.is_valid(
+    v::MatrixOfConstraints{T},
+    ci::MOI.ConstraintIndex{F,S},
+) where {T,F,S}
+    return F == _affine_function_type(T, S) && MOI.is_valid(v.sets, ci)
 end
 
 function MOI.get(
@@ -382,6 +402,9 @@ function _load_constraints(
 end
 
 _add_variable(model::MatrixOfConstraints) = add_column(model.coefficients)
+function _add_variables(model::MatrixOfConstraints, n)
+    return add_columns(model.coefficients, n)
+end
 
 function pass_nonvariable_constraints(
     dest::MatrixOfConstraints,
@@ -398,6 +421,10 @@ function pass_nonvariable_constraints(
 end
 
 function final_touch(model::MatrixOfConstraints, index_map)
+    if model.final_touch
+        @assert index_map === nothing
+        return
+    end
     final_touch(model.sets)
     num_rows = MOI.dimension(model.sets)
     resize!(model.constants, num_rows)
@@ -410,6 +437,7 @@ function final_touch(model::MatrixOfConstraints, index_map)
     final_touch(model.coefficients)
     empty!(model.caches)
     empty!(model.are_indices_mapped)
+    model.final_touch = true
     return
 end
 
@@ -446,56 +474,26 @@ function load_constants(
     copyto!(b, offset + 1, func.constants)
     return
 end
+# FIXME does not work for all sets
+set_from_constants(::Vector, ::Type{S}, rows) where {S} = S(length(rows))
 
-###
-### .constants::Box
-###
-
-"""
-    struct Box{T}
-        lower::Vector{T}
-        upper::Vector{T}
-    end
-
-Stores the constants of scalar constraints with the lower bound of the set in
-`lower` and the upper bound in `upper`.
-"""
-struct Box{T}
-    lower::Vector{T}
-    upper::Vector{T}
+function MOI.get(
+    model::MatrixOfConstraints,
+    attr::Union{MOI.CanonicalConstraintFunction,MOI.ConstraintFunction},
+    ci::MOI.ConstraintIndex,
+)
+    @assert model.final_touch
+    MOI.throw_if_not_valid(model, ci)
+    return extract_function(model.coefficients, rows(model, ci))
 end
 
-Box{T}() where {T} = Box{T}(T[], T[])
-
-Base.:(==)(a::Box, b::Box) = a.lower == b.lower && a.upper == b.upper
-
-function Base.empty!(b::Box)
-    empty!(b.lower)
-    empty!(b.upper)
-    return b
+function MOI.get(
+    model::MatrixOfConstraints,
+    attr::MOI.ConstraintSet,
+    ci::MOI.ConstraintIndex{F,S},
+) where {F,S}
+    @assert model.final_touch
+    MOI.throw_if_not_valid(model, ci)
+    return set_from_constants(model.constants, S, rows(model, ci))
 end
 
-function Base.resize!(b::Box, n)
-    resize!(b.lower, n)
-    resize!(b.upper, n)
-    return
-end
-
-function load_constants(
-    b::Box{T},
-    offset,
-    set::SUPPORTED_VARIABLE_SCALAR_SETS{T},
-) where {T}
-    flag = single_variable_flag(typeof(set))
-    if iszero(flag & LOWER_BOUND_MASK)
-        b.lower[offset+1] = typemin(T)
-    else
-        b.lower[offset+1] = extract_lower_bound(set)
-    end
-    if iszero(flag & UPPER_BOUND_MASK)
-        b.upper[offset+1] = typemax(T)
-    else
-        b.upper[offset+1] = extract_upper_bound(set)
-    end
-    return
-end

--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -60,8 +60,8 @@ The `.constants::BT` type must implement:
  * `Base.empty!(::BT)`
  * `Base.resize(::BT)`
  * [`MOI.Utilities.load_constants`](@ref)
+ * [`MOI.Utilities.function_constants`](@ref)
  * [`MOI.Utilities.set_from_constants`](@ref)
- * [`MOI.Utilities.constants`](@ref)
 
 The `.sets::ST` type must implement:
 
@@ -173,6 +173,17 @@ The constants are loaded in three steps:
     constraint or set for scalar constraint.
 """
 function load_constants end
+
+"""
+    function_constants(constants, rows)
+
+This function returns the function constants that were loaded with
+[`load_constants`](@ref) at the rows `rows`.
+
+This function should be implemented to be usable as storage of constants for
+[`MatrixOfConstraints`](@ref).
+"""
+function function_constants end
 
 """
     set_from_constants(constants, S::Type, rows)::S
@@ -475,7 +486,7 @@ function load_constants(
     copyto!(b, offset + 1, func.constants)
     return
 end
-constants(b::Vector, rows) = b[rows]
+function_constants(b::Vector, rows) = b[rows]
 
 # FIXME does not work for all sets
 set_from_constants(::Vector, ::Type{S}, rows) where {S} = S(length(rows))
@@ -491,7 +502,7 @@ function MOI.get(
     return extract_function(
         model.coefficients,
         r,
-        constants(model.constants, r),
+        function_constants(model.constants, r),
     )
 end
 

--- a/src/Utilities/product_of_sets.jl
+++ b/src/Utilities/product_of_sets.jl
@@ -246,10 +246,9 @@ function final_touch(sets::OrderedProductOfSets)
 end
 
 function _num_rows(sets::OrderedProductOfSets, ::Type{S}) where {S}
-    @assert sets.final_touch
     i = set_index(sets, S)
-    if i == 1
-        return sets.num_rows[1]
+    if !sets.final_touch || i == 1
+        return sets.num_rows[i]
     end
     return sets.num_rows[i] - sets.num_rows[i-1]
 end
@@ -258,7 +257,6 @@ function MOI.get(
     sets::OrderedProductOfSets{T},
     ::MOI.ListOfConstraintTypesPresent,
 ) where {T}
-    @assert sets.final_touch
     return Tuple{DataType,DataType}[
         (_affine_function_type(T, S), S) for
         S in set_types(sets) if _num_rows(sets, S) > 0
@@ -325,7 +323,6 @@ function MOI.get(
     sets::OrderedProductOfSets,
     ::MOI.NumberOfConstraints{F,S},
 ) where {F,S}
-    @assert sets.final_touch
     r = _range_iterator(sets, F, S)
     return _length(r)
 end
@@ -334,7 +331,6 @@ function MOI.get(
     sets::OrderedProductOfSets,
     ::MOI.ListOfConstraintIndices{F,S},
 ) where {F,S}
-    @assert sets.final_touch
     rows = _range_iterator(sets, F, S)
     if rows === nothing
         return MOI.ConstraintIndex{F,S}[]
@@ -346,7 +342,6 @@ function MOI.is_valid(
     sets::OrderedProductOfSets,
     ci::MOI.ConstraintIndex{F,S},
 ) where {F,S}
-    @assert sets.final_touch
     r = _range_iterator(sets, F, S)
     return r !== nothing && ci.value in r
 end

--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -230,14 +230,18 @@ _mapreduce_field(s::SymbolFS) = :(cur = op(cur, f(model.$(_field(s)))))
 """
     struct_of_constraint_code(struct_name, types, field_types = nothing)
 
-Given a vector of `n` `SymbolFun` or `SymbolSet` in `types`, creates a
-struct of name `struct_name` that is a subtype of
-`StructOfConstraint{T, C1, C2, ..., Cn}` if `field_types` is `nothing` and
-a subtype of `StructOfConstraint{T}` otherwise.
+Given a vector of `n` `SymbolFun` or `SymbolSet` in `types`, defines
+a subtype of `StructOfConstraints` of name `name` and which type parameters
+`{T, F1, F2, ..., Fn}` if `field_types` is `nothing` and
+a `{T}` otherwise.
 It contains `n` field where the `i`th field has type `Ci` if `field_types` is
 `nothing` and type `field_types[i]` otherwise.
 If `types` is vector of `SymbolFun` (resp. `SymbolSet`) then the constraints
 of that function (resp. set) type are stored in the corresponding field.
+
+This function is used by the macros [`@model`](@ref),
+[`@struct_of_constraints_by_function_types`](@ref) and
+[`@struct_of_constraints_by_set_types`](@ref).
 """
 function struct_of_constraint_code(struct_name, types, field_types = nothing)
     T = esc(:T)
@@ -322,10 +326,29 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
     return code
 end
 
+"""
+    Utilities.@struct_of_constraints_by_function_types(name, func_types...)
+
+Given a vector of `n` function types `(F1, F2,..., Fn)` in `func_types`, defines
+a subtype of `StructOfConstraints` of name `name` and which type parameters
+`{T, C1, C2, ..., Cn}`.
+It contains `n` field where the `i`th field has type `Ci` and stores the
+constraints of function type `Fi`.
+"""
 macro struct_of_constraints_by_function_types(name, func_types...)
     funcs = SymbolFun.(func_types)
     return struct_of_constraint_code(esc(name), funcs)
 end
+
+"""
+    Utilities.@struct_of_constraints_by_set_types(name, func_types...)
+
+Given a vector of `n` set types `(S1, S2,..., Sn)` in `func_types`, defines
+a subtype of `StructOfConstraints` of name `name` and which type parameters
+`{T, C1, C2, ..., Cn}`.
+It contains `n` field where the `i`th field has type `Ci` and stores the
+constraints of set type `Si`.
+"""
 macro struct_of_constraints_by_set_types(name, set_types...)
     sets = SymbolSet.(set_types)
     return struct_of_constraint_code(esc(name), sets)

--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -309,17 +309,13 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
             end
         ),
     )
-    if !isempty(field_types)
-        # If there is no field type, the default constructor is sufficient and
-        # adding this constructor will make a `StackOverflow`.
-        constructor_code = :(function $typed_struct() where {$T}
-            return $typed_struct(0, $([:(nothing) for _ in field_types]...))
-        end)
-        if type_parametrized
-            append!(constructor_code.args[1].args, field_types)
-        end
-        push!(code.args, constructor_code)
+    constructor_code = :(function $typed_struct() where {$T}
+        return $typed_struct(0, $([:(nothing) for _ in field_types]...))
+    end)
+    if type_parametrized
+        append!(constructor_code.args[1].args, field_types)
     end
+    push!(code.args, constructor_code)
     return code
 end
 

--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -284,7 +284,10 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
             )::$(field_type) where {$T}
                 if model.$field === nothing
                     model.$field = $(field_type)()
-                    $MOI.Utilities._add_variables(model.$field, model.num_variables)
+                    $MOI.Utilities._add_variables(
+                        model.$field,
+                        model.num_variables,
+                    )
                 end
                 return model.$field
             end

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -146,6 +146,7 @@ function MOI.modify(
 end
 
 function _add_variable(::VectorOfConstraints) end
+function _add_variables(::VectorOfConstraints, ::Int64) end
 
 # Deletion of variables in vector of variables
 

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -370,3 +370,143 @@ end
 @testset "Get constraint by name" begin
     test_get_by_name()
 end
+
+MOIU.@struct_of_constraints_by_function_types(
+    VoVorSAff,
+    MOI.VectorOfVariables,
+    MOI.ScalarAffineFunction{T},
+)
+
+function test_nametest()
+    T = Float64
+    Indexing = MOIU.OneBasedIndexing
+    ConstantsType = MOIU.Box{T}
+    for ProductOfSetsType in [MixLP{Float64}, OrdLP{Float64}]
+        model = MOIU.GenericOptimizer{
+            T,
+            VoVorSAff{T}{
+                MOIU.VectorOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives},
+                MOIU.MatrixOfConstraints{
+                    T,
+                    MOIU.MutableSparseMatrixCSC{T,Int,Indexing},
+                    ConstantsType,
+                    ProductOfSetsType,
+                },
+            },
+        }()
+        MOI.Test.nametest(
+            model,
+            delete = false,
+        )
+    end
+end
+
+@testset "test_nametest" begin
+    test_nametest()
+end
+
+
+MOIU.@struct_of_constraints_by_function_types(
+    VoVorVAff,
+    MOI.VectorOfVariables,
+    MOI.VectorAffineFunction{T},
+)
+
+MOIU.@product_of_sets(Zeros, MOI.Zeros)
+
+function test_empty()
+    T = Float64
+    Indexing = MOIU.OneBasedIndexing
+    model = MOIU.GenericOptimizer{
+        T,
+        VoVorVAff{T}{
+            MOIU.VectorOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives},
+            MOIU.MatrixOfConstraints{
+                T,
+                MOIU.MutableSparseMatrixCSC{T,Int,Indexing},
+                Vector{T},
+                Zeros{Float64},
+            },
+        },
+    }()
+    MOI.Test.emptytest(model)
+end
+
+@testset "test_empty" begin
+    test_empty()
+end
+
+function test_valid()
+    T = Float64
+    Indexing = MOIU.OneBasedIndexing
+    ConstantsType = MOIU.Box{T}
+    for ProductOfSetsType in [MixLP{Float64}, OrdLP{Float64}]
+        model = matrix_instance(T, ConstantsType, ProductOfSetsType, Indexing)
+        MOI.Test.validtest(model, delete = false)
+    end
+end
+
+@testset "test_valid" begin
+    test_valid()
+end
+
+function test_supports_constraint(T::Type=Float64, BadT::Type=Float32)
+    Indexing = MOIU.OneBasedIndexing
+    ConstantsType = MOIU.Box{T}
+    for ProductOfSetsType in [MixLP{Float64}, OrdLP{Float64}]
+        model = MOIU.GenericOptimizer{
+            T,
+            VoVorSAff{T}{
+                MOIU.VectorOfConstraints{MOI.VectorOfVariables,MOI.Zeros},
+                MOIU.MatrixOfConstraints{
+                    T,
+                    MOIU.MutableSparseMatrixCSC{T,Int,Indexing},
+                    ConstantsType,
+                    ProductOfSetsType,
+                },
+            },
+        }()
+        MOI.Test.supports_constrainttest(model, T, BadT)
+    end
+end
+
+@testset "test_supports_constraint" begin
+    test_supports_constraint()
+end
+
+MOIU.@struct_of_constraints_by_function_types(
+    VoVorSAfforVAff,
+    MOI.VectorOfVariables,
+    MOI.ScalarAffineFunction{T},
+    MOI.VectorAffineFunction{T},
+)
+
+function test_copy()
+    T = Float64
+    Indexing = MOIU.OneBasedIndexing
+    for ScalarSetsType in [MixLP{T}, OrdLP{T}]
+        model = MOIU.GenericOptimizer{
+            T,
+            VoVorSAfforVAff{T}{
+                MOIU.VectorOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives},
+                MOIU.MatrixOfConstraints{
+                    T,
+                    MOIU.MutableSparseMatrixCSC{T,Int,Indexing},
+                    MOIU.Box{T},
+                    ScalarSetsType,
+                },
+                MOIU.MatrixOfConstraints{
+                    T,
+                    MOIU.MutableSparseMatrixCSC{T,Int,Indexing},
+                    Vector{T},
+                    Zeros{T},
+                },
+            },
+        }()
+        MOI.Test.copytest(model, MOIU.Model{T}())
+    end
+end
+
+@testset "test_copy" begin
+    test_copy()
+end

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -481,9 +481,8 @@ MOIU.@struct_of_constraints_by_function_types(
     MOI.VectorAffineFunction{T},
 )
 
-function test_copy()
+function test_copy(Indexing)
     T = Float64
-    Indexing = MOIU.OneBasedIndexing
     for ScalarSetsType in [MixLP{T}, OrdLP{T}]
         model = MOIU.GenericOptimizer{
             T,
@@ -508,5 +507,6 @@ function test_copy()
 end
 
 @testset "test_copy" begin
-    test_copy()
+    test_copy(MOIU.ZeroBasedIndexing)
+    test_copy(MOIU.OneBasedIndexing)
 end

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -6,52 +6,52 @@ const MOIU = MOI.Utilities
 
 function bound_vectors_test(::Type{T}, nolb, noub) where {T}
     model = MOIU.Model{T}()
-    @test model.lower_bound == T[]
-    @test model.upper_bound == T[]
+    @test model.variable_bounds.lower == T[]
+    @test model.variable_bounds.upper == T[]
     x = MOI.add_variable(model)
     fx = MOI.SingleVariable(x)
-    @test model.lower_bound == [nolb]
-    @test model.upper_bound == [noub]
+    @test model.variable_bounds.lower == [nolb]
+    @test model.variable_bounds.upper == [noub]
     ux = MOI.add_constraint(model, fx, MOI.LessThan(T(1)))
-    @test model.lower_bound == [nolb]
-    @test model.upper_bound == [T(1)]
+    @test model.variable_bounds.lower == [nolb]
+    @test model.variable_bounds.upper == [T(1)]
     y = MOI.add_variable(model)
     fy = MOI.SingleVariable(y)
-    @test model.lower_bound == [nolb, nolb]
-    @test model.upper_bound == [T(1), noub]
+    @test model.variable_bounds.lower == [nolb, nolb]
+    @test model.variable_bounds.upper == [T(1), noub]
     cy = MOI.add_constraint(model, fy, MOI.Interval(T(2), T(3)))
-    @test model.lower_bound == [nolb, T(2)]
-    @test model.upper_bound == [T(1), T(3)]
+    @test model.variable_bounds.lower == [nolb, T(2)]
+    @test model.variable_bounds.upper == [T(1), T(3)]
     lx = MOI.add_constraint(model, fx, MOI.GreaterThan(T(0)))
-    @test model.lower_bound == [T(0), T(2)]
-    @test model.upper_bound == [T(1), T(3)]
+    @test model.variable_bounds.lower == [T(0), T(2)]
+    @test model.variable_bounds.upper == [T(1), T(3)]
     MOI.delete(model, lx)
-    @test model.lower_bound == [nolb, T(2)]
-    @test model.upper_bound == [T(1), T(3)]
+    @test model.variable_bounds.lower == [nolb, T(2)]
+    @test model.variable_bounds.upper == [T(1), T(3)]
     MOI.delete(model, ux)
-    @test model.lower_bound == [nolb, T(2)]
-    @test model.upper_bound == [noub, T(3)]
+    @test model.variable_bounds.lower == [nolb, T(2)]
+    @test model.variable_bounds.upper == [noub, T(3)]
     cx = MOI.add_constraint(model, fx, MOI.Semicontinuous(T(3), T(4)))
-    @test model.lower_bound == [T(3), T(2)]
-    @test model.upper_bound == [T(4), T(3)]
+    @test model.variable_bounds.lower == [T(3), T(2)]
+    @test model.variable_bounds.upper == [T(4), T(3)]
     MOI.delete(model, cy)
-    @test model.lower_bound == [T(3), nolb]
-    @test model.upper_bound == [T(4), noub]
+    @test model.variable_bounds.lower == [T(3), nolb]
+    @test model.variable_bounds.upper == [T(4), noub]
     sy = MOI.add_constraint(model, fy, MOI.Semiinteger(T(-2), T(-1)))
-    @test model.lower_bound == [T(3), T(-2)]
-    @test model.upper_bound == [T(4), T(-1)]
+    @test model.variable_bounds.lower == [T(3), T(-2)]
+    @test model.variable_bounds.upper == [T(4), T(-1)]
     MOI.delete(model, sy)
-    @test model.lower_bound == [T(3), nolb]
-    @test model.upper_bound == [T(4), noub]
+    @test model.variable_bounds.lower == [T(3), nolb]
+    @test model.variable_bounds.upper == [T(4), noub]
     ey = MOI.add_constraint(model, fy, MOI.EqualTo(T(-3)))
-    @test model.lower_bound == [T(3), T(-3)]
-    @test model.upper_bound == [T(4), T(-3)]
+    @test model.variable_bounds.lower == [T(3), T(-3)]
+    @test model.variable_bounds.upper == [T(4), T(-3)]
     MOI.delete(model, ey)
-    @test model.lower_bound == [T(3), nolb]
-    @test model.upper_bound == [T(4), noub]
+    @test model.variable_bounds.lower == [T(3), nolb]
+    @test model.variable_bounds.upper == [T(4), noub]
     MOI.delete(model, cx)
-    @test model.lower_bound == [nolb, nolb]
-    @test model.upper_bound == [noub, noub]
+    @test model.variable_bounds.lower == [nolb, nolb]
+    @test model.variable_bounds.upper == [noub, noub]
 end
 
 @testset "Basic constraint tests" begin


### PR DESCRIPTION
Various improvements to `MatrixOfConstraints`. It can now pass the relevant tests in `Test/modellike.jl`.

- Add macros to create subtypes of `StructOfConstraints` and improve `StructOfConstraints` so that sub-fields can be `MatrixOfConstraints`s.
- [breaking] Use `Box` in `MOIU.Model` for storing variable bounds.
- Implement some of the getters for MOI attributes.