### PR TITLE
[Tests] Remove unnecessary whitespace

### DIFF
--- a/src/Test/UnitTests/basic_constraint_tests.jl
+++ b/src/Test/UnitTests/basic_constraint_tests.jl
@@ -325,14 +325,11 @@ function basic_constraint_test_helper(
     x = MOI.add_variables(model, N)
     constraint_function = func(x)
     F, S = typeof(constraint_function), typeof(set)
-
     @test MOI.supports_constraint(model, F, S)
-
     @testset "add_constraint" begin
         @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 0
         c = MOI.add_constraint(model, constraint_function, set)
         @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 1
-
         if name
             @testset "ConstraintName" begin
                 if F == MOI.SingleVariable
@@ -352,7 +349,6 @@ function basic_constraint_test_helper(
                 end
             end
         end
-
         if get_constraint_function
             @testset "ConstraintFunction" begin
                 func = MOI.get(model, MOI.ConstraintFunction(), c)
@@ -366,14 +362,12 @@ function basic_constraint_test_helper(
             end
         end
     end
-
     @testset "ListOfConstraintIndices" begin
         c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         @test length(c_indices) ==
               MOI.get(model, MOI.NumberOfConstraints{F,S}()) ==
               1
     end
-
     if F != MOI.SingleVariable && F != MOI.VectorOfVariables
         # We can't add multiple variable constraints as these are
         # interpreted as bounds etc.
@@ -389,12 +383,10 @@ function basic_constraint_test_helper(
                   3
         end
     end
-
     @testset "is_valid" begin
         c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         @test all(MOI.is_valid.(model, c_indices))
     end
-
     if delete
         @testset "delete" begin
             c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())

--- a/src/Test/UnitTests/constraints.jl
+++ b/src/Test/UnitTests/constraints.jl
@@ -197,17 +197,14 @@ function solve_duplicate_terms_scalar_affine(
     x = MOI.add_variable(model)
     objective_function =
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{typeof(objective_function)}(),
         objective_function,
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, x]), 0.0)
     c = MOI.add_constraint(model, f, MOI.LessThan(1.0))
-
     return test_model_solution(
         model,
         config;
@@ -236,20 +233,17 @@ function solve_duplicate_terms_vector_affine(
     x = MOI.add_variable(model)
     objective_function =
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{typeof(objective_function)}(),
         objective_function,
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     f = MOI.VectorAffineFunction(
         MOI.VectorAffineTerm.(1, MOI.ScalarAffineTerm.([1.0, 1.0], [x, x])),
         [-1.0],
     )
     c = MOI.add_constraint(model, f, MOI.Nonpositives(1))
-
     return test_model_solution(
         model,
         config;

--- a/src/Test/UnitTests/objectives.jl
+++ b/src/Test/UnitTests/objectives.jl
@@ -226,7 +226,6 @@ function solve_qp_edge_cases(model::MOI.ModelLike, config::Config)
         MOI.GreaterThan(2.0),
     )
     @test vc2.value == x[2].value
-
     @testset "Basic model" begin
         # min x^2 + y^2 | x>=1, y>=2
         MOI.set(

--- a/src/Test/UnitTests/solve.jl
+++ b/src/Test/UnitTests/solve.jl
@@ -27,7 +27,6 @@ function solve_objbound_edge_cases(model::MOI.ModelLike, config::Config)
             @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
         end
     end
-
     @testset "Max IP with constant" begin
         MOI.empty!(model)
         @test MOI.is_empty(model)
@@ -51,7 +50,6 @@ function solve_objbound_edge_cases(model::MOI.ModelLike, config::Config)
             @test MOI.get(model, MOI.ObjectiveBound()) >= 3.0
         end
     end
-
     @testset "Min LP with constant" begin
         MOI.empty!(model)
         @test MOI.is_empty(model)
@@ -74,7 +72,6 @@ function solve_objbound_edge_cases(model::MOI.ModelLike, config::Config)
             @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
         end
     end
-
     @testset "Max LP with constant" begin
         MOI.empty!(model)
         @test MOI.is_empty(model)

--- a/src/Test/UnitTests/variables.jl
+++ b/src/Test/UnitTests/variables.jl
@@ -338,7 +338,6 @@ function solve_integer_edge_cases(model::MOI.ModelLike, config::Config)
             variable_primal = [(x, 1.0)],
         )
     end
-
     @testset "binary with upper" begin
         MOI.empty!(model)
         @test MOI.is_empty(model)
@@ -359,7 +358,6 @@ function solve_integer_edge_cases(model::MOI.ModelLike, config::Config)
             variable_primal = [(x, 1.0)],
         )
     end
-
     @testset "binary with 0 upper" begin
         MOI.empty!(model)
         @test MOI.is_empty(model)

--- a/src/Test/contconic.jl
+++ b/src/Test/contconic.jl
@@ -10,7 +10,6 @@ function _lin1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
     #            y +  z == 2
     #       x>=0 y>=0 z>=0
     # Opt obj = -11, soln x = 1, y = 0, z = 2
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -35,13 +34,10 @@ function _lin1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.VectorAffineFunction{Float64},
         MOI.Zeros,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v = MOI.add_variables(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
-
     vov = MOI.VectorOfVariables(v)
     if vecofvars
         vc = MOI.add_constraint(model, vov, MOI.Nonnegatives(3))
@@ -52,7 +48,6 @@ function _lin1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             MOI.Nonnegatives(3),
         )
     end
-
     c = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -88,7 +83,6 @@ function _lin1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.Nonnegatives,
     ) in loc
     @test (MOI.VectorAffineFunction{Float64}, MOI.Zeros) in loc
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -98,33 +92,25 @@ function _lin1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -11 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -11 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0, 2] atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ [1, 0, 2] atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ zeros(2) atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), vc) ≈ [0, 2, 0] atol =
                 atol rtol = rtol
@@ -161,7 +147,6 @@ function _lin2test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
     #       s zero
     # Opt solution = -82
     # x = -4, y = -3, z = 16, s == 0
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -193,13 +178,10 @@ function _lin2test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.VectorAffineFunction{Float64},
         MOI.Zeros,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     if vecofvars
         ys, vc = MOI.add_constrained_variables(model, MOI.Nonpositives(1))
         y = ys[1]
@@ -209,10 +191,8 @@ function _lin2test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         vc = MOI.add_constraint(model, func, MOI.Nonpositives(1))
     end
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-
     z, s = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 4
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -222,7 +202,6 @@ function _lin2test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     c = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -237,7 +216,6 @@ function _lin2test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         ),
         MOI.Zeros(3),
     )
-
     if vecofvars
         # test fallback
         vz = MOI.add_constraint(model, [z], MOI.Nonnegatives(1))
@@ -261,7 +239,6 @@ function _lin2test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             MOI.Zeros(1),
         )
     end
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -287,25 +264,19 @@ function _lin2test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             }(),
         ) == 1
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -82 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -82 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ -4 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ -3 atol = atol rtol =
@@ -314,7 +285,6 @@ function _lin2test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), s) ≈ 0 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ zeros(3) atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ [-3] atol = atol rtol =
@@ -323,7 +293,6 @@ function _lin2test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), vs) ≈ [0] atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ [7, 2, -4] atol =
                 atol rtol = rtol
@@ -355,7 +324,6 @@ function lin3test(model::MOI.ModelLike, config::Config)
     # min 0
     # s.t. -1 + x ∈ R₊
     #       1 + x ∈ R₋
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -372,12 +340,9 @@ function lin3test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.Nonnegatives,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
-
     MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -394,7 +359,6 @@ function lin3test(model::MOI.ModelLike, config::Config)
         ),
         MOI.Nonpositives(1),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -411,12 +375,9 @@ function lin3test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         if config.infeas_certificates
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
             @test MOI.get(model, MOI.ResultCount()) > 0
@@ -447,7 +408,6 @@ function lin4test(model::MOI.ModelLike, config::Config)
     # min 0
     # s.t. -1 + x ∈ R₊
     #           x ∈ R₋
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -460,13 +420,10 @@ function lin4test(model::MOI.ModelLike, config::Config)
         MOI.Nonnegatives,
     )
     @test MOI.supports_add_constrained_variables(model, MOI.Nonpositives)
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     xs, cx = MOI.add_constrained_variables(model, MOI.Nonpositives(1))
     x = xs[1]
-
     MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -475,7 +432,6 @@ function lin4test(model::MOI.ModelLike, config::Config)
         ),
         MOI.Nonnegatives(1),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -489,12 +445,9 @@ function lin4test(model::MOI.ModelLike, config::Config)
             MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonpositives}(),
         ) == 1
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         if config.infeas_certificates
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
             @test MOI.get(model, MOI.ResultCount()) > 0
@@ -533,7 +486,6 @@ function _norminf1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
     #  st  x == 1
     #      y == 1/2
     #      x >= ||(y,z)||_∞
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -554,12 +506,9 @@ function _norminf1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.VectorOfVariables,
         MOI.NormInfinityCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x, y, z = MOI.add_variables(model, 3)
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -569,7 +518,6 @@ function _norminf1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     ceq1 = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -596,7 +544,6 @@ function _norminf1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             MOI.NormInfinityCone(3),
         )
     end
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -621,39 +568,31 @@ function _norminf1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},
         MOI.NormInfinityCone,
     ) in loc
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.5 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 1.5 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.5 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 1 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), ceq1) ≈ [0] atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), ceq2) ≈ [0] atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), ccone) ≈ [1.0, 0.5, 1.0] atol =
             atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), ceq1) ≈ [-1] atol = atol rtol =
                 rtol
@@ -685,7 +624,6 @@ function norminf2test(model::MOI.ModelLike, config::Config)
     # s.t. -2 + y ∈ R₊
     #      -1 + x ∈ R₋
     #       (x,y) ∈ NormInf₂
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -707,12 +645,9 @@ function norminf2test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.NormInfinityCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x, y = MOI.add_variables(model, 2)
-
     MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -737,7 +672,6 @@ function norminf2test(model::MOI.ModelLike, config::Config)
         ),
         MOI.NormInfinityCone(2),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -761,21 +695,16 @@ function norminf2test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
-
         @test MOI.get(model, MOI.PrimalStatus()) in
               (MOI.NO_SOLUTION, MOI.INFEASIBLE_POINT)
         if config.duals && config.infeas_certificates
             @test MOI.get(model, MOI.DualStatus()) ==
                   MOI.INFEASIBILITY_CERTIFICATE
         end
-
         # TODO test dual feasibility and objective sign
     end
 end
@@ -788,7 +717,6 @@ function norminf3test(model::MOI.ModelLike, config::Config)
     #  st  (-1 + x, 2 .+ y) in NormInf(1 + n)
     #      (1 .+ y) in Nonnegatives(n)
     # let n = 3. optimal solution: y .= -1, x = 2
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
     @test MOI.supports(model, MOI.ObjectiveSense())
@@ -797,20 +725,16 @@ function norminf3test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.NormInfinityCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     y = MOI.add_variables(model, 3)
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.SingleVariable}(),
         MOI.SingleVariable(x),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     norminf_vaf = MOI.VectorAffineFunction(
         MOI.VectorAffineTerm.(1:4, MOI.ScalarAffineTerm.(1.0, vcat(x, y))),
         [-1.0, 2, 2, 2],
@@ -821,7 +745,6 @@ function norminf3test(model::MOI.ModelLike, config::Config)
         ones(3),
     )
     nonneg = MOI.add_constraint(model, nonneg_vaf, MOI.Nonnegatives(3))
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -842,35 +765,27 @@ function norminf3test(model::MOI.ModelLike, config::Config)
     @test length(loc) == 2
     @test (MOI.VectorAffineFunction{Float64}, MOI.NormInfinityCone) in loc
     @test (MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives) in loc
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 2 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 2 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ fill(-1.0, 3) atol =
             atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), norminf) ≈ ones(4) atol =
             atol rtol = rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), nonneg) ≈ zeros(3) atol =
             atol rtol = rtol
-
         if config.duals
             dual_nonneg = MOI.get(model, MOI.ConstraintDual(), nonneg)
             @test minimum(dual_nonneg) >= -atol
@@ -898,7 +813,6 @@ function _normone1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
     #  st  x == 1
     #      y == 1/2
     #      x >= ||(y,z)||_1
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -915,12 +829,9 @@ function _normone1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         )
     end
     @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.NormOneCone)
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x, y, z = MOI.add_variables(model, 3)
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -930,7 +841,6 @@ function _normone1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     ceq1 = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -957,7 +867,6 @@ function _normone1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             MOI.NormOneCone(3),
         )
     end
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -982,39 +891,31 @@ function _normone1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},
         MOI.NormOneCone,
     ) in loc
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 1 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 0.5 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 0.5 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), ceq1) ≈ [0] atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), ceq2) ≈ [0] atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), ccone) ≈ [1.0, 0.5, 0.5] atol =
             atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), ceq1) ≈ [-1] atol = atol rtol =
                 rtol
@@ -1046,7 +947,6 @@ function normone2test(model::MOI.ModelLike, config::Config)
     # s.t. -2 + y ∈ R₊
     #      -1 + x ∈ R₋
     #       (x,y) ∈ NormOne₂
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -1068,12 +968,9 @@ function normone2test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.NormOneCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x, y = MOI.add_variables(model, 2)
-
     MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -1098,7 +995,6 @@ function normone2test(model::MOI.ModelLike, config::Config)
         ),
         MOI.NormOneCone(2),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -1122,21 +1018,16 @@ function normone2test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
-
         @test MOI.get(model, MOI.PrimalStatus()) in
               (MOI.NO_SOLUTION, MOI.INFEASIBLE_POINT)
         if config.duals && config.infeas_certificates
             @test MOI.get(model, MOI.DualStatus()) ==
                   MOI.INFEASIBILITY_CERTIFICATE
         end
-
         # TODO test dual feasibility and objective sign
     end
 end
@@ -1149,7 +1040,6 @@ function normone3test(model::MOI.ModelLike, config::Config)
     #  st  (-1 + x, 2 .+ y) in NormOne(1 + n)
     #      (1 .+ y) in Nonnegatives(n)
     # let n = 3. optimal solution: y .= -1, x = 4
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
     @test MOI.supports(model, MOI.ObjectiveSense())
@@ -1158,20 +1048,16 @@ function normone3test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.NormOneCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     y = MOI.add_variables(model, 3)
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.SingleVariable}(),
         MOI.SingleVariable(x),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     norminf_vaf = MOI.VectorAffineFunction(
         MOI.VectorAffineTerm.(1:4, MOI.ScalarAffineTerm.(1.0, vcat(x, y))),
         [-1.0, 2, 2, 2],
@@ -1182,7 +1068,6 @@ function normone3test(model::MOI.ModelLike, config::Config)
         ones(3),
     )
     nonneg = MOI.add_constraint(model, nonneg_vaf, MOI.Nonnegatives(3))
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -1203,35 +1088,27 @@ function normone3test(model::MOI.ModelLike, config::Config)
     @test length(loc) == 2
     @test (MOI.VectorAffineFunction{Float64}, MOI.NormOneCone) in loc
     @test (MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives) in loc
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 4 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 4 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 4 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ fill(-1.0, 3) atol =
             atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), norminf) ≈ vcat(3, ones(3)) atol =
             atol rtol = rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), nonneg) ≈ zeros(3) atol =
             atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), norminf) ≈
                   vcat(1, fill(-1, 3)) atol = atol rtol = rtol
@@ -1257,7 +1134,6 @@ function _soc1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
     # max 0x + 1y + 1z
     #  st  x == 1
     #      x >= ||(y,z)||
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -1274,10 +1150,8 @@ function _soc1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         )
     end
     @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.Zeros)
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     if vecofvars
         xyz, csoc = MOI.add_constrained_variables(model, MOI.SecondOrderCone(3))
         x, y, z = xyz
@@ -1290,7 +1164,6 @@ function _soc1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             MOI.SecondOrderCone(3),
         )
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -1300,7 +1173,6 @@ function _soc1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     ceq = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -1309,7 +1181,6 @@ function _soc1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         ),
         MOI.Zeros(1),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -1334,37 +1205,29 @@ function _soc1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         vecofvars ? MOI.VectorOfVariables : MOI.VectorAffineFunction{Float64},
         MOI.SecondOrderCone,
     ) in loc
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √2 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ √2 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1 / √2 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), z) ≈ 1 / √2 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), ceq) ≈ [0.0] atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), csoc) ≈
               [1.0, 1 / √2, 1 / √2] atol = atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), ceq) ≈ [-√2] atol = atol rtol =
                 rtol
@@ -1393,7 +1256,6 @@ function _soc2test(model::MOI.ModelLike, config::Config, nonneg::Bool)
     # s.t.  -1/√2 + y ∈ R₊
     #        1 - t ∈ {0}
     #      (t,x,y) ∈ SOC₃
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -1423,19 +1285,15 @@ function _soc2test(model::MOI.ModelLike, config::Config, nonneg::Bool)
         MOI.VectorAffineFunction{Float64},
         MOI.SecondOrderCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x, y, t = MOI.add_variables(model, 3)
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if nonneg
         cnon = MOI.add_constraint(
             model,
@@ -1474,7 +1332,6 @@ function _soc2test(model::MOI.ModelLike, config::Config, nonneg::Bool)
         ),
         MOI.SecondOrderCone(3),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -1498,40 +1355,32 @@ function _soc2test(model::MOI.ModelLike, config::Config, nonneg::Bool)
             }(),
         ) == 1
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -1 / √2 atol = atol rtol =
             rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -1 / √2 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ -1 / √2 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1 / √2 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 1 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), cnon) ≈ [0.0] atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), ceq) ≈ [0.0] atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), csoc) ≈
               [1.0, -1 / √2, 1 / √2] atol = atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), cnon) ≈
                   [nonneg ? 1.0 : -1.0] atol = atol rtol = rtol
@@ -1563,7 +1412,6 @@ function soc3test(model::MOI.ModelLike, config::Config)
     # s.t. -2 + y ∈ R₊
     #      -1 + x ∈ R₋
     #       (x,y) ∈ SOC₂
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -1585,12 +1433,9 @@ function soc3test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.SecondOrderCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x, y = MOI.add_variables(model, 2)
-
     MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -1615,7 +1460,6 @@ function soc3test(model::MOI.ModelLike, config::Config)
         ),
         MOI.SecondOrderCone(2),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -1639,21 +1483,16 @@ function soc3test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
-
         @test MOI.get(model, MOI.PrimalStatus()) in
               (MOI.NO_SOLUTION, MOI.INFEASIBLE_POINT)
         if config.duals && config.infeas_certificates
             @test MOI.get(model, MOI.DualStatus()) ==
                   MOI.INFEASIBILITY_CERTIFICATE
         end
-
         # TODO test dual feasibility and objective sign
     end
 end
@@ -1673,7 +1512,6 @@ function soc4test(model::MOI.ModelLike, config::Config)
     #      (x[1],x[4],x[5]) ∈ SOC₃
     # Like SOCINT1 but with copies of variables and integrality relaxed
     # Tests out-of-order indices in cones
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -1690,12 +1528,9 @@ function soc4test(model::MOI.ModelLike, config::Config)
         MOI.VectorOfVariables,
         MOI.SecondOrderCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variables(model, 5)
-
     c1 = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -1712,7 +1547,6 @@ function soc4test(model::MOI.ModelLike, config::Config)
         MOI.VectorOfVariables([x[1], x[4], x[5]]),
         MOI.SecondOrderCone(3),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -1726,7 +1560,6 @@ function soc4test(model::MOI.ModelLike, config::Config)
             MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -1738,30 +1571,23 @@ function soc4test(model::MOI.ModelLike, config::Config)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -√5 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ -√5 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈
               [1.0, 2 / √5, 1 / √5, 2 / √5, 1 / √5] atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ zeros(3) atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ [1.0, 2 / √5, 1 / √5] atol =
             atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ [-√5, -2.0, -1.0] atol =
                 atol rtol = rtol
@@ -1796,7 +1622,6 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::Config, abvars::Bool)
     #     [1.0] - [      ] SOCRotated
     #     [0.0] - [-y    ] SOCRotated
     #     [0.0] - [    -z] SOCRotated
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -1820,10 +1645,8 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::Config, abvars::Bool)
             MOI.RotatedSecondOrderCone,
         )
     end
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     if abvars
         abx, rsoc =
             MOI.add_constrained_variables(model, MOI.RotatedSecondOrderCone(4))
@@ -1851,7 +1674,6 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::Config, abvars::Bool)
             MOI.RotatedSecondOrderCone(4),
         )
     end
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -1866,7 +1688,6 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::Config, abvars::Bool)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -1875,22 +1696,17 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::Config, abvars::Bool)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √2 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ √2 atol = atol rtol =
                 rtol
         end
-
         if abvars
             @test MOI.get(model, MOI.VariablePrimal(), a) ≈ 0.5 atol = atol rtol =
                 rtol
@@ -1899,27 +1715,22 @@ function _rotatedsoc1test(model::MOI.ModelLike, config::Config, abvars::Bool)
         end
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [1 / √2, 1 / √2] atol =
             atol rtol = rtol
-
         if abvars
             @test MOI.get(model, MOI.ConstraintPrimal(), vc1) ≈ 0.5 atol = atol rtol =
                 rtol
             @test MOI.get(model, MOI.ConstraintPrimal(), vc2) ≈ 1.0 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.ConstraintPrimal(), rsoc) ≈
               [0.5, 1.0, 1 / √2, 1 / √2] atol = atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus(1)) == MOI.FEASIBLE_POINT
-
             if abvars
                 @test MOI.get(model, MOI.ConstraintDual(), vc1) ≈ -√2 atol =
                     atol rtol = rtol
                 @test MOI.get(model, MOI.ConstraintDual(), vc2) ≈ -1 / √2 atol =
                     atol rtol = rtol
             end
-
             @test MOI.get(model, MOI.ConstraintDual(), rsoc) ≈
                   [√2, 1 / √2, -1.0, -1.0] atol = atol rtol = rtol
         end
@@ -1952,7 +1763,6 @@ function rotatedsoc2test(model::MOI.ModelLike, config::Config)
     #       (x,y,z) ∈ SOCRotated
     b = [-2, -1, 1 / 2]
     c = [0.0, 0.0, 0.0]
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -1978,13 +1788,10 @@ function rotatedsoc2test(model::MOI.ModelLike, config::Config)
         model,
         MOI.RotatedSecondOrderCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x, rsoc =
         MOI.add_constrained_variables(model, MOI.RotatedSecondOrderCone(3))
-
     vc1 = MOI.add_constraint(model, MOI.SingleVariable(x[1]), MOI.LessThan(1.0))
     @test vc1.value == x[1].value
     vc2 = MOI.add_constraint(model, MOI.SingleVariable(x[2]), MOI.EqualTo(0.5))
@@ -1995,7 +1802,6 @@ function rotatedsoc2test(model::MOI.ModelLike, config::Config)
         MOI.GreaterThan(2.0),
     )
     @test vc3.value == x[3].value
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -2020,7 +1826,6 @@ function rotatedsoc2test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -2029,12 +1834,9 @@ function rotatedsoc2test(model::MOI.ModelLike, config::Config)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) in
               [MOI.INFEASIBLE, MOI.INFEASIBLE_OR_UNBOUNDED]
-
         if config.duals
             if config.infeas_certificates
                 @test MOI.get(model, MOI.DualStatus()) in [
@@ -2042,19 +1844,13 @@ function rotatedsoc2test(model::MOI.ModelLike, config::Config)
                     MOI.NEARLY_INFEASIBILITY_CERTIFICATE,
                 ]
             end
-
             y1 = MOI.get(model, MOI.ConstraintDual(), vc1)
             @test y1 < -atol # Should be strictly negative
-
             y2 = MOI.get(model, MOI.ConstraintDual(), vc2)
-
             y3 = MOI.get(model, MOI.ConstraintDual(), vc3)
             @test y3 > atol # Should be strictly positive
-
             y = [y1, y2, y3]
-
             vardual = MOI.get(model, MOI.ConstraintDual(), rsoc)
-
             @test vardual ≈ -y atol = atol rtol = rtol
             @test 2 * vardual[1] * vardual[2] ≥ vardual[3]^2 - atol
             @test dot(b, y) > atol
@@ -2075,7 +1871,6 @@ function rotatedsoc3test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
     #      t2 == 1
     # [t1/√2, t2/√2, x] in SOC4
     # [x1/√2, u/√2,  v] in SOC3
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -2103,15 +1898,12 @@ function rotatedsoc3test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
         MOI.VectorAffineFunction{Float64},
         MOI.RotatedSecondOrderCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x, cx = MOI.add_constrained_variables(model, MOI.Nonnegatives(n))
     u = MOI.add_variable(model)
     v = MOI.add_variable(model)
     t = MOI.add_variables(model, 2)
-
     ct1 = MOI.add_constraint(model, MOI.SingleVariable(t[1]), MOI.EqualTo(1.0))
     @test ct1.value == t[1].value
     ct2 = MOI.add_constraint(model, MOI.SingleVariable(t[2]), MOI.EqualTo(1.0))
@@ -2120,7 +1912,6 @@ function rotatedsoc3test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
     @test cu1.value == u.value
     cu2 = MOI.add_constraint(model, MOI.SingleVariable(u), MOI.LessThan(ub))
     @test cu2.value == u.value
-
     c1 = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -2143,7 +1934,6 @@ function rotatedsoc3test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
         ),
         MOI.RotatedSecondOrderCone(3),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -2179,32 +1969,25 @@ function rotatedsoc3test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
             }(),
         ) == 2
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v)], 0.0),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √ub atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ √ub atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ [1.0; zeros(n - 1)] atol =
             atol rtol = rtol
         @test MOI.get(model, MOI.VariablePrimal(), u) ≈ ub atol = atol rtol =
@@ -2213,7 +1996,6 @@ function rotatedsoc3test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ ones(2) atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ [1.0; zeros(n - 1)] atol =
             atol rtol = rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cu1) ≈ ub atol = atol rtol =
@@ -2224,12 +2006,10 @@ function rotatedsoc3test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), ct2) ≈ 1.0 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈
               [1 / √2; 1 / √2; 1.0; zeros(n - 1)] atol = atol rtol = rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈
               [1 / √2, ub / √2, √ub] atol = atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ zeros(n) atol =
                 atol rtol = rtol
@@ -2241,7 +2021,6 @@ function rotatedsoc3test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
                 atol rtol = rtol
             @test MOI.get(model, MOI.ConstraintDual(), ct2) ≈ -√ub / 4 atol =
                 atol rtol = rtol
-
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈
                   [√ub / (2 * √2); √ub / (2 * √2); -√ub / 2; zeros(n - 1)] atol =
                 atol rtol = rtol
@@ -2274,7 +2053,6 @@ function rotatedsoc4test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
     # with equality iff x = y.
     # We conclude that the optimal solution is x = y = t = u = 1
     # with objective value 2.
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -2290,10 +2068,8 @@ function rotatedsoc4test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
         model,
         MOI.RotatedSecondOrderCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v, cv = MOI.add_constrained_variables(model, MOI.RotatedSecondOrderCone(4))
     t, u, x, y = v
     ft = MOI.SingleVariable(t)
@@ -2304,25 +2080,19 @@ function rotatedsoc4test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
     func = 1.0fx + 1.0fy
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{typeof(func)}(), func)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 2.0 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 1.0 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), u) ≈ 1.0 atol = atol rtol =
@@ -2331,12 +2101,10 @@ function rotatedsoc4test(model::MOI.ModelLike, config::Config; n = 2, ub = 3.0)
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1.0 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), cv) ≈ ones(4) atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2.0 atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), cv) ≈
                   [1.0, 1.0, -1.0, -1.0] atol = atol rtol = rtol
@@ -2372,7 +2140,6 @@ function _geomean1test(model::MOI.ModelLike, config::Config, vecofvars, n = 3)
     # (xyz)^(1/3) ≤ (x+y+z)/3 = 1
     # Therefore xyz ≤ 1
     # This can be attained using x = y = z = 1 so it is optimal.
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -2397,13 +2164,10 @@ function _geomean1test(model::MOI.ModelLike, config::Config, vecofvars, n = 3)
         MOI.ScalarAffineFunction{Float64},
         MOI.LessThan{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     t = MOI.add_variable(model)
     x = MOI.add_variables(model, n)
-
     vov = MOI.VectorOfVariables([t; x])
     if vecofvars
         gmc = MOI.add_constraint(model, vov, MOI.GeometricMeanCone(n + 1))
@@ -2419,7 +2183,6 @@ function _geomean1test(model::MOI.ModelLike, config::Config, vecofvars, n = 3)
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, x), 0.0),
         MOI.LessThan(Float64(n)),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -2437,7 +2200,6 @@ function _geomean1test(model::MOI.ModelLike, config::Config, vecofvars, n = 3)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -2446,25 +2208,18 @@ function _geomean1test(model::MOI.ModelLike, config::Config, vecofvars, n = 3)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 1 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ ones(n) atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), gmc) ≈ ones(n + 1) atol =
             atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ n atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈
                   vcat(-1.0, fill(inv(n), n)) atol = atol rtol = rtol
@@ -2490,7 +2245,6 @@ function _geomean2test(model::MOI.ModelLike, config::Config, vecofvars)
     # st  (t,x_1,x_2,...,x_9) ∈ GeometricMeanCone(10)
     #     x_1 == x_2, ..., x_9 == 1
     # the optimal solution is 1 with optimal value 1
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -2510,15 +2264,12 @@ function _geomean2test(model::MOI.ModelLike, config::Config, vecofvars)
             MOI.GeometricMeanCone,
         )
     end
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     n = 9
     t = MOI.add_variable(model)
     x = MOI.add_variables(model, n)
     @test MOI.get(model, MOI.NumberOfVariables()) == n + 1
-
     vov = MOI.VectorOfVariables([t; x])
     if vecofvars
         gmc = MOI.add_constraint(model, vov, MOI.GeometricMeanCone(n + 1))
@@ -2529,7 +2280,6 @@ function _geomean2test(model::MOI.ModelLike, config::Config, vecofvars)
             MOI.GeometricMeanCone(n + 1),
         )
     end
-
     cx = Vector{
         MOI.ConstraintIndex{
             MOI.ScalarAffineFunction{Float64},
@@ -2546,7 +2296,6 @@ function _geomean2test(model::MOI.ModelLike, config::Config, vecofvars)
             MOI.EqualTo(1.0),
         )
     end
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -2564,7 +2313,6 @@ function _geomean2test(model::MOI.ModelLike, config::Config, vecofvars)
             }(),
         ) == n
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -2573,24 +2321,18 @@ function _geomean2test(model::MOI.ModelLike, config::Config, vecofvars)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.0 atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 1.0 atol = atol rtol =
             rtol
         @test MOI.get.(model, MOI.VariablePrimal(), x) ≈ ones(n) atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), gmc) ≈ ones(n + 1) atol =
             atol rtol = rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ ones(n) atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈
                   vcat(-1, fill(inv(n), n)) atol = atol rtol = rtol
@@ -2616,7 +2358,6 @@ function _geomean3test(model::MOI.ModelLike, config::Config, vecofvars)
     # st  (t,x) ∈ GeometricMeanCone(2)
     #     x <= 2
     # the optimal solution is (t, x) = (2, 2) with objective value 4
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -2636,14 +2377,11 @@ function _geomean3test(model::MOI.ModelLike, config::Config, vecofvars)
             MOI.GeometricMeanCone,
         )
     end
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     t = MOI.add_variable(model)
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-
     vov = MOI.VectorOfVariables([t; x])
     if vecofvars
         gmc = MOI.add_constraint(model, vov, MOI.GeometricMeanCone(2))
@@ -2659,7 +2397,6 @@ function _geomean3test(model::MOI.ModelLike, config::Config, vecofvars)
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0),
         MOI.LessThan(2.0),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -2677,7 +2414,6 @@ function _geomean3test(model::MOI.ModelLike, config::Config, vecofvars)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -2686,24 +2422,18 @@ function _geomean3test(model::MOI.ModelLike, config::Config, vecofvars)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 4.0 atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 2.0 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 2.0 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), gmc) ≈ [2.0; 2.0] atol =
             atol rtol = rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ 2.0 atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), gmc) ≈ [-2.0, 2.0] atol =
                 atol rtol = rtol
@@ -2739,7 +2469,6 @@ function _exp1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
     #  st  y e^(x/y) <= z, y > 0 (i.e (x, y, z) are in the exponential primal cone)
     #      x == 1
     #      y == 2
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -2764,13 +2493,10 @@ function _exp1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.ScalarAffineFunction{Float64},
         MOI.EqualTo{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v = MOI.add_variables(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
-
     vov = MOI.VectorOfVariables(v)
     if vecofvars
         vc = MOI.add_constraint(model, vov, MOI.ExponentialCone())
@@ -2781,7 +2507,6 @@ function _exp1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             MOI.ExponentialCone(),
         )
     end
-
     cx = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[1])], 0.0),
@@ -2792,50 +2517,39 @@ function _exp1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[2])], 0.0),
         MOI.EqualTo(2.0),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(1.0, v), 0.0),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 + 2exp(1 / 2) atol = atol rtol =
             rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 3 + 2exp(1 / 2) atol =
                 atol rtol = rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1.0, 2.0, 2exp(1 / 2)] atol =
             atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈
               [1.0, 2.0, 2exp(1 / 2)] atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ 1 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cy) ≈ 2 atol = atol rtol =
             rtol
-
         if config.duals
             u, v, w = MOI.get(model, MOI.ConstraintDual(), vc)
             @test u ≈ -exp(1 / 2) atol = atol rtol = rtol
             @test v ≈ -exp(1 / 2) / 2 atol = atol rtol = rtol
             @test w ≈ 1 atol = atol rtol = rtol
-
             @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ 1 + exp(1 / 2) atol =
                 atol rtol = rtol
             @test MOI.get(model, MOI.ConstraintDual(), cy) ≈ 1 + exp(1 / 2) / 2 atol =
@@ -2856,7 +2570,6 @@ function exp2test(model::MOI.ModelLike, config::Config)
     # A problem where ECOS was failing
     atol = config.atol
     rtol = config.rtol
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -2883,13 +2596,10 @@ function exp2test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.Nonnegatives,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v = MOI.add_variables(model, 9)
     @test MOI.get(model, MOI.NumberOfVariables()) == 9
-
     ec1 = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -2961,37 +2671,29 @@ function exp2test(model::MOI.ModelLike, config::Config)
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[7])], 0.0),
         MOI.EqualTo(0.0),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[6])], 0.0),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ exp(-0.3) atol = atol rtol =
             rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ exp(-0.3) atol =
                 atol rtol = rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈
               [0.0, -0.3, 0.0, exp(-0.3), exp(-0.3), exp(-0.3), 0.0, 1.0, 0.0] atol =
             atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), ec1) ≈
               [-0.3, 1.0, exp(-0.3)] atol = atol rtol = rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), ec2) ≈
@@ -3006,7 +2708,6 @@ function exp2test(model::MOI.ModelLike, config::Config)
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c5) ≈ 0.0 atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), ec1) ≈
                   [-exp(-0.3) / 2, -1.3exp(-0.3) / 2, 0.5] atol = atol rtol =
@@ -3034,7 +2735,6 @@ function exp3test(model::MOI.ModelLike, config::Config)
     # A problem where ECOS was failing
     atol = config.atol
     rtol = config.rtol
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -3056,14 +2756,11 @@ function exp3test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.ExponentialCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-
     xc = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(2.0, x)], 0.0),
@@ -3079,45 +2776,36 @@ function exp3test(model::MOI.ModelLike, config::Config)
         ),
         MOI.ExponentialCone(),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ log(5) atol = atol rtol =
             rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ log(5) atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ log(5) atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 5.0 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), xc) ≈ 2log(5) atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), yc) ≈ 5 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), ec) ≈ [log(5), 1.0, 5.0] atol =
             atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), xc) ≈ 0.0 atol = atol rtol =
                 rtol
@@ -3148,7 +2836,6 @@ function _dualexp1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
     # x_2 + v == 1
     # w == 1
     # (u, v, w) ∈ DualExponentialCone
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -3173,14 +2860,11 @@ function _dualexp1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.ScalarAffineFunction{Float64},
         MOI.EqualTo{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v = MOI.add_variables(model, 3)
     x = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 5
-
     vov = MOI.VectorOfVariables(v)
     if vecofvars
         vc = MOI.add_constraint(model, vov, MOI.DualExponentialCone())
@@ -3191,7 +2875,6 @@ function _dualexp1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             MOI.DualExponentialCone(),
         )
     end
-
     cu = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction(
@@ -3213,54 +2896,43 @@ function _dualexp1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[3])], 0.0),
         MOI.EqualTo(1.0),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0], x), 0.0),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 + 2exp(1 / 2) atol = atol rtol =
             rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 3 + 2exp(1 / 2) atol =
                 atol rtol = rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈
               [-exp(1 / 2), -exp(1 / 2) / 2, 1.0] atol = atol rtol = rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈
               [1 + exp(1 / 2), 1 + exp(1 / 2) / 2] atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈
               [-exp(1 / 2), -exp(1 / 2) / 2, 1.0] atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), cu) ≈ 1 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cv) ≈ 1 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cw) ≈ 1 atol = atol rtol =
             rtol
-
         if config.duals
             x, y, z = MOI.get(model, MOI.ConstraintDual(), vc)
             @test x ≈ 1.0 atol = atol rtol = rtol
             @test y ≈ 2.0 atol = atol rtol = rtol
             @test z ≈ 2exp(1 / 2) atol = atol rtol = rtol
-
             @test MOI.get(model, MOI.ConstraintDual(), cu) ≈ -1 atol = atol rtol =
                 rtol
             @test MOI.get(model, MOI.ConstraintDual(), cv) ≈ -2 atol = atol rtol =
@@ -3303,7 +2975,6 @@ function _pow1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
     )
     @test MOI.supports(model, MOI.ObjectiveSense())
-
     if vecofvars
         @test MOI.supports_constraint(
             model,
@@ -3322,15 +2993,11 @@ function _pow1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.ScalarAffineFunction{Float64},
         MOI.EqualTo{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v = MOI.add_variables(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
-
     vov = MOI.VectorOfVariables(v)
-
     if vecofvars
         vc = MOI.add_constraint(model, vov, MOI.PowerCone(a))
     else
@@ -3340,7 +3007,6 @@ function _pow1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             MOI.PowerCone(a),
         )
     end
-
     cx = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[1])], 0.0),
@@ -3351,39 +3017,30 @@ function _pow1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[2])], 0.0),
         MOI.EqualTo(1.0),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[3])], 0.0),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2^0.9 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0, 1.0, 2^0.9] atol =
             atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ [2.0, 1.0, 2^0.9] atol =
             atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ 2.0 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cy) ≈ 1.0 atol = atol rtol =
             rtol
-
         if config.duals
             # Only real solution of u^10 - u^9 / 2^0.1 = -(0.1*0.9^9)/2
             u_value = 0.839729692
@@ -3392,7 +3049,6 @@ function _pow1test(model::MOI.ModelLike, config::Config, vecofvars::Bool)
             @test u ≈ u_value atol = atol rtol = rtol
             @test v ≈ v_value atol = atol rtol = rtol
             @test w ≈ -1 atol = atol rtol = rtol
-
             @test MOI.get(model, MOI.ConstraintDual(), cx) ≈ -u_value atol =
                 atol rtol = rtol
             @test MOI.get(model, MOI.ConstraintDual(), cy) ≈ -v_value atol =
@@ -3426,7 +3082,6 @@ function _dualpow1test(
     #      x_2 + v == 0
     #      w == 1
     #     (u, v, w) ∈ DualPowerCone(exponent)
-
     # By the Weighted AM–GM inequality, you have
     # 0.9a + 0.1b >= a^0.9 b^0.1
     # with equality if and only if a == b
@@ -3436,14 +3091,12 @@ function _dualpow1test(
     # Here the best you can do is u + v == 1 and for that inequality must hold so u = 9v
     # hence you get v = 0.1 and u = 0.9.
     # The same works for other values of exponent as key word argument
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
     )
     @test MOI.supports(model, MOI.ObjectiveSense())
-
     if vecofvars
         @test MOI.supports_constraint(
             model,
@@ -3462,16 +3115,12 @@ function _dualpow1test(
         MOI.ScalarAffineFunction{Float64},
         MOI.EqualTo{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v = MOI.add_variables(model, 3)
     x = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 5
-
     vov = MOI.VectorOfVariables(v)
-
     if vecofvars
         vc = MOI.add_constraint(model, vov, MOI.DualPowerCone(exponent))
     else
@@ -3481,7 +3130,6 @@ function _dualpow1test(
             MOI.DualPowerCone(exponent),
         )
     end
-
     cu = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction(
@@ -3503,7 +3151,6 @@ function _dualpow1test(
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, v[3])], 0.0),
         MOI.EqualTo(1.0),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -3513,41 +3160,32 @@ function _dualpow1test(
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.0 atol = atol rtol = rtol
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈
               [exponent, (1 - exponent), 1.0] atol = atol rtol = rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈
               [-exponent, -(1 - exponent)] atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈
               [exponent, (1 - exponent), 1.0] atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), cu) ≈ 0.0 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cv) ≈ 0.0 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cw) ≈ 1.0 atol = atol rtol =
             rtol
-
         if config.duals
             x, y, z = MOI.get(model, MOI.ConstraintDual(), vc)
             @test x ≈ 1.0 atol = atol rtol = rtol
             @test y ≈ 1.0 atol = atol rtol = rtol
             @test z ≈ -1 atol = atol rtol = rtol
-
             @test MOI.get(model, MOI.ConstraintDual(), cu) ≈ -1.0 atol = atol rtol =
                 rtol
             @test MOI.get(model, MOI.ConstraintDual(), cv) ≈ -1.0 atol = atol rtol =
@@ -3577,7 +3215,6 @@ function relentr1test(model::MOI.ModelLike, config::Config)
     #  st  u >= 2*log(2/1) + 3*log(3/5)  (i.e. (u, 1, 5, 2, 3) in RelativeEntropyCone(5))
     # Optimal solution is:
     # u = 2*log(2/1) + 3*log(3/5) ≈ -0.1461825
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
     @test MOI.supports(model, MOI.ObjectiveSense())
@@ -3586,13 +3223,10 @@ function relentr1test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.RelativeEntropyCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     u = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     relentr = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -3601,26 +3235,20 @@ function relentr1test(model::MOI.ModelLike, config::Config)
         ),
         MOI.RelativeEntropyCone(5),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.SingleVariable}(),
         MOI.SingleVariable(u),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         u_opt = 2 * log(2) + 3 * log(3 / 5)
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ u_opt atol = atol rtol =
             rtol
@@ -3628,12 +3256,10 @@ function relentr1test(model::MOI.ModelLike, config::Config)
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ u_opt atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), u) ≈ u_opt atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), relentr) ≈
               [u_opt, 1, 5, 2, 3] atol = atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), relentr) ≈
                   [1, 2, 0.6, log(0.5) - 1, log(5 / 3) - 1] atol = atol rtol =
@@ -3654,7 +3280,6 @@ function normspec1test(model::MOI.ModelLike, config::Config)
     #  st  t >= sigma_1([1 1 0; 1 -1 1]) (i.e (t, 1, 1, 1, -1, 0, 1]) is in NormSpectralCone(2, 3))
     # Singular values are [sqrt(3), sqrt(2)], so optimal solution is:
     # t = sqrt(3)
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
     @test MOI.supports(model, MOI.ObjectiveSense())
@@ -3663,13 +3288,10 @@ function normspec1test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.NormSpectralCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     t = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     data = Float64[1, 1, 1, -1, 0, 1]
     spec = MOI.add_constraint(
         model,
@@ -3679,38 +3301,30 @@ function normspec1test(model::MOI.ModelLike, config::Config)
         ),
         MOI.NormSpectralCone(2, 3),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.SingleVariable}(),
         MOI.SingleVariable(t),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         rt3 = sqrt(3)
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ rt3 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ rt3 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ rt3 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), spec) ≈ vcat(rt3, data) atol =
             atol rtol = rtol
-
         if config.duals
             invrt3 = inv(rt3)
             @test MOI.get(model, MOI.ConstraintDual(), spec) ≈
@@ -3728,7 +3342,6 @@ function normspec2test(model::MOI.ModelLike, config::Config)
     #  st  t >= sigma_1([1 1; 1 -1; 0 1]) (i.e (t, 1, 1, 0, 1, -1, 1]) is in NormSpectralCone(3, 2))
     # Singular values are [sqrt(3), sqrt(2)], so optimal solution is:
     # t = sqrt(3)
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
     @test MOI.supports(model, MOI.ObjectiveSense())
@@ -3737,13 +3350,10 @@ function normspec2test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.NormSpectralCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     t = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     data = Float64[1, 1, 0, 1, -1, 1]
     spec = MOI.add_constraint(
         model,
@@ -3753,38 +3363,30 @@ function normspec2test(model::MOI.ModelLike, config::Config)
         ),
         MOI.NormSpectralCone(3, 2),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.SingleVariable}(),
         MOI.SingleVariable(t),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         rt3 = sqrt(3)
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ rt3 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ rt3 atol = atol rtol =
                 rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ rt3 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), spec) ≈ vcat(rt3, data) atol =
             atol rtol = rtol
-
         if config.duals
             invrt3 = inv(rt3)
             @test MOI.get(model, MOI.ConstraintDual(), spec) ≈
@@ -3806,7 +3408,6 @@ function normnuc1test(model::MOI.ModelLike, config::Config)
     #  st  t >= sum_i sigma_i([1 1 0; 1 -1 1]) (i.e (t, 1, 1, 1, -1, 0, 1]) is in NormNuclearCone(2, 3))
     # Singular values are [sqrt(3), sqrt(2)], so optimal solution is:
     # t = sqrt(3) + sqrt(2)
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
     @test MOI.supports(model, MOI.ObjectiveSense())
@@ -3815,13 +3416,10 @@ function normnuc1test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.NormNuclearCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     t = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     data = Float64[1, 1, 1, -1, 0, 1]
     nuc = MOI.add_constraint(
         model,
@@ -3831,26 +3429,20 @@ function normnuc1test(model::MOI.ModelLike, config::Config)
         ),
         MOI.NormNuclearCone(2, 3),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.SingleVariable}(),
         MOI.SingleVariable(t),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         rt3 = sqrt(3)
         rt2 = sqrt(2)
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ rt3 + rt2 atol = atol rtol =
@@ -3859,12 +3451,10 @@ function normnuc1test(model::MOI.ModelLike, config::Config)
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ rt3 + rt2 atol =
                 atol rtol = rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ rt3 + rt2 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), nuc) ≈
               vcat(rt3 + rt2, data) atol = atol rtol = rtol
-
         if config.duals
             invrt2 = inv(rt2)
             invrt3 = inv(rt3)
@@ -3883,7 +3473,6 @@ function normnuc2test(model::MOI.ModelLike, config::Config)
     #  st  t >= sum_i sigma_i([1 1; 1 -1; 0 1]) (i.e (t, 1, 1, 0, 1, -1, 1]) is in NormNuclearCone(3, 2))
     # Singular values are [sqrt(3), sqrt(2)], so optimal solution is:
     # t = sqrt(3) + sqrt(2)
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
     @test MOI.supports(model, MOI.ObjectiveSense())
@@ -3892,13 +3481,10 @@ function normnuc2test(model::MOI.ModelLike, config::Config)
         MOI.VectorAffineFunction{Float64},
         MOI.NormNuclearCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     t = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     data = Float64[1, 1, 0, 1, -1, 1]
     nuc = MOI.add_constraint(
         model,
@@ -3908,26 +3494,20 @@ function normnuc2test(model::MOI.ModelLike, config::Config)
         ),
         MOI.NormNuclearCone(3, 2),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.SingleVariable}(),
         MOI.SingleVariable(t),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         rt3 = sqrt(3)
         rt2 = sqrt(2)
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ rt3 + rt2 atol = atol rtol =
@@ -3936,12 +3516,10 @@ function normnuc2test(model::MOI.ModelLike, config::Config)
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ rt3 + rt2 atol =
                 atol rtol = rtol
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ rt3 + rt2 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), nuc) ≈
               vcat(rt3 + rt2, data) atol = atol rtol = rtol
-
         if config.duals
             invrt2 = inv(rt2)
             invrt3 = inv(rt3)
@@ -3973,7 +3551,6 @@ function _psd0test(
     #     ⎛ 1   1 ⎞
     # X = ⎜       ⎟           y = 2
     #     ⎝ 1   1 ⎠
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -3994,13 +3571,10 @@ function _psd0test(
         MOI.ScalarAffineFunction{Float64},
         MOI.EqualTo{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     X = MOI.add_variables(model, square ? 4 : 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == (square ? 4 : 3)
-
     vov = MOI.VectorOfVariables(X)
     if vecofvars
         cX = MOI.add_constraint(model, vov, psdcone(2))
@@ -4011,13 +3585,11 @@ function _psd0test(
             psdcone(2),
         )
     end
-
     c = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, X[2])], 0.0),
         MOI.EqualTo(1.0),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -4035,7 +3607,6 @@ function _psd0test(
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -4047,32 +3618,25 @@ function _psd0test(
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2 atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ 2 atol = atol rtol =
                 rtol
         end
-
         Xv = square ? ones(4) : ones(3)
         @test MOI.get(model, MOI.VariablePrimal(), X) ≈ Xv atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cX) ≈ Xv atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), c) ≈ 2 atol = atol rtol =
                 rtol
-
             cXv = square ? [1, -2, 0, 1] : [1, -1, 1]
             @test MOI.get(model, MOI.ConstraintDual(), cX) ≈ cXv atol = atol rtol =
                 rtol
@@ -4171,7 +3735,6 @@ function _psd1test(
     # With (2) we get
     α = √(3 - 2obj - 4x2) / 2
     β = k * α
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -4197,15 +3760,12 @@ function _psd1test(
         MOI.VectorOfVariables,
         MOI.SecondOrderCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     X = MOI.add_variables(model, square ? 9 : 6)
     @test MOI.get(model, MOI.NumberOfVariables()) == (square ? 9 : 6)
     x = MOI.add_variables(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == (square ? 12 : 9)
-
     vov = MOI.VectorOfVariables(X)
     if vecofvars
         cX = MOI.add_constraint(model, vov, psdcone(3))
@@ -4221,7 +3781,6 @@ function _psd1test(
         MOI.VectorOfVariables(x),
         MOI.SecondOrderCone(3),
     )
-
     c1 = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction(
@@ -4244,7 +3803,6 @@ function _psd1test(
         ),
         MOI.EqualTo(1 / 2),
     )
-
     objXidx = square ? [1:2; 4:6; 8:9] : [1:3; 5:6]
     objXcoefs = square ? [2.0, 1.0, 1.0, 2.0, 1.0, 1.0, 2.0] : 2 * ones(5)
     MOI.set(
@@ -4256,7 +3814,6 @@ function _psd1test(
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -4278,25 +3835,19 @@ function _psd1test(
             MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}(),
         ) == 1
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ obj atol = atol rtol = rtol
         if config.dual_objective_value
             @test MOI.get(model, MOI.DualObjectiveValue()) ≈ obj atol = atol rtol =
                 rtol
         end
-
         Xv =
             square ? [α^2, α * β, α^2, α * β, β^2, α * β, α^2, α * β, α^2] :
             [α^2, α * β, β^2, α^2, α * β, α^2]
@@ -4305,7 +3856,6 @@ function _psd1test(
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ xv atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), cX) ≈ Xv atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), cx) ≈ xv atol = atol rtol =
@@ -4314,7 +3864,6 @@ function _psd1test(
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 0.5 atol = atol rtol =
             rtol
-
         if config.duals
             cX0 = 1 + (√2 - 1) * y2
             cX1 = 1 - y2
@@ -4351,7 +3900,6 @@ function psdt2test(model::MOI.ModelLike, config::Config)
     atol = config.atol
     rtol = config.rtol
     # Caused getdual to fail on SCS and Mosek
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -4378,13 +3926,10 @@ function psdt2test(model::MOI.ModelLike, config::Config)
         MOI.ScalarAffineFunction{Float64},
         MOI.EqualTo{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variables(model, 7)
     @test MOI.get(model, MOI.NumberOfVariables()) == 7
-
     η = 10.0
     c1 = MOI.add_constraint(
         model,
@@ -4442,7 +3987,6 @@ function psdt2test(model::MOI.ModelLike, config::Config)
         ),
         MOI.EqualTo(0.0),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -4473,7 +4017,6 @@ function psdt2test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -4482,20 +4025,15 @@ function psdt2test(model::MOI.ModelLike, config::Config)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈
               [2η / 3, 0, η / 3, 0, 0, 0, η * δ * (1 - 1 / √3) / 2] atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ -η atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈
@@ -4507,7 +4045,6 @@ function psdt2test(model::MOI.ModelLike, config::Config)
         ] atol = atol rtol = rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c4) ≈ 0.0 atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈
                   δ * (1 - 1 / √3) / 2 atol = atol rtol = rtol
@@ -4532,21 +4069,16 @@ function _psd3test(model::MOI.ModelLike, psdcone, config::Config{T}) where {T}
     # s.t. [x 1 1]
     #      [1 x 1] ⪰ 0
     #      [1 1 x]
-
     atol = config.atol
     rtol = config.rtol
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
     @test MOI.supports(model, MOI.ObjectiveSense())
     @test MOI.supports_constraint(model, MOI.VectorAffineFunction{T}, psdcone)
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     fx = MOI.SingleVariable(x)
-
     if psdcone == MOI.PositiveSemidefiniteConeTriangle
         func = MOIU.operate(vcat, T, fx, one(T), fx, one(T), one(T), fx)
     else
@@ -4565,31 +4097,23 @@ function _psd3test(model::MOI.ModelLike, psdcone, config::Config{T}) where {T}
             fx,
         )
     end
-
     c = MOI.add_constraint(model, func, psdcone(3))
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.SingleVariable}(),
         MOI.SingleVariable(x),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ one(T) atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈
               ones(T, MOI.output_dimension(func)) atol = atol rtol = rtol
         if config.duals
@@ -4672,7 +4196,6 @@ function _det1test(
     #           |         |
     #           |_________|
     #            -Q22 ≥ -1
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -4700,15 +4223,12 @@ function _det1test(
         MOI.VectorAffineFunction{Float64},
         MOI.Nonnegatives,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     t = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
     Q = MOI.add_variables(model, square ? 4 : 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == (square ? 5 : 4)
-
     if use_logdet
         u = MOI.add_variable(model)
         vc = MOI.add_constraint(model, MOI.SingleVariable(u), MOI.EqualTo(1.0))
@@ -4726,7 +4246,6 @@ function _det1test(
             detcone(2),
         )
     end
-
     c = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -4738,7 +4257,6 @@ function _det1test(
         ),
         MOI.Nonnegatives(2),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -4756,7 +4274,6 @@ function _det1test(
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -4765,25 +4282,18 @@ function _det1test(
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         expectedobjval = use_logdet ? 0.0 : 1.0
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ expectedobjval atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ expectedobjval atol =
             atol rtol = rtol
-
         if use_logdet
             @test MOI.get(model, MOI.VariablePrimal(), u) ≈ 1.0 atol = atol rtol =
                 rtol
         end
-
         Qv = MOI.get(model, MOI.VariablePrimal(), Q)
         @test Qv[1] ≈ 1.0 atol = atol rtol = rtol
         @test Qv[2] ≈ 0.0 atol = atol rtol = rtol
@@ -4791,18 +4301,15 @@ function _det1test(
             @test Qv[3] ≈ 0.0 atol = atol rtol = rtol
         end
         @test Qv[end] ≈ 1.0 atol = atol rtol = rtol
-
         tQv = MOI.get(model, MOI.ConstraintPrimal(), cX)
         @test tQv[1] ≈ expectedobjval atol = atol rtol = rtol
         @test tQv[(use_logdet ? 3 : 2):end] ≈ Qv atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ [0.0, 0.0] atol = atol rtol =
             rtol
         if use_logdet
             @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ 1.0 atol = atol rtol =
                 rtol
         end
-
         if config.duals
             if use_logdet
                 @test MOI.get(model, MOI.ConstraintDual(), c) ≈ [1, 1] atol =
@@ -4848,10 +4355,8 @@ function _det2test(model::MOI.ModelLike, config::Config, detcone)
     # det(mat) = 5, so:
     # rootdet(mat) ≈ 1.709976
     # logdet(mat)  ≈ 1.609438
-
     mat = Float64[3 2 1; 2 2 1; 1 1 3]
     matL = Float64[3, 2, 2, 1, 1, 3]
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(model, MOI.ObjectiveFunction{MOI.SingleVariable}())
     @test MOI.supports(model, MOI.ObjectiveSense())
@@ -4860,20 +4365,16 @@ function _det2test(model::MOI.ModelLike, config::Config, detcone)
         MOI.VectorAffineFunction{Float64},
         detcone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     t = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.SingleVariable}(),
         MOI.SingleVariable(t),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     constant_mat = square ? vec(mat) : matL
     constant_vec = use_logdet ? vcat(0, 1, constant_mat) : vcat(0, constant_mat)
     vaf = MOI.VectorAffineFunction(
@@ -4887,22 +4388,16 @@ function _det2test(model::MOI.ModelLike, config::Config, detcone)
             MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},detcone}(),
         ) == 1
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         expected_objval = use_logdet ? log(5) : (5^inv(3))
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ expected_objval atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), t) ≈ expected_objval atol =
             atol rtol = rtol
-
         det_value = MOI.get(model, MOI.ConstraintPrimal(), det_constraint)
         @test det_value[1] ≈ expected_objval atol = atol rtol = rtol
         if use_logdet
@@ -4910,7 +4405,6 @@ function _det2test(model::MOI.ModelLike, config::Config, detcone)
         end
         @test det_value[(use_logdet ? 3 : 2):end] ≈ (square ? vec(mat) : matL) atol =
             atol rtol = rtol
-
         if config.duals
             psd_dual =
                 square ? [1, -1, 0, -1, 1.6, -0.2, 0, -0.2, 0.4] :

--- a/src/Test/contquadratic.jl
+++ b/src/Test/contquadratic.jl
@@ -8,7 +8,6 @@ function qp1test(model::MOI.ModelLike, config::Config)
     # st  x + 2y + 3z >= 4 (c1)
     #     x +  y      >= 1 (c2)
     #     x, y, z \in R
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     MOI.supports(
         model,
@@ -19,13 +18,10 @@ function qp1test(model::MOI.ModelLike, config::Config)
         MOI.ScalarAffineFunction{Float64},
         MOI.GreaterThan{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v = MOI.add_variables(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
-
     cf1 =
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0, 3.0], v), 0.0)
     c1 = MOI.add_constraint(model, cf1, MOI.GreaterThan(4.0))
@@ -38,7 +34,6 @@ function qp1test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     c2 = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction(
@@ -56,7 +51,6 @@ function qp1test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 2
     end
-
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
     obj = MOI.ScalarQuadraticFunction(
@@ -73,33 +67,23 @@ function qp1test(model::MOI.ModelLike, config::Config)
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
         obj,
     )
-
     if config.query
         @test obj ≈ MOI.get(
             model,
             MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
         )
-
         @test cf1 ≈ MOI.get(model, MOI.ConstraintFunction(), c1)
-
         @test MOI.GreaterThan(4.0) == MOI.get(model, MOI.ConstraintSet(), c1)
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 13 / 7 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [4 / 7, 3 / 7, 6 / 7] atol =
             atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             # The dual constraint gives
@@ -123,7 +107,6 @@ function qp2test(model::MOI.ModelLike, config::Config)
     # st  x + 2y + 3z >= 4 (c1)
     #     x +  y      >= 1 (c2)
     #     x, y, z \in R
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -134,13 +117,10 @@ function qp2test(model::MOI.ModelLike, config::Config)
         MOI.ScalarAffineFunction{Float64},
         MOI.GreaterThan{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v = MOI.add_variables(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
-
     c1f =
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0, 3.0], v), 0.0)
     c1 = MOI.add_constraint(model, c1f, MOI.GreaterThan(4.0))
@@ -153,7 +133,6 @@ function qp2test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     c2 = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction(
@@ -171,7 +150,6 @@ function qp2test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 2
     end
-
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
     obj = MOI.ScalarQuadraticFunction(
@@ -188,33 +166,23 @@ function qp2test(model::MOI.ModelLike, config::Config)
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
         obj,
     )
-
     if config.query
         @test obj ≈ MOI.get(
             model,
             MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
         )
-
         @test c1f ≈ MOI.get(model, MOI.ConstraintFunction(), c1)
-
         @test MOI.GreaterThan(4.0) == MOI.get(model, MOI.ConstraintSet(), c1)
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 13 / 7 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [4 / 7, 3 / 7, 6 / 7] atol =
             atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ 5 / 7 atol = atol rtol =
@@ -223,7 +191,6 @@ function qp2test(model::MOI.ModelLike, config::Config)
                 rtol
         end
     end
-
     # change objective to Max -2(x^2 + xy + y^2 + yz + z^2)
     # First clear the objective, this is needed if a `Bridges.Objective.SlackBridge` is used.
     MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
@@ -243,27 +210,20 @@ function qp2test(model::MOI.ModelLike, config::Config)
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
         obj2,
     )
-
     if config.query
         @test obj2 ≈ MOI.get(
             model,
             MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
         )
     end
-
     if config.solve
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -2 * 13 / 7 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [4 / 7, 3 / 7, 6 / 7] atol =
             atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ 10 / 7 atol = atol rtol =
@@ -281,7 +241,6 @@ function qp3test(model::MOI.ModelLike, config::Config)
     #    minimize 2 x^2 + y^2 + xy + x + y + 1
     #       s.t.  x, y >= 0
     #             x + y = 1
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -293,13 +252,10 @@ function qp3test(model::MOI.ModelLike, config::Config)
         MOI.ScalarAffineFunction{Float64},
         MOI.EqualTo{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
-
     c1 = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction(
@@ -308,14 +264,12 @@ function qp3test(model::MOI.ModelLike, config::Config)
         ),
         MOI.EqualTo(1.0),
     )
-
     vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test vc1.value == x.value
     vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
     @test vc2.value == y.value
-
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     obj = MOI.ScalarQuadraticFunction(
         MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]),
@@ -327,16 +281,11 @@ function qp3test(model::MOI.ModelLike, config::Config)
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
         obj,
     )
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.875 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [0.25, 0.75] atol =
@@ -345,7 +294,6 @@ function qp3test(model::MOI.ModelLike, config::Config)
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), vc2) ≈ 0.75 atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             # The dual constraint gives [λ_vc1 + λ_c1, λ_vc2 + λ_c1] = [4 1; 1 2] * x + [1, 1] = [11, 11] / 4
@@ -359,7 +307,6 @@ function qp3test(model::MOI.ModelLike, config::Config)
                 rtol
         end
     end
-
     # change back to linear
     #        max 2x + y + 1
     #       s.t.  x, y >= 0
@@ -375,14 +322,10 @@ function qp3test(model::MOI.ModelLike, config::Config)
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         objf,
     )
-
     if config.solve
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol = atol rtol = rtol
         @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [1.0, 0.0] atol =
             atol rtol = rtol
@@ -390,7 +333,6 @@ function qp3test(model::MOI.ModelLike, config::Config)
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), vc2) ≈ 0.0 atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             @test MOI.get(model, MOI.ConstraintDual(), c1) ≈ -2 atol = atol rtol =
@@ -421,7 +363,6 @@ function qcp1test(model::MOI.ModelLike, config::Config)
     #     x² + y <= 2 (c2)
     # Optimal solution
     # x = 1/2, y = 7/4
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -437,14 +378,11 @@ function qcp1test(model::MOI.ModelLike, config::Config)
         MOI.ScalarQuadraticFunction{Float64},
         MOI.LessThan{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-
     c1 = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -465,7 +403,6 @@ function qcp1test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     c2f = MOI.ScalarQuadraticFunction(
         [MOI.ScalarAffineTerm(1.0, y)],
         [MOI.ScalarQuadraticTerm(2.0, x, x)],
@@ -481,7 +418,6 @@ function qcp1test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -492,32 +428,23 @@ function qcp1test(model::MOI.ModelLike, config::Config)
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
-
     if config.query
         @test c2f ≈ MOI.get(model, MOI.ConstraintFunction(), c2) atol = atol rtol =
             rtol
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.25 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), [x, y]) ≈ [0.5, 1.75] atol =
             atol rtol = rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c1) ≈ [5 / 4, 9 / 4] atol =
             atol rtol = rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 2 atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             # The dual constraint gives
@@ -531,9 +458,7 @@ function qcp1test(model::MOI.ModelLike, config::Config)
                 rtol
         end
     end
-
     # try delete quadratic constraint and go back to linear
-
     # FIXME why is this commented ?
     # MOI.delete(model, c2)
     #
@@ -551,7 +476,6 @@ function qcp2test(model::MOI.ModelLike, config::Config)
     rtol = config.rtol
     # Max x
     # s.t. x^2 <= 2 (c)
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -562,13 +486,10 @@ function qcp2test(model::MOI.ModelLike, config::Config)
         MOI.ScalarQuadraticFunction{Float64},
         MOI.LessThan{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     cf = MOI.ScalarQuadraticFunction(
         [MOI.ScalarAffineTerm(0.0, x)],
         [MOI.ScalarQuadraticTerm(2.0, x, x)],
@@ -584,7 +505,6 @@ function qcp2test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -592,29 +512,20 @@ function qcp2test(model::MOI.ModelLike, config::Config)
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
-
     if config.query
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c) atol = atol rtol =
             rtol
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ √2 atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ √2 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             # The dual constraint gives
@@ -631,7 +542,6 @@ function qcp3test(model::MOI.ModelLike, config::Config)
     rtol = config.rtol
     # Min -x
     # s.t. x^2 <= 2
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -642,13 +552,10 @@ function qcp3test(model::MOI.ModelLike, config::Config)
         MOI.ScalarQuadraticFunction{Float64},
         MOI.LessThan{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     cf = MOI.ScalarQuadraticFunction(
         MOI.ScalarAffineTerm{Float64}[],
         [MOI.ScalarQuadraticTerm(2.0, x, x)],
@@ -664,7 +571,6 @@ function qcp3test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -672,33 +578,23 @@ function qcp3test(model::MOI.ModelLike, config::Config)
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
-
     if config.query
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c) atol = atol rtol =
             rtol
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
         end
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -√2 atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ √2 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 2 atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             # The dual constraint gives
@@ -716,7 +612,6 @@ function _qcp4test(model::MOI.ModelLike, config::Config, less_than::Bool)
     # Max  x
     # s.t. x^2 + x * y + y^2 <= 3 (c)
     #      y == 1
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -728,17 +623,13 @@ function _qcp4test(model::MOI.ModelLike, config::Config, less_than::Bool)
         MOI.ScalarQuadraticFunction{Float64},
         typeof(quad_set),
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-
     vc = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.EqualTo(1.0))
     @test vc.value == y.value
-
     cf = MOI.ScalarQuadraticFunction(
         [MOI.ScalarAffineTerm(0.0, x)],
         MOI.ScalarQuadraticTerm.([2.0, 1.0, 2.0], [x, x, y], [x, y, y]),
@@ -757,7 +648,6 @@ function _qcp4test(model::MOI.ModelLike, config::Config, less_than::Bool)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -765,34 +655,25 @@ function _qcp4test(model::MOI.ModelLike, config::Config, less_than::Bool)
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
-
     if config.query
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c) atol = atol rtol =
             rtol
         @test quad_set == MOI.get(model, MOI.ConstraintSet(), c)
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.0 atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1.0 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1.0 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ MOI.constant(quad_set) atol =
             atol rtol = rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), vc) ≈ 1.0 atol = atol rtol =
             rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             # The dual constraint gives
@@ -835,7 +716,6 @@ function ncqcp1test(model::MOI.ModelLike, config::Config)
     # Max 2x + y
     # s.t. x * y <= 4 (c)
     #      x, y >= 1
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -846,19 +726,15 @@ function ncqcp1test(model::MOI.ModelLike, config::Config)
         MOI.ScalarQuadraticFunction{Float64},
         MOI.LessThan{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-
     vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(1.0))
     @test vc1.value == x.value
     vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(1.0))
     @test vc2.value == y.value
-
     cf = MOI.ScalarQuadraticFunction(
         [MOI.ScalarAffineTerm(0.0, x)],
         [MOI.ScalarQuadraticTerm(1.0, x, y)],
@@ -874,7 +750,6 @@ function ncqcp1test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -885,27 +760,19 @@ function ncqcp1test(model::MOI.ModelLike, config::Config)
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
-
     if config.query
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 9.0 atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 4.0 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1.0 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 4.0 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), vc1) ≈ 4.0 atol = atol rtol =
@@ -922,40 +789,33 @@ function ncqcp2test(model::MOI.ModelLike, config::Config)
     # s.t. x * y == 4 (c)
     #      x * x == 4 (c2)
     #      x, y >= 0
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports_constraint(
         model,
         MOI.ScalarQuadraticFunction{Float64},
         MOI.EqualTo{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-
     vc1 = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(0.0))
     @test vc1.value == x.value
     vc2 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.GreaterThan(0.0))
     @test vc2.value == y.value
-
     cf = MOI.ScalarQuadraticFunction(
         [MOI.ScalarAffineTerm(0.0, x)],
         [MOI.ScalarQuadraticTerm(1.0, x, y)],
         0.0,
     )
     c = MOI.add_constraint(model, cf, MOI.EqualTo(4.0))
-
     cf2 = MOI.ScalarQuadraticFunction(
         [MOI.ScalarAffineTerm(0.0, x)],
         [MOI.ScalarQuadraticTerm(2.0, x, x)],
         0.0,
     )
     c2 = MOI.add_constraint(model, cf2, MOI.EqualTo(4.0))
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -965,26 +825,19 @@ function ncqcp2test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 2
     end
-
     if config.query
         @test cf ≈ MOI.get(model, MOI.ConstraintFunction(), c)
         @test cf2 ≈ MOI.get(model, MOI.ConstraintFunction(), c2)
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 2.0 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 2.0 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 4.0 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 4.0 atol = atol rtol =
@@ -1011,7 +864,6 @@ function socp1test(model::MOI.ModelLike, config::Config)
     # s.t. x + y >= 1 (c1)
     #      x^2 + y^2 <= t^2 (c2)
     #      t >= 0 (bound)
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -1032,15 +884,12 @@ function socp1test(model::MOI.ModelLike, config::Config)
         MOI.SingleVariable,
         MOI.GreaterThan{Float64},
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     t = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
-
     c1f =
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], [x, y]), 0.0)
     c1 = MOI.add_constraint(model, c1f, MOI.GreaterThan(1.0))
@@ -1053,7 +902,6 @@ function socp1test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     c2f = MOI.ScalarQuadraticFunction(
         MOI.ScalarAffineTerm{Float64}[],
         MOI.ScalarQuadraticTerm.([2.0, 2.0, -2.0], [x, y, t], [x, y, t]),
@@ -1069,7 +917,6 @@ function socp1test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     bound =
         MOI.add_constraint(model, MOI.SingleVariable(t), MOI.GreaterThan(0.0))
     @test bound.value == t.value
@@ -1082,7 +929,6 @@ function socp1test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -1090,31 +936,21 @@ function socp1test(model::MOI.ModelLike, config::Config)
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
-
     if config.query
         @test c1f ≈ MOI.get(model, MOI.ConstraintFunction(), c1)
-
         @test c2f ≈ MOI.get(model, MOI.ConstraintFunction(), c2)
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 / √2 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), [x, y, t]) ≈
               [0.5, 0.5, 1 / √2] atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), [t, x, y, t]) ≈
               [1 / √2, 0.5, 0.5, 1 / √2] atol = atol rtol = rtol
-
         if config.duals
             @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
             # The dual constraint gives

--- a/src/Test/intconic.jl
+++ b/src/Test/intconic.jl
@@ -3,13 +3,11 @@
 function intsoc1test(model::MOI.ModelLike, config::Config)
     atol = config.atol
     rtol = config.rtol
-
     # Problem SINTSOC1
     # min 0x - 2y - 1z
     #  st  x            == 1
     #      x >= ||(y,z)||
     #      (y,z) binary
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -26,12 +24,9 @@ function intsoc1test(model::MOI.ModelLike, config::Config)
         MOI.VectorOfVariables,
         MOI.SecondOrderCone,
     )
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     x, y, z = MOI.add_variables(model, 3)
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -41,7 +36,6 @@ function intsoc1test(model::MOI.ModelLike, config::Config)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     ceq = MOI.add_constraint(
         model,
         MOI.VectorAffineFunction(
@@ -55,7 +49,6 @@ function intsoc1test(model::MOI.ModelLike, config::Config)
         MOI.VectorOfVariables([x, y, z]),
         MOI.SecondOrderCone(3),
     )
-
     if config.query_number_of_constraints
         @test MOI.get(
             model,
@@ -73,25 +66,18 @@ function intsoc1test(model::MOI.ModelLike, config::Config)
     @test length(loc) == 2
     @test (MOI.VectorAffineFunction{Float64}, MOI.Zeros) in loc
     @test (MOI.VectorOfVariables, MOI.SecondOrderCone) in loc
-
     bin1 = MOI.add_constraint(model, MOI.SingleVariable(y), MOI.ZeroOne())
     # We test this after the creation of every `SingleVariable` constraint
     # to ensure a good coverage of corner cases.
     @test bin1.value == y.value
     bin2 = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.ZeroOne())
     @test bin2.value == z.value
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ -2 atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), x) ≈ 1 atol = atol rtol =
             rtol
         @test MOI.get(model, MOI.VariablePrimal(), y) ≈ 1 atol = atol rtol =

--- a/src/Test/intlinear.jl
+++ b/src/Test/intlinear.jl
@@ -12,7 +12,6 @@ function int1test(model::MOI.ModelLike, config::Config)
     #         x is continuous: 0 <= x <= 5
     #         y is integer: 0 <= y <= 10
     #         z is binary
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -31,13 +30,10 @@ function int1test(model::MOI.ModelLike, config::Config)
     )
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)
     @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.Integer)
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v = MOI.add_variables(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
-
     cf =
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0, 1.0], v), 0.0)
     c = MOI.add_constraint(model, cf, MOI.LessThan(10.0))
@@ -50,7 +46,6 @@ function int1test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     cf2 =
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 2.0, 1.0], v), 0.0)
     c2 = MOI.add_constraint(model, cf2, MOI.LessThan(15.0))
@@ -63,7 +58,6 @@ function int1test(model::MOI.ModelLike, config::Config)
             }(),
         ) == 2
     end
-
     vc1 = MOI.add_constraint(
         model,
         MOI.SingleVariable(v[1]),
@@ -78,7 +72,6 @@ function int1test(model::MOI.ModelLike, config::Config)
             MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Interval{Float64}}(),
         ) == 1
     end
-
     vc2 = MOI.add_constraint(
         model,
         MOI.SingleVariable(v[2]),
@@ -99,7 +92,6 @@ function int1test(model::MOI.ModelLike, config::Config)
             MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Integer}(),
         ) == 1
     end
-
     vc4 = MOI.add_constraint(model, MOI.SingleVariable(v[3]), MOI.ZeroOne())
     @test vc4.value == v[3].value
     if config.query_number_of_constraints
@@ -108,7 +100,6 @@ function int1test(model::MOI.ModelLike, config::Config)
             MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}(),
         ) == 1
     end
-
     objf =
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.1, 2.0, 5.0], v), 0.0)
     MOI.set(
@@ -117,33 +108,22 @@ function int1test(model::MOI.ModelLike, config::Config)
         objf,
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) in
               [MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT]
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 19.4 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [4, 5, 1] atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 10 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ConstraintPrimal(), c2) ≈ 15 atol = atol rtol =
             rtol
-
         @test MOI.get(model, MOI.ObjectiveBound()) >= 19.4 - atol
         # FIXME the following are currently not implemented in MockOptimizer
         #        @test MOI.get(model, MOI.RelativeGap()) >= 0.0
@@ -175,10 +155,8 @@ function int2test(model::MOI.ModelLike, config::Config)
             MOI.SingleVariable,
             MOI.LessThan{Float64},
         )
-
         MOI.empty!(model)
         @test MOI.is_empty(model)
-
         v = MOI.add_variables(model, 3)
         @test MOI.get(model, MOI.NumberOfVariables()) == 3
         vc1 = MOI.add_constraint(
@@ -199,7 +177,6 @@ function int2test(model::MOI.ModelLike, config::Config)
             MOI.LessThan(2.0),
         )
         @test vc3.value == v[3].value
-
         c1 = MOI.add_constraint(
             model,
             MOI.VectorOfVariables([v[1], v[2]]),
@@ -219,7 +196,6 @@ function int2test(model::MOI.ModelLike, config::Config)
                 }(),
             ) == 2
         end
-
         #=
             To allow for permutations in the sets and variable vectors
             we're going to sort according to the weights
@@ -229,7 +205,6 @@ function int2test(model::MOI.ModelLike, config::Config)
         p = sortperm(cs_sos.weights)
         @test cs_sos.weights[p] ≈ [1.0, 2.0] atol = atol rtol = rtol
         @test cf_sos.variables[p] == v[[1, 3]]
-
         objf = MOI.ScalarAffineFunction(
             MOI.ScalarAffineTerm.([2.0, 1.0, 1.0], v),
             0.0,
@@ -241,43 +216,29 @@ function int2test(model::MOI.ModelLike, config::Config)
         )
         MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
         @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
-
         if config.solve
             @test MOI.get(model, MOI.TerminationStatus()) ==
                   MOI.OPTIMIZE_NOT_CALLED
-
             MOI.optimize!(model)
-
             @test MOI.get(model, MOI.TerminationStatus()) ==
                   config.optimal_status
-
             @test MOI.get(model, MOI.ResultCount()) >= 1
-
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3 atol = atol rtol =
                 rtol
-
             @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0, 1, 2] atol =
                 atol rtol = rtol
         end
-
         MOI.delete(model, c1)
         MOI.delete(model, c2)
-
         if config.solve
             MOI.optimize!(model)
-
             @test MOI.get(model, MOI.TerminationStatus()) ==
                   config.optimal_status
-
             @test MOI.get(model, MOI.ResultCount()) >= 1
-
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 5 atol = atol rtol =
                 rtol
-
             @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 1, 2] atol =
                 atol rtol = rtol
         end
@@ -305,13 +266,10 @@ function int2test(model::MOI.ModelLike, config::Config)
             MOI.ScalarAffineFunction{Float64},
             MOI.EqualTo{Float64},
         )
-
         MOI.empty!(model)
         @test MOI.is_empty(model)
-
         v = MOI.add_variables(model, 10)
         @test MOI.get(model, MOI.NumberOfVariables()) == 10
-
         bin_constraints = []
         for i in 1:8
             vc = MOI.add_constraint(
@@ -330,7 +288,6 @@ function int2test(model::MOI.ModelLike, config::Config)
             )
             @test bin_constraints[i].value == v[i].value
         end
-
         MOI.add_constraint(
             model,
             MOI.ScalarAffineFunction(
@@ -339,7 +296,6 @@ function int2test(model::MOI.ModelLike, config::Config)
             ),
             MOI.EqualTo(0.0),
         )
-
         MOI.add_constraint(
             model,
             MOI.ScalarAffineFunction(
@@ -351,17 +307,14 @@ function int2test(model::MOI.ModelLike, config::Config)
             ),
             MOI.EqualTo(0.0),
         )
-
         MOI.add_constraint(
             model,
             MOI.VectorOfVariables(v[[1, 2, 3]]),
             MOI.SOS1([1.0, 2.0, 3.0]),
         )
-
         vv = MOI.VectorOfVariables(v[[4, 5, 6, 7, 8]])
         sos2 = MOI.SOS2([5.0, 4.0, 7.0, 2.0, 1.0])
         c = MOI.add_constraint(model, vv, sos2)
-
         #=
             To allow for permutations in the sets and variable vectors
             we're going to sort according to the weights
@@ -372,7 +325,6 @@ function int2test(model::MOI.ModelLike, config::Config)
         @test cs_sos.weights[p] ≈ [1.0, 2.0, 4.0, 5.0, 7.0] atol = atol rtol =
             rtol
         @test cf_sos.variables[p] == v[[8, 7, 5, 4, 6]]
-
         objf = MOI.ScalarAffineFunction(
             MOI.ScalarAffineTerm.([1.0, 1.0], [v[9], v[10]]),
             0.0,
@@ -384,45 +336,31 @@ function int2test(model::MOI.ModelLike, config::Config)
         )
         MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
         @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
-
         if config.solve
             @test MOI.get(model, MOI.TerminationStatus()) ==
                   MOI.OPTIMIZE_NOT_CALLED
-
             MOI.optimize!(model)
-
             @test MOI.get(model, MOI.TerminationStatus()) ==
                   config.optimal_status
-
             @test MOI.get(model, MOI.ResultCount()) >= 1
-
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 15.0 atol = atol rtol =
                 rtol
-
             @test MOI.get(model, MOI.VariablePrimal(), v) ≈
                   [0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 3.0, 12.0] atol =
                 atol rtol = rtol
         end
-
         for cref in bin_constraints
             MOI.delete(model, cref)
         end
-
         if config.solve
             MOI.optimize!(model)
-
             @test MOI.get(model, MOI.TerminationStatus()) ==
                   config.optimal_status
-
             @test MOI.get(model, MOI.ResultCount()) >= 1
-
             @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 30.0 atol = atol rtol =
                 rtol
-
             @test MOI.get(model, MOI.VariablePrimal(), v) ≈
                   [0.0, 0.0, 2.0, 2.0, 0.0, 2.0, 0.0, 0.0, 6.0, 24.0] atol =
                 atol rtol = rtol
@@ -439,10 +377,8 @@ function int3test(model::MOI.ModelLike, config::Config)
     # s.t.  0 <= z - 0.5 eᵀ b / 40 <= 0.999
     #       b1, b2, ... b10 ∈ {0, 1}
     #       z in {0, 1, 2, ..., 100}
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -461,7 +397,6 @@ function int3test(model::MOI.ModelLike, config::Config)
         MOI.ScalarAffineFunction{Float64},
         MOI.Interval{Float64},
     )
-
     z = MOI.add_variable(model)
     vc1 = MOI.add_constraint(model, MOI.SingleVariable(z), MOI.Integer())
     @test vc1.value == z.value
@@ -471,14 +406,11 @@ function int3test(model::MOI.ModelLike, config::Config)
         MOI.Interval(0.0, 100.0),
     )
     @test vc2.value == z.value
-
     b = MOI.add_variables(model, 10)
-
     for bi in b
         vc = MOI.add_constraint(model, MOI.SingleVariable(bi), MOI.ZeroOne())
         @test vc.value == bi.value
     end
-
     c = MOI.add_constraint(
         model,
         MOI.ScalarAffineFunction(
@@ -487,7 +419,6 @@ function int3test(model::MOI.ModelLike, config::Config)
         ),
         MOI.Interval(0.0, 0.999),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -500,25 +431,16 @@ function int3test(model::MOI.ModelLike, config::Config)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol = atol rtol = rtol
-
         # test for CPLEX.jl #76
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1 atol = atol rtol = rtol
     end
 end
@@ -532,10 +454,8 @@ function knapsacktest(model::MOI.ModelLike, config::Config)
     # max 5a + 3b + 2c + 7d + 4e
     # st  2a + 8b + 4c + 2d + 5e <= 10
     #                  a,b,c,d,e ∈ binary
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -548,10 +468,8 @@ function knapsacktest(model::MOI.ModelLike, config::Config)
         MOI.ScalarAffineFunction{Float64},
         MOI.LessThan{Float64},
     )
-
     v = MOI.add_variables(model, 5)
     @test MOI.get(model, MOI.NumberOfVariables()) == 5
-
     for vi in v
         vc = MOI.add_constraint(model, MOI.SingleVariable(vi), MOI.ZeroOne())
         @test vc.value == vi.value
@@ -579,7 +497,6 @@ function knapsacktest(model::MOI.ModelLike, config::Config)
             }(),
         ) == 1
     end
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -589,23 +506,16 @@ function knapsacktest(model::MOI.ModelLike, config::Config)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     if MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
         MOI.set(model, MOI.VariablePrimalStart(), v, [0.0, 0.0, 0.0, 0.0, 0.0])
     end
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.PrimalStatus()) in
               [MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT]
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 16 atol = atol rtol = rtol
-
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [1, 0, 0, 1, 1] atol =
             atol rtol = rtol
     end
@@ -620,10 +530,8 @@ function indicator1_test(model::MOI.ModelLike, config::Config)
     #      z1 ==> x2 <= 8
     #      z2 ==> x2 + x1/5 <= 9
     #      z1 + z2 >= 1
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     @test MOI.supports(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -660,7 +568,6 @@ function indicator1_test(model::MOI.ModelLike, config::Config)
     )
     iset1 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(8.0))
     MOI.add_constraint(model, f1, iset1)
-
     f2 = MOI.VectorAffineFunction(
         [
             MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, z2)),
@@ -670,9 +577,7 @@ function indicator1_test(model::MOI.ModelLike, config::Config)
         [0.0, 0.0],
     )
     iset2 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(9.0))
-
     MOI.add_constraint(model, f2, iset2)
-
     # Additional regular constraint.
     MOI.add_constraint(
         model,
@@ -682,7 +587,6 @@ function indicator1_test(model::MOI.ModelLike, config::Config)
         ),
         MOI.LessThan(10.0),
     )
-
     # Disjunction z1 ⋁ z2
     MOI.add_constraint(
         model,
@@ -692,7 +596,6 @@ function indicator1_test(model::MOI.ModelLike, config::Config)
         ),
         MOI.GreaterThan(1.0),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -702,12 +605,9 @@ function indicator1_test(model::MOI.ModelLike, config::Config)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 28.75 atol = atol rtol =
@@ -732,12 +632,9 @@ function indicator2_test(model::MOI.ModelLike, config::Config)
     #      z1 ==> x2 <= 8
     #      z2 ==> x2 + x1/5 <= 9
     #      z1 + z2 >= 1
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     # This is the same model as indicator_test1, except that the penalty on z2 forces z1 to be 1.
-
     x1 = MOI.add_variable(model)
     x2 = MOI.add_variable(model)
     z1 = MOI.add_variable(model)
@@ -753,7 +650,6 @@ function indicator2_test(model::MOI.ModelLike, config::Config)
     )
     iset1 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(8.0))
     MOI.add_constraint(model, f1, iset1)
-
     f2 = MOI.VectorAffineFunction(
         [
             MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, z2)),
@@ -763,9 +659,7 @@ function indicator2_test(model::MOI.ModelLike, config::Config)
         [0.0, 0.0],
     )
     iset2 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(9.0))
-
     MOI.add_constraint(model, f2, iset2)
-
     # additional regular constraint
     MOI.add_constraint(
         model,
@@ -775,7 +669,6 @@ function indicator2_test(model::MOI.ModelLike, config::Config)
         ),
         MOI.LessThan(10.0),
     )
-
     # disjunction z1 ⋁ z2
     MOI.add_constraint(
         model,
@@ -785,7 +678,6 @@ function indicator2_test(model::MOI.ModelLike, config::Config)
         ),
         MOI.GreaterThan(1.0),
     )
-
     # objective penalized on z2
     MOI.set(
         model,
@@ -796,12 +688,9 @@ function indicator2_test(model::MOI.ModelLike, config::Config)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 28.0 atol = atol rtol =
@@ -827,10 +716,8 @@ function indicator3_test(model::MOI.ModelLike, config::Config)
     #      z1 == 0 ==> x2 <= 8
     #      z2 == 1 ==> x2 + x1/5 <= 9
     #      (1-z1) + z2 >= 1 <=> z2 - z1 >= 0
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     @test MOI.supports(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -869,7 +756,6 @@ function indicator3_test(model::MOI.ModelLike, config::Config)
     )
     iset1 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ZERO}(MOI.LessThan(8.0))
     MOI.add_constraint(model, f1, iset1)
-
     f2 = MOI.VectorAffineFunction(
         [
             MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, z2)),
@@ -879,9 +765,7 @@ function indicator3_test(model::MOI.ModelLike, config::Config)
         [0.0, 0.0],
     )
     iset2 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(9.0))
-
     MOI.add_constraint(model, f2, iset2)
-
     # Additional regular constraint.
     MOI.add_constraint(
         model,
@@ -891,7 +775,6 @@ function indicator3_test(model::MOI.ModelLike, config::Config)
         ),
         MOI.LessThan(10.0),
     )
-
     # Disjunction (1-z1) ⋁ z2
     MOI.add_constraint(
         model,
@@ -901,7 +784,6 @@ function indicator3_test(model::MOI.ModelLike, config::Config)
         ),
         MOI.GreaterThan(0.0),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -911,12 +793,9 @@ function indicator3_test(model::MOI.ModelLike, config::Config)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 28.75 atol = atol rtol =
@@ -942,10 +821,8 @@ function indicator4_test(model::MOI.ModelLike, config::Config)
     #      z1 ==> x2 - 1 <= 7
     #      z2 ==> x2 + x1/5 + 1 <= 10
     #      z1 + z2 >= 1
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     @test MOI.supports(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -982,7 +859,6 @@ function indicator4_test(model::MOI.ModelLike, config::Config)
     )
     iset1 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(7.0))
     MOI.add_constraint(model, f1, iset1)
-
     f2 = MOI.VectorAffineFunction(
         [
             MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, z2)),
@@ -992,9 +868,7 @@ function indicator4_test(model::MOI.ModelLike, config::Config)
         [0.0, 1.0],
     )
     iset2 = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(10.0))
-
     MOI.add_constraint(model, f2, iset2)
-
     # Additional regular constraint.
     MOI.add_constraint(
         model,
@@ -1004,7 +878,6 @@ function indicator4_test(model::MOI.ModelLike, config::Config)
         ),
         MOI.LessThan(10.0),
     )
-
     # Disjunction z1 ⋁ z2
     MOI.add_constraint(
         model,
@@ -1014,7 +887,6 @@ function indicator4_test(model::MOI.ModelLike, config::Config)
         ),
         MOI.GreaterThan(1.0),
     )
-
     MOI.set(
         model,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -1024,12 +896,9 @@ function indicator4_test(model::MOI.ModelLike, config::Config)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 28.75 atol = atol rtol =
@@ -1048,7 +917,6 @@ end
 function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
     atol = config.atol
     rtol = config.rtol
-
     @test MOI.supports_incremental_interface(model, false) #=copy_names=#
     @test MOI.supports(
         model,
@@ -1068,7 +936,6 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
             MOI.Semiinteger{T},
         )
     end
-
     # 2 variables
     #
     # min  x
@@ -1078,13 +945,10 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
     #      if int
     #           x ∈ {0.0} U {2.0} U {3.0}
     #      y = 0.0
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     v = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
-
     if !int
         vc1 = MOI.add_constraint(
             model,
@@ -1113,7 +977,6 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
             ) == 1
         end
     end
-
     vc2 = MOI.add_constraint(
         model,
         MOI.SingleVariable(v[2]),
@@ -1125,7 +988,6 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
             MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{T}}(),
         ) == 1
     end
-
     cf = MOI.ScalarAffineFunction{T}(
         MOI.ScalarAffineTerm{T}.([one(T), -one(T)], v),
         zero(T),
@@ -1140,7 +1002,6 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
             }(),
         ) == 1
     end
-
     objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.0], v), 0.0)
     MOI.set(
         model,
@@ -1148,14 +1009,10 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
         objf,
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
-
     if config.solve
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
-
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.ResultCount()) >= 1
         @test MOI.get(model, MOI.PrimalStatus()) in
@@ -1167,14 +1024,10 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
             rtol
         @test MOI.get(model, MOI.ObjectiveBound()) <= 0.0 + atol
     end
-
     # Change y fixed value
-
     MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(one(T)))
-
     if config.solve
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.ResultCount()) >= 1
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
@@ -1185,12 +1038,9 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
             rtol
         @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0 + atol
     end
-
     MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(2)))
-
     if config.solve
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.ResultCount()) >= 1
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
@@ -1201,12 +1051,9 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
             rtol
         @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0 + atol
     end
-
     MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(5 // 2)))
-
     if config.solve
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.ResultCount()) >= 1
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
@@ -1228,12 +1075,9 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
             @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0 + atol
         end
     end
-
     MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(3)))
-
     if config.solve
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
         @test MOI.get(model, MOI.ResultCount()) >= 1
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
@@ -1244,12 +1088,9 @@ function _semitest(model::MOI.ModelLike, config::Config{T}, int::Bool) where {T}
             rtol
         @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0 + atol
     end
-
     MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(4)))
-
     if config.solve
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
               MOI.get(model, MOI.TerminationStatus()) ==
               MOI.INFEASIBLE_OR_UNBOUNDED

--- a/src/Test/modellike.jl
+++ b/src/Test/modellike.jl
@@ -39,7 +39,6 @@ function nametest(model::MOI.ModelLike)
         MOI.set(model, MOI.VariableName(), x[1], "x1")
         @test_throws ErrorException MOI.get(model, MOI.VariableIndex, "x1")
     end
-
     @testset "Variable bounds" begin
         MOI.empty!(model)
         x = MOI.add_variable(model)
@@ -54,7 +53,6 @@ function nametest(model::MOI.ModelLike)
             MOI.set(model, MOI.ConstraintName(), c1, "c1"),
         )
     end
-
     @testset "Affine constraints" begin
         MOI.empty!(model)
         x = MOI.add_variable(model)
@@ -71,7 +69,6 @@ function nametest(model::MOI.ModelLike)
         MOI.set(model, MOI.ConstraintName(), c1, "c1")
         @test_throws ErrorException MOI.get(model, MOI.ConstraintIndex, "c1")
     end
-
     @testset "Name test with $(typeof(model))" begin
         MOI.empty!(model)
         @test MOI.supports_incremental_interface(model, true) #=copy_names=#
@@ -84,7 +81,6 @@ function nametest(model::MOI.ModelLike)
         MOI.set(model, MOI.Name(), "Name2")
         @test MOI.Name() in MOI.get(model, MOI.ListOfModelAttributesSet())
         @test MOI.get(model, MOI.Name()) == "Name2"
-
         @test MOI.get(model, MOI.NumberOfVariables()) == 0
         @test MOI.get(
             model,
@@ -93,7 +89,6 @@ function nametest(model::MOI.ModelLike)
                 MOI.LessThan{Float64},
             }(),
         ) == 0
-
         @test MOI.supports(model, MOI.VariableName(), MOI.VariableIndex)
         v = MOI.add_variables(model, 2)
         @test MOI.get(model, MOI.VariableName(), v[1]) == ""
@@ -104,40 +99,32 @@ function nametest(model::MOI.ModelLike)
             @test MOI.get(model, MOI.VariableName(), yi) == ""
         end
         @test MOI.get(model, MOI.ConstraintName(), cy) == ""
-
         MOI.set(model, MOI.VariableName(), v[1], "")
         MOI.set(model, MOI.VariableName(), v[2], "") # Shouldn't error with duplicate empty name
         MOI.set(model, MOI.VariableName(), x, "")
         for yi in y
             MOI.set(model, MOI.VariableName(), yi, "")
         end
-
         MOI.set(model, MOI.VariableName(), v[1], "Var1")
         MOI.set(model, MOI.VariableName(), v[2], "Var1")
         # Lookup must fail when there are multiple variables with the same name.
         @test_throws Exception MOI.get(model, MOI.VariableIndex, "Var1")
-
         MOI.set(model, MOI.VariableName(), v[2], "Var2")
-
         @test MOI.get(model, MOI.VariableIndex, "Var1") == v[1]
         @test MOI.get(model, MOI.VariableIndex, "Var2") == v[2]
         @test MOI.get(model, MOI.VariableIndex, "Var3") === nothing
-
         MOI.set(model, MOI.VariableName(), x, "Var1")
         @test_throws Exception MOI.get(model, MOI.VariableIndex, "Var1")
-
         MOI.set(model, MOI.VariableName(), x, "Varx")
         @test MOI.get(model, MOI.VariableIndex, "Var1") == v[1]
         @test MOI.get(model, MOI.VariableIndex, "Var2") == v[2]
         @test MOI.get(model, MOI.VariableIndex, "Varx") == x
         @test MOI.get(model, MOI.VariableIndex, "Var3") === nothing
-
         vynames = ["VarX", "Var2", "Vary1", "Vary2", "Vary3", "Vary4"]
         MOI.set(model, MOI.VariableName(), [v; y], vynames)
         @test MOI.get(model, MOI.VariableName(), v) == vynames[1:2]
         @test MOI.get(model, MOI.VariableName(), y) == vynames[3:6]
         @test MOI.get(model, MOI.VariableName(), [v; y]) == vynames
-
         @test MOI.supports_constraint(
             model,
             MOI.ScalarAffineFunction{Float64},
@@ -164,24 +151,20 @@ function nametest(model::MOI.ModelLike)
         @test MOI.get(model, MOI.ConstraintName(), c) == ""
         @test MOI.get(model, MOI.ConstraintName(), c2) == ""
         @test MOI.get(model, MOI.ConstraintName(), cy) == ""
-
         @test MOI.supports(model, MOI.ConstraintName(), typeof(c))
         MOI.set(model, MOI.ConstraintName(), c, "")
         @test MOI.supports(model, MOI.ConstraintName(), typeof(c2))
         MOI.set(model, MOI.ConstraintName(), c2, "") # Shouldn't error with duplicate empty name
         @test MOI.supports(model, MOI.ConstraintName(), typeof(cy))
         MOI.set(model, MOI.ConstraintName(), cy, "")
-
         MOI.set(model, MOI.ConstraintName(), c, "Con0")
         @test MOI.get(model, MOI.ConstraintName(), c) == "Con0"
         MOI.set(model, MOI.ConstraintName(), c2, "Con0")
         # Lookup must fail when multiple constraints have the same name.
         @test_throws Exception MOI.get(model, MOI.ConstraintIndex, "Con0")
         @test_throws Exception MOI.get(model, typeof(c), "Con0")
-
         MOI.set(model, MOI.ConstraintName(), [c], ["Con1"])
         @test MOI.get(model, MOI.ConstraintName(), [c]) == ["Con1"]
-
         @test MOI.get(
             model,
             MOI.ConstraintIndex{
@@ -216,14 +199,11 @@ function nametest(model::MOI.ModelLike)
         ) === nothing
         @test MOI.get(model, MOI.ConstraintIndex, "Con1") == c
         @test MOI.get(model, MOI.ConstraintIndex, "Con2") === nothing
-
         MOI.set(model, MOI.ConstraintName(), [c2, cy], ["Con2", "Con2"])
         @test_throws Exception MOI.get(model, MOI.ConstraintIndex, "Con2")
         @test_throws Exception MOI.get(model, typeof(c2), "Con2")
         @test_throws Exception MOI.get(model, typeof(cy), "Con2")
-
         MOI.set(model, MOI.ConstraintName(), cy, "Con4")
-
         for (i, ca) in zip([1, 2, 4], [c, c2, cy])
             namea = "Con$i"
             @test MOI.get(model, MOI.ConstraintName(), ca) == namea
@@ -238,20 +218,16 @@ function nametest(model::MOI.ModelLike)
                 @test MOI.get(model, typeof(ca), nameb) === nothing
             end
         end
-
         MOI.delete(model, v[2])
         @test MOI.get(model, MOI.VariableIndex, "Var2") === nothing
-
         MOI.delete(model, c)
         @test MOI.get(model, typeof(c), "Con1") === nothing
         @test MOI.get(model, MOI.ConstraintIndex, "Con1") === nothing
-
         MOI.delete(model, x)
         @test MOI.get(model, MOI.VariableIndex, "Varx") === nothing
         @test MOI.get(model, MOI.ConstraintIndex, "Con3") === nothing
         @test MOI.get(model, typeof(c2), "Con2") === c2
         @test MOI.get(model, MOI.ConstraintIndex, "Con2") === c2
-
         MOI.delete(model, y)
         @test MOI.get(model, typeof(cy), "Con4") === nothing
         @test MOI.get(model, MOI.ConstraintIndex, "Con4") === nothing
@@ -392,13 +368,9 @@ function emptytest(model::MOI.ModelLike)
         ),
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     @test !MOI.is_empty(model)
-
     MOI.empty!(model)
-
     @test MOI.is_empty(model)
-
     @test MOI.get(model, MOI.NumberOfVariables()) == 0
     @test MOI.get(
         model,
@@ -409,7 +381,6 @@ function emptytest(model::MOI.ModelLike)
         MOI.NumberOfConstraints{MOI.VectorAffineFunction{Float64},MOI.Zeros}(),
     ) == 0
     @test isempty(MOI.get(model, MOI.ListOfConstraintTypesPresent()))
-
     @test !MOI.is_valid(model, v[1])
     @test !MOI.is_valid(model, vc)
     @test !MOI.is_valid(model, c)
@@ -558,17 +529,14 @@ function start_values_unset_test(model::MOI.ModelLike, config)
     )
     F2 = MOI.VectorAffineFunction{Float64}
     S2 = MOI.Nonnegatives
-
     vpattr = MOI.VariablePrimalStart()
     cpattr = MOI.ConstraintPrimalStart()
     cdattr = MOI.ConstraintDualStart()
-
     @testset "Newly created variables have start values set to nothing" begin
         @test !(vpattr in MOI.get(model, MOI.ListOfVariableAttributesSet()))
         @test MOI.get(model, vpattr, x) === nothing
         @test MOI.get(model, vpattr, y) === nothing
         @test MOI.get(model, vpattr, z) === nothing
-
         @test cpattr ∉
               MOI.get(model, MOI.ListOfConstraintAttributesSet{F1,S1}())
         @test MOI.get(model, cpattr, a) === nothing
@@ -576,7 +544,6 @@ function start_values_unset_test(model::MOI.ModelLike, config)
         @test cpattr ∉
               MOI.get(model, MOI.ListOfConstraintAttributesSet{F2,S2}())
         @test MOI.get(model, cpattr, c) === nothing
-
         @test cdattr ∉
               MOI.get(model, MOI.ListOfConstraintAttributesSet{F1,S1}())
         @test MOI.get(model, cdattr, a) === nothing
@@ -585,7 +552,6 @@ function start_values_unset_test(model::MOI.ModelLike, config)
               MOI.get(model, MOI.ListOfConstraintAttributesSet{F2,S2}())
         @test MOI.get(model, cdattr, c) === nothing
     end
-
     @testset "Allows unsetting by nothing" begin
         # First set the attributes to some values.
         MOI.set.((model,), (vpattr,), (x, y, z), (0.0, 1.0, 2.0))
@@ -593,7 +559,6 @@ function start_values_unset_test(model::MOI.ModelLike, config)
         MOI.set.((model,), (cdattr,), (a, b), (0.0, 1.0))
         MOI.set(model, cpattr, c, [2.0])
         MOI.set(model, cdattr, c, [2.0])
-
         @test vpattr ∈ MOI.get(model, MOI.ListOfVariableAttributesSet())
         @test cpattr ∈
               MOI.get(model, MOI.ListOfConstraintAttributesSet{F1,S1}())
@@ -603,19 +568,16 @@ function start_values_unset_test(model::MOI.ModelLike, config)
               MOI.get(model, MOI.ListOfConstraintAttributesSet{F1,S1}())
         @test cdattr ∈
               MOI.get(model, MOI.ListOfConstraintAttributesSet{F2,S2}())
-
         @test all(MOI.get.((model,), (vpattr,), (x, y, z)) .== (0.0, 1.0, 2.0))
         @test all(MOI.get.((model,), (cpattr,), (a, b)) .== (0.0, 1.0))
         @test all(MOI.get.((model,), (cdattr,), (a, b)) .== (0.0, 1.0))
         @test MOI.get(model, cpattr, c) == [2.0]
         @test MOI.get(model, cdattr, c) == [2.0]
-
         MOI.set(model, vpattr, y, nothing)
         MOI.set(model, cpattr, a, nothing)
         MOI.set(model, cdattr, a, nothing)
         MOI.set(model, cpattr, c, nothing)
         MOI.set(model, cdattr, c, nothing)
-
         # The tests below are commented because it was decided to not pin a
         # determined behaviour, there are two possibilities about the behaviour
         # of ListOfConstraintAttributesSet and ListOfVariableAttributesSet:
@@ -629,7 +591,6 @@ function start_values_unset_test(model::MOI.ModelLike, config)
         # Ref.: https://github.com/jump-dev/MathOptInterface.jl/pull/1136#discussion_r496466058
         #@test cpattr ∉ MOI.get(model, MOI.ListOfConstraintAttributesSet{F2, S2}())
         #@test cdattr ∉ MOI.get(model, MOI.ListOfConstraintAttributesSet{F2, S2}())
-
         @test all(
             MOI.get.((model,), (vpattr,), (x, y, z)) .=== (0.0, nothing, 2.0),
         )
@@ -637,12 +598,10 @@ function start_values_unset_test(model::MOI.ModelLike, config)
         @test all(MOI.get.((model,), (cdattr,), (a, b)) .=== (nothing, 1.0))
         @test MOI.get(model, cpattr, c) === nothing
         @test MOI.get(model, cdattr, c) === nothing
-
         MOI.set(model, vpattr, x, nothing)
         MOI.set(model, vpattr, z, nothing)
         MOI.set(model, cpattr, b, nothing)
         MOI.set(model, cdattr, b, nothing)
-
         # The three tests below are commented for the same reason the two
         # commented tests above.
         #@test vpattr ∉ MOI.get(model, MOI.ListOfVariableAttributesSet())
@@ -667,11 +626,9 @@ function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
     )
     F2 = MOI.VectorAffineFunction{Float64}
     S2 = MOI.Nonnegatives
-
     vpattr = MOI.VariablePrimalStart()
     cpattr = MOI.ConstraintPrimalStart()
     cdattr = MOI.ConstraintDualStart()
-
     @testset "Supports" begin
         @test MOI.supports(dest, vpattr, MOI.VariableIndex)
         @test MOI.supports(dest, cpattr, MOI.ConstraintIndex{F1,S1})
@@ -679,10 +636,8 @@ function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
         @test MOI.supports(dest, cdattr, MOI.ConstraintIndex{F1,S1})
         @test MOI.supports(dest, cdattr, MOI.ConstraintIndex{F2,S2})
     end
-
     @testset "Attribute set to no indices" begin
         dict = MOI.copy_to(dest, src, copy_names = false)
-
         @test !(vpattr in MOI.get(dest, MOI.ListOfVariableAttributesSet()))
         @test MOI.get(dest, vpattr, dict[x]) === nothing
         @test MOI.get(dest, vpattr, dict[y]) === nothing
@@ -706,7 +661,6 @@ function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
         )
         @test MOI.get(dest, cdattr, dict[c]) === nothing
     end
-
     @testset "Attribute set to some indices" begin
         MOI.set(src, vpattr, x, 1.0)
         MOI.set(src, vpattr, z, 3.0)
@@ -714,9 +668,7 @@ function start_values_test(dest::MOI.ModelLike, src::MOI.ModelLike)
         MOI.set(src, cpattr, b, 2.0)
         MOI.set(src, cdattr, b, 2.0)
         MOI.set(src, cdattr, c, [3.0])
-
         dict = MOI.copy_to(dest, src, copy_names = false)
-
         @test vpattr in MOI.get(dest, MOI.ListOfVariableAttributesSet())
         @test MOI.get(dest, vpattr, dict[x]) == 1.0
         @test MOI.get(dest, vpattr, dict[y]) === nothing
@@ -780,7 +732,6 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike; copy_names = false)
         ),
     )
     MOI.set(src, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     @test MOI.supports(
         dest,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -801,9 +752,7 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike; copy_names = false)
         MOI.VectorAffineFunction{Float64},
         MOI.Zeros,
     )
-
     dict = MOI.copy_to(dest, src, copy_names = copy_names)
-
     dest_name(src_name) = copy_names ? src_name : ""
     @test !MOI.supports(dest, MOI.Name()) ||
           MOI.get(dest, MOI.Name()) == dest_name("ModelName")
@@ -860,7 +809,6 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike; copy_names = false)
     @test (MOI.VectorOfVariables, MOI.Nonnegatives) in loc
     @test (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) in loc
     @test (MOI.VectorAffineFunction{Float64}, MOI.Zeros) in loc
-
     @test MOI.get(dest, MOI.ConstraintFunction(), dict[csv]) ==
           MOI.SingleVariable(dict[w])
     @test MOI.get(dest, MOI.ConstraintSet(), dict[csv]) == MOI.EqualTo(2.0)
@@ -888,7 +836,6 @@ function copytest(dest::MOI.ModelLike, src::MOI.ModelLike; copy_names = false)
         [-3.0, -2.0],
     )
     @test MOI.get(dest, MOI.ConstraintSet(), dict[cva]) == MOI.Zeros(2)
-
     @test MOI.get(
         dest,
         MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
@@ -928,7 +875,6 @@ function supports_constrainttest(
         MOI.EqualTo{BadT},
     )
     @test !MOI.supports_constraint(model, MOI.SingleVariable, MOI.EqualTo{BadT})
-
     @test MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.Zeros)
     @test !MOI.supports_constraint(
         model,
@@ -962,7 +908,6 @@ function orderedindicestest(model::MOI.ModelLike)
     @test MOI.get(model, MOI.ListOfVariableIndices()) == [v2, v3]
     v4 = MOI.add_variable(model)
     @test MOI.get(model, MOI.ListOfVariableIndices()) == [v2, v3, v4]
-
     # Note: there are too many combinations to test, so we're just going to
     # check SingleVariable-in-LessThan and hope it works for the rest
     c1 = MOI.add_constraint(model, MOI.SingleVariable(v2), MOI.LessThan(1.0))

--- a/src/Test/nlp.jl
+++ b/src/Test/nlp.jl
@@ -132,7 +132,6 @@ function MOI.eval_hessian_lagrangian(d::HS071, H, x, σ, μ)
     H[8] = σ * (x[1])               # 4,2
     H[9] = σ * (x[1])               # 4,3
     H[10] = 0                         # 4,4
-
     # First constraint
     H[2] += μ[1] * (x[3] * x[4])  # 2,1
     H[4] += μ[1] * (x[2] * x[4])  # 3,1
@@ -140,7 +139,6 @@ function MOI.eval_hessian_lagrangian(d::HS071, H, x, σ, μ)
     H[7] += μ[1] * (x[2] * x[3])  # 4,1
     H[8] += μ[1] * (x[1] * x[3])  # 4,2
     H[9] += μ[1] * (x[1] * x[2])  # 4,3
-
     # Second constraint
     H[1] += μ[2] * 2  # 1,1
     H[3] += μ[2] * 2  # 2,2
@@ -170,7 +168,6 @@ function MOI.eval_hessian_lagrangian_product(d::HS071, h, x, v, σ, μ)
         μ[1] * (x[2] * x[4] * v[1] + x[1] * x[4] * v[2] + x[1] * x[2] * v[4])
     h[4] +=
         μ[1] * (x[2] * x[3] * v[1] + x[1] * x[3] * v[2] + x[1] * x[2] * v[3])
-
     # Second constraint
     h[1] += μ[2] * 2.0 * v[1]
     h[2] += μ[2] * 2.0 * v[2]
@@ -186,7 +183,6 @@ function hs071test_template(
 )
     atol = config.atol
     rtol = config.rtol
-
     @test MOI.supports(model, MOI.NLPBlock())
     @test MOI.supports_constraint(
         model,
@@ -199,22 +195,16 @@ function hs071test_template(
         MOI.GreaterThan{Float64},
     )
     @test MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     lb = [25.0, 40.0]
     ub = [Inf, 40.0]
-
     block_data = MOI.NLPBlockData(MOI.NLPBoundsPair.(lb, ub), evaluator, true)
-
     v = MOI.add_variables(model, 4)
     @test MOI.get(model, MOI.NumberOfVariables()) == 4
-
     l = [1.0, 1.0, 1.0, 1.0]
     u = [5.0, 5.0, 5.0, 5.0]
     start = [1, 5, 5, 1]
-
     for i in 1:4
         cub = MOI.add_constraint(
             model,
@@ -232,29 +222,20 @@ function hs071test_template(
         @test clb.value == v[i].value
         MOI.set(model, MOI.VariablePrimalStart(), v[i], start[i])
     end
-
     MOI.set(model, MOI.NLPBlock(), block_data)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-
     # TODO: config.query tests
     if config.solve
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 17.014017145179164 atol =
             atol rtol = rtol
-
         optimal_v =
             [1.0, 4.7429996418092970, 3.8211499817883077, 1.3794082897556983]
-
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ optimal_v atol = atol rtol =
             rtol
-
         # TODO: Duals? Maybe better to test on a convex instance.
     end
 end
@@ -344,43 +325,30 @@ function feasibility_sense_test_template(
 )
     atol = config.atol
     rtol = config.rtol
-
     @test MOI.supports(model, MOI.NLPBlock())
     @test MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     lb = [1.0]
     ub = [1.0]
-
     block_data = MOI.NLPBlockData(
         MOI.NLPBoundsPair.(lb, ub),
         evaluator,
         set_has_objective,
     )
-
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     # Avoid starting at zero because it's a critial point.
     MOI.set(model, MOI.VariablePrimalStart(), x, 1.5)
-
     MOI.set(model, MOI.NLPBlock(), block_data)
     MOI.set(model, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
-
     # TODO: config.query tests
     if config.solve
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol = atol rtol = rtol
-
         @test abs(MOI.get(model, MOI.VariablePrimal(), x)) ≈ 1.0 atol = atol rtol =
             rtol
     end
@@ -431,46 +399,33 @@ function nlp_objective_and_moi_objective_test(
 )
     atol = config.atol
     rtol = config.rtol
-
     @test MOI.supports(model, MOI.NLPBlock())
     @test MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
-
     MOI.empty!(model)
     @test MOI.is_empty(model)
-
     lb = [1.0]
     ub = [2.0]
-
     block_data = MOI.NLPBlockData(
         MOI.NLPBoundsPair.(lb, ub),
         FeasibilitySenseEvaluator(true),
         true,
     )
-
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-
     # Avoid starting at zero because it's a critial point.
     MOI.set(model, MOI.VariablePrimalStart(), x, 1.5)
-
     MOI.set(model, MOI.NLPBlock(), block_data)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     f_x = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
     # This objective function should be ignored.
     MOI.set(model, MOI.ObjectiveFunction{typeof(f_x)}(), f_x)
-
     # TODO: config.query tests
     if config.solve
         MOI.optimize!(model)
-
         @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-
         @test MOI.get(model, MOI.ResultCount()) >= 1
-
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
-
         @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol = atol rtol = rtol
-
         @test 1.0 ≤ MOI.get(model, MOI.VariablePrimal(), x) ≤ 2.0
     end
 end


### PR DESCRIPTION
I'm on a mission to clean up the tests (https://github.com/jump-dev/MathOptInterface.jl/pull/1404) and an annoying piece of style is the arbitrary whitespace in some of the tests. There's a lot of it too! 1300 lines!

If the tests are unreadable, we should break them into smaller tests. Not introduce blank lines arbitrarily or between every line.