### PR TITLE
[Test] various fixes to MOI.Test

### DIFF
--- a/src/Test/test_constraint.jl
+++ b/src/Test/test_constraint.jl
@@ -282,7 +282,6 @@ function test_constraint_ScalarAffineFunction_duplicate(
     model::MOI.ModelLike,
     config::Config,
 )
-    MOI.empty!(model)
     x = MOI.add_variable(model)
     objective_function =
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
@@ -337,7 +336,6 @@ function test_constraint_VectorAffineFunction_duplicate(
     model::MOI.ModelLike,
     config::Config,
 )
-    MOI.empty!(model)
     x = MOI.add_variable(model)
     objective_function =
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)
@@ -398,7 +396,6 @@ function test_constraint_qcp_duplicate_diagonal(
         MOI.ScalarQuadraticFunction{Float64},
         MOI.LessThan{Float64},
     )
-    MOI.empty!(model)
     x = MOI.add_variables(model, 2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     MOI.set(
@@ -471,7 +468,6 @@ function test_constraint_qcp_duplicate_off_diagonal(
         MOI.ScalarQuadraticFunction{Float64},
         MOI.LessThan{Float64},
     )
-    MOI.empty!(model)
     x = MOI.add_variables(model, 2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     MOI.set(
@@ -536,7 +532,6 @@ Test a problem with a bounded ZeroOne variable.
 """
 function test_constraint_ZeroOne_bounds(model::MOI.ModelLike, config::Config)
     @requires MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)
-    MOI.empty!(model)
     MOIU.loadfromstring!(
         model,
         """
@@ -577,7 +572,6 @@ Test a problem with a ZeroOne and binding fractional upper bound.
 """
 function test_constraint_ZeroOne_bounds_2(model::MOI.ModelLike, config::Config)
     @requires MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)
-    MOI.empty!(model)
     MOIU.loadfromstring!(
         model,
         """
@@ -619,7 +613,6 @@ Test a problem with a ZeroOne and infeasible fractional bounds.
 function test_constraint_ZeroOne_bounds_3(model::MOI.ModelLike, config::Config)
     @requires MOI.supports_constraint(model, MOI.SingleVariable, MOI.ZeroOne)
     @requires _supports(config, MOI.optimize!)
-    MOI.empty!(model)
     MOIU.loadfromstring!(
         model,
         """
@@ -668,7 +661,6 @@ function test_constraint_PrimalStart_DualStart_SecondOrderCone(
         MOI.SecondOrderCone,
     )
     @requires _supports(config, MOI.optimize!)
-    MOI.empty!(model)
     x = MOI.add_variable(model)
     fx = MOI.SingleVariable(x)
     o = one(T)

--- a/src/Test/test_linear.jl
+++ b/src/Test/test_linear.jl
@@ -38,8 +38,6 @@ function test_linear_integration(
         MOI.SingleVariable,
         MOI.GreaterThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     v = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
     cf = MOI.ScalarAffineFunction{T}(
@@ -573,8 +571,6 @@ function test_linear_integration_2(
         MOI.SingleVariable,
         MOI.GreaterThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
@@ -715,8 +711,6 @@ function test_linear_inactive_bounds(
         MOI.SingleVariable,
         MOI.LessThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
     vc = MOI.add_constraint(
@@ -869,8 +863,6 @@ function test_linear_LessThan_and_GreaterThan(
         MOI.SingleVariable,
         MOI.LessThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     # Min  x - y
@@ -994,8 +986,6 @@ function test_linear_integration_modification(
         MOI.ScalarAffineFunction{T},
         MOI.LessThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
@@ -1159,8 +1149,6 @@ function test_linear_modify_GreaterThan_and_LessThan_constraints(
         MOI.ScalarAffineFunction{T},
         MOI.LessThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     # Min  x - y
@@ -1302,8 +1290,6 @@ function test_linear_VectorAffineFunction(
         MOI.VectorAffineFunction{T},
         MOI.Nonpositives,
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     # Min  x - y
@@ -1459,8 +1445,6 @@ function test_linear_INFEASIBLE(
         MOI.SingleVariable,
         MOI.GreaterThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     c = MOI.add_constraint(
@@ -1567,8 +1551,6 @@ function test_linear_DUAL_INFEASIBLE(
         MOI.SingleVariable,
         MOI.GreaterThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     MOI.add_constraint(
@@ -1662,8 +1644,6 @@ function test_linear_DUAL_INFEASIBLE_2(
         MOI.SingleVariable,
         MOI.GreaterThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     MOI.add_constraint(
@@ -1772,8 +1752,6 @@ function test_linear_add_constraints(
         MOI.SingleVariable,
         MOI.GreaterThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     vc12 = MOI.add_constraints(
@@ -1895,8 +1873,6 @@ function test_linear_integration_Interval(
         MOI.SingleVariable,
         MOI.GreaterThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     vc = MOI.add_constraints(
@@ -2141,8 +2117,6 @@ function test_linear_Interval_inactive(
         MOI.SingleVariable,
         MOI.GreaterThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     vc = MOI.add_constraints(
@@ -2284,8 +2258,6 @@ function test_linear_transform(
         MOI.ScalarAffineFunction{T},
         MOI.LessThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     v = MOI.add_variables(model, 2)
     c1 = MOI.add_constraint(
         model,
@@ -2387,8 +2359,6 @@ function test_linear_INFEASIBLE_2(
         MOI.SingleVariable,
         MOI.GreaterThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     c1 = MOI.add_constraint(
@@ -2501,8 +2471,6 @@ function test_linear_FEASIBILITY_SENSE(
         MOI.ScalarAffineFunction{T},
         MOI.GreaterThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     c1 = MOI.add_constraint(
@@ -2607,8 +2575,6 @@ function test_linear_integration_delete_variables(
         MOI.SingleVariable,
         MOI.LessThan{T},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x, y, z = MOI.add_variables(model, 3)
     c = MOI.add_constraint(
         model,
@@ -2792,8 +2758,6 @@ function test_linear_VectorAffineFunction_empty_row(
         MOI.VectorAffineFunction{T},
         MOI.Zeros,
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variables(model, 1)
     # Create a VectorAffineFunction with two rows, but only one term, belonging
     # to the second row. The first row, which is empty, is essentially a
@@ -2875,8 +2839,6 @@ function test_linear_VariablePrimalStart_partial(
 ) where {T}
     atol = config.atol
     rtol = config.rtol
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     MOI.set(model, MOI.VariablePrimalStart(), x, one(T))

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -138,7 +138,6 @@ end
 Test that the default ObjectiveSense is FEASIBILITY_SENSE.
 """
 function test_model_default_ObjectiveSense(model::MOI.ModelLike, ::Config)
-    @test MOI.is_empty(model)
     MOI.get(model, MOI.ObjectiveSense()) == MOI.FEASIBILITY_SENSE
     return
 end
@@ -149,7 +148,6 @@ end
 Test that the default TerminationStatus is OPTIMIZE_NOT_CALLED.
 """
 function test_model_default_TerminationStatus(model::MOI.ModelLike, ::Config)
-    @test MOI.is_empty(model)
     MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
     return
 end
@@ -160,7 +158,6 @@ end
 Test that the default PrimalStatus is NO_SOLUTION.
 """
 function test_model_default_PrimalStatus(model::MOI.ModelLike, ::Config)
-    @test MOI.is_empty(model)
     MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
     return
 end
@@ -171,7 +168,6 @@ end
 Test that the default DualStatus is NO_SOLUTION.
 """
 function test_model_default_DualStatus(model::MOI.ModelLike, ::Config)
-    @test MOI.is_empty(model)
     MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
     return
 end
@@ -285,7 +281,6 @@ function test_model_Name_VariableName_ConstraintName(
             MOI.LessThan{Float64},
         }(),
     ) == 0
-    @test MOI.supports(model, MOI.VariableName(), MOI.VariableIndex)
     v = MOI.add_variables(model, 2)
     @test MOI.get(model, MOI.VariableName(), v[1]) == ""
     x, cx = MOI.add_constrained_variable(model, MOI.GreaterThan(0.0))
@@ -321,7 +316,7 @@ function test_model_Name_VariableName_ConstraintName(
     @test MOI.get(model, MOI.VariableName(), v) == vynames[1:2]
     @test MOI.get(model, MOI.VariableName(), y) == vynames[3:6]
     @test MOI.get(model, MOI.VariableName(), [v; y]) == vynames
-    @test MOI.supports_constraint(
+    @requires MOI.supports_constraint(
         model,
         MOI.ScalarAffineFunction{Float64},
         MOI.LessThan{Float64},
@@ -331,7 +326,7 @@ function test_model_Name_VariableName_ConstraintName(
         MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], v), 0.0),
         MOI.LessThan(1.0),
     )
-    @test MOI.supports_constraint(
+    @requires MOI.supports_constraint(
         model,
         MOI.ScalarAffineFunction{Float64},
         MOI.EqualTo{Float64},
@@ -344,11 +339,11 @@ function test_model_Name_VariableName_ConstraintName(
     @test MOI.get(model, MOI.ConstraintName(), c) == ""
     @test MOI.get(model, MOI.ConstraintName(), c2) == ""
     @test MOI.get(model, MOI.ConstraintName(), cy) == ""
-    @test MOI.supports(model, MOI.ConstraintName(), typeof(c))
+    @requires MOI.supports(model, MOI.ConstraintName(), typeof(c))
     MOI.set(model, MOI.ConstraintName(), c, "")
-    @test MOI.supports(model, MOI.ConstraintName(), typeof(c2))
+    @requires MOI.supports(model, MOI.ConstraintName(), typeof(c2))
     MOI.set(model, MOI.ConstraintName(), c2, "") # Shouldn't error with duplicate empty name
-    @test MOI.supports(model, MOI.ConstraintName(), typeof(cy))
+    @requires MOI.supports(model, MOI.ConstraintName(), typeof(cy))
     MOI.set(model, MOI.ConstraintName(), cy, "")
     MOI.set(model, MOI.ConstraintName(), c, "Con0")
     @test MOI.get(model, MOI.ConstraintName(), c) == "Con0"
@@ -519,7 +514,7 @@ function test_model_is_valid(model::MOI.ModelLike, config::Config)
         @test !MOI.is_valid(model, x)
     end
     cf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 1.0], v), 0.0)
-    @test MOI.supports_constraint(model, typeof(cf), MOI.LessThan{Float64})
+    @requires MOI.supports_constraint(model, typeof(cf), MOI.LessThan{Float64})
     c = MOI.add_constraint(model, cf, MOI.LessThan(1.0))
     @test MOI.is_valid(model, c)
     @test !MOI.is_valid(
@@ -694,7 +689,6 @@ sorted by creation time.
 """
 function test_model_ordered_indices(model::MOI.ModelLike, ::Config)
     @requires MOI.supports_incremental_interface(model, false)
-    MOI.empty!(model)
     v1 = MOI.add_variable(model)
     @test MOI.get(model, MOI.ListOfVariableIndices()) == [v1]
     v2 = MOI.add_variable(model)
@@ -840,12 +834,10 @@ function test_model_UpperBoundAlreadySet(
     model::MOI.ModelLike,
     ::Config{T},
 ) where {T}
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     f = MOI.SingleVariable(x)
     ub = zero(T)
-    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.LessThan{T})
+    @requires MOI.supports_constraint(model, MOI.SingleVariable, MOI.LessThan{T})
     sets = [
         MOI.EqualTo(ub),
         MOI.Interval(ub, ub),

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -837,7 +837,11 @@ function test_model_UpperBoundAlreadySet(
     x = MOI.add_variable(model)
     f = MOI.SingleVariable(x)
     ub = zero(T)
-    @requires MOI.supports_constraint(model, MOI.SingleVariable, MOI.LessThan{T})
+    @requires MOI.supports_constraint(
+        model,
+        MOI.SingleVariable,
+        MOI.LessThan{T},
+    )
     sets = [
         MOI.EqualTo(ub),
         MOI.Interval(ub, ub),

--- a/src/Test/test_modification.jl
+++ b/src/Test/test_modification.jl
@@ -781,8 +781,6 @@ function test_modification_delete_variables_in_a_batch(
     model::MOI.ModelLike,
     config::Config,
 )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     MOIU.loadfromstring!(
         model,
         """
@@ -849,7 +847,6 @@ function test_modification_affine_deletion_edge_cases(
     model::MOI.ModelLike,
     config::Config,
 )
-    MOI.empty!(model)
     x = MOI.add_variable(model)
     # helpers. The function 1.0x + 0.0
     saf = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0)

--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -281,8 +281,6 @@ function _test_HS071(model::MOI.ModelLike, config::Config, evaluator::HS071)
         MOI.GreaterThan{Float64},
     )
     @requires MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     lb = [25.0, 40.0]
     ub = [Inf, 40.0]
     block_data = MOI.NLPBlockData(MOI.NLPBoundsPair.(lb, ub), evaluator, true)
@@ -458,8 +456,6 @@ function test_nonlinear_objective_and_moi_objective_test(
 )
     @requires MOI.supports(model, MOI.NLPBlock())
     @requires MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     lb = [1.0]
     ub = [2.0]
     block_data = MOI.NLPBlockData(
@@ -521,7 +517,6 @@ function test_nonlinear_mixed_complementarity(
         MOI.VectorAffineFunction{Float64},
         MOI.Complements,
     )
-    MOI.empty!(model)
     x = MOI.add_variables(model, 4)
     MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.Interval(0.0, 10.0))
     MOI.set.(model, MOI.VariablePrimalStart(), x, 0.0)
@@ -614,7 +609,6 @@ function test_nonlinear_qp_complementarity_constraint(
         MOI.VectorOfVariables,
         MOI.Complements,
     )
-    MOI.empty!(model)
     x = MOI.add_variables(model, 8)
     MOI.set.(model, MOI.VariablePrimalStart(), x, 0.0)
     MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.GreaterThan(0.0))

--- a/src/Test/test_objective.jl
+++ b/src/Test/test_objective.jl
@@ -233,9 +233,7 @@ function test_objective_qp_ObjectiveFunction_edge_cases(
     config::Config,
 )
     obj_attr = MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}()
-    if !MOI.supports(model, obj_attr)
-        return
-    end
+    @requires MOI.supports(model, obj_attr)
     x = MOI.add_variables(model, 2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     vc1 = MOI.add_constraint(
@@ -371,10 +369,7 @@ function test_objective_qp_ObjectiveFunction_zero_ofdiag(
     config::Config,
 )
     obj_attr = MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}()
-    if !MOI.supports(model, obj_attr)
-        return
-    end
-    MOI.empty!(model)
+    @requires MOI.supports(model, obj_attr)
     x = MOI.add_variables(model, 2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     vc1 = MOI.add_constraint(

--- a/src/Test/test_quadratic.jl
+++ b/src/Test/test_quadratic.jl
@@ -321,7 +321,11 @@ function test_quadratic_nonhomogeneous(model::MOI.ModelLike, config::Config)
         model,
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
     )
-    @requires MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @requires MOI.supports_constraint(
+        model,
+        MOI.SingleVariable,
+        MOI.GreaterThan{Float64},
+    )
     @requires MOI.supports_constraint(
         model,
         MOI.ScalarAffineFunction{Float64},

--- a/src/Test/test_quadratic.jl
+++ b/src/Test/test_quadratic.jl
@@ -11,17 +11,15 @@ st  x + 2y + 3z >= 4 (c1)
 """
 function test_quadratic_integration(model::MOI.ModelLike, config::Config)
     @requires MOI.supports_incremental_interface(model, false) #=copy_names=#
-    MOI.supports(
+    @requires MOI.supports(
         model,
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
     )
-    MOI.supports_constraint(
+    @requires MOI.supports_constraint(
         model,
         MOI.ScalarAffineFunction{Float64},
         MOI.GreaterThan{Float64},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     v = MOI.add_variables(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
     cf1 =
@@ -148,8 +146,6 @@ function test_quadratic_duplicate_terms(model::MOI.ModelLike, config::Config)
         MOI.ScalarAffineFunction{Float64},
         MOI.GreaterThan{Float64},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     v = MOI.add_variables(model, 3)
     @test MOI.get(model, MOI.NumberOfVariables()) == 3
     c1f =
@@ -325,14 +321,12 @@ function test_quadratic_nonhomogeneous(model::MOI.ModelLike, config::Config)
         model,
         MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
     )
-    MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
-    MOI.supports_constraint(
+    @requires MOI.supports_constraint(model, MOI.SingleVariable, MOI.GreaterThan{Float64})
+    @requires MOI.supports_constraint(
         model,
         MOI.ScalarAffineFunction{Float64},
         MOI.EqualTo{Float64},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     c1 = MOI.add_constraint(
@@ -489,8 +483,6 @@ function test_quadratic_constraint_integration(
         MOI.ScalarQuadraticFunction{Float64},
         MOI.LessThan{Float64},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
@@ -631,8 +623,6 @@ function test_quadratic_constraint_basic(model::MOI.ModelLike, config::Config)
         MOI.ScalarQuadraticFunction{Float64},
         MOI.LessThan{Float64},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
     cf = MOI.ScalarQuadraticFunction(
@@ -726,8 +716,6 @@ function test_quadratic_constraint_minimize(
         MOI.ScalarQuadraticFunction{Float64},
         MOI.LessThan{Float64},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
     cf = MOI.ScalarQuadraticFunction(
@@ -819,8 +807,6 @@ function _test_quadratic_constraint_helper(
         MOI.ScalarQuadraticFunction{Float64},
         typeof(quad_set),
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
@@ -959,8 +945,6 @@ function test_quadratic_nonconvex_constraint_integration(
         MOI.ScalarQuadraticFunction{Float64},
         MOI.LessThan{Float64},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
@@ -1048,8 +1032,6 @@ function test_quadratic_nonconvex_constraint_basic(
         MOI.ScalarQuadraticFunction{Float64},
         MOI.EqualTo{Float64},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     @test MOI.get(model, MOI.NumberOfVariables()) == 2
@@ -1145,8 +1127,6 @@ function test_quadratic_SecondOrderCone_basic(
         MOI.SingleVariable,
         MOI.GreaterThan{Float64},
     )
-    MOI.empty!(model)
-    @test MOI.is_empty(model)
     x = MOI.add_variable(model)
     y = MOI.add_variable(model)
     t = MOI.add_variable(model)

--- a/src/Test/test_solve.jl
+++ b/src/Test/test_solve.jl
@@ -285,7 +285,6 @@ function test_solve_SingleVariable_ConstraintDual_MAX_SENSE(
 )
     @requires _supports(config, MOI.optimize!)
     @requires _supports(config, MOI.ConstraintDual)
-    MOI.empty!(model)
     x = MOI.add_variable(model)
     xl = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(1.0))
     xu = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(1.0))
@@ -339,7 +338,6 @@ function test_solve_result_index(model::MOI.ModelLike, config::Config)
     @requires _supports(config, MOI.optimize!)
     atol = config.atol
     rtol = config.rtol
-    MOI.empty!(model)
     x = MOI.add_variable(model)
     c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(1.0))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
@@ -427,7 +425,6 @@ function test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_EqualTo_upper(
 )
     @requires _supports(config, MOI.optimize!)
     @requires _supports(config, MOI.ConstraintDual)
-    MOI.empty!(model)
     x = MOI.add_variables(model, 2)
     clb =
         MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.GreaterThan(0.0))
@@ -484,7 +481,6 @@ function test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_EqualTo_lower(
 )
     @requires _supports(config, MOI.optimize!)
     @requires _supports(config, MOI.ConstraintDual)
-    MOI.empty!(model)
     x = MOI.add_variables(model, 2)
     clb =
         MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.GreaterThan(0.0))
@@ -596,7 +592,6 @@ function test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_GreaterThan(
 )
     @requires _supports(config, MOI.optimize!)
     @requires _supports(config, MOI.ConstraintDual)
-    MOI.empty!(model)
     x = MOI.add_variables(model, 2)
     clb =
         MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.GreaterThan(0.0))
@@ -653,7 +648,6 @@ function test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_Interval_upper(
 )
     @requires _supports(config, MOI.optimize!)
     @requires _supports(config, MOI.ConstraintDual)
-    MOI.empty!(model)
     x = MOI.add_variables(model, 2)
     clb =
         MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.GreaterThan(0.0))
@@ -710,7 +704,6 @@ function test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_Interval_lower(
 )
     @requires _supports(config, MOI.optimize!)
     @requires _supports(config, MOI.ConstraintDual)
-    MOI.empty!(model)
     x = MOI.add_variables(model, 2)
     clb =
         MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.GreaterThan(0.0))
@@ -767,7 +760,6 @@ function test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_SingleVariable_LessThan
 )
     @requires _supports(config, MOI.optimize!)
     @requires _supports(config, MOI.ConstraintDual)
-    MOI.empty!(model)
     x = MOI.add_variables(model, 2)
     clb = MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.LessThan(0.0))
     c = MOI.add_constraint(
@@ -825,7 +817,6 @@ function test_solve_DualStatus_INFEASIBILITY_CERTIFICATE_SingleVariable_LessThan
 )
     @requires _supports(config, MOI.optimize!)
     @requires _supports(config, MOI.ConstraintDual)
-    MOI.empty!(model)
     x = MOI.add_variables(model, 2)
     clb = MOI.add_constraint.(model, MOI.SingleVariable.(x), MOI.LessThan(0.0))
     c = MOI.add_constraint(
@@ -888,7 +879,6 @@ function test_solve_optimize_twice(
     config::Config{T},
 ) where {T}
     @requires _supports(config, MOI.optimize!)
-    MOI.empty!(model)
     x = MOI.add_variable(model)
     MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(one(T)))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)

--- a/test/Test/Test.jl
+++ b/test/Test/Test.jl
@@ -11,9 +11,13 @@ MOI.Test.runtests(
     MOI.Test.Config(),
     exclude = [
         "test_model_ScalarFunctionConstantNotZero",
-        "test_model_copy_to_",
-        "test_model_supports_constraint_",
+        "test_model_copy_to_UnsupportedAttribute",
+        "test_model_copy_to_UnsupportedConstraint",
+        "test_model_supports_constraint_ScalarAffineFunction_EqualTo",
+        "test_model_supports_constraint_SingleVariable_EqualTo",
+        "test_model_supports_constraint_VectorOfVariables_Nonnegatives",
     ],
+    warn_unsupported = true,
 )
 
 # Run the previously excluded tests, this time without UniversalFallback.
@@ -26,7 +30,10 @@ MOI.Test.runtests(
     MOI.Test.Config(),
     include = [
         "test_model_ScalarFunctionConstantNotZero",
-        "test_model_copy_to_",
-        "test_model_supports_constraint_",
+        "test_model_copy_to_UnsupportedAttribute",
+        "test_model_copy_to_UnsupportedConstraint",
+        "test_model_supports_constraint_ScalarAffineFunction_EqualTo",
+        "test_model_supports_constraint_SingleVariable_EqualTo",
+        "test_model_supports_constraint_VectorOfVariables_Nonnegatives",
     ],
 )


### PR DESCRIPTION
In particular:
 - removes calls to `MOI.empty!` inside test functions. This now gets called outside.
 - Uses `@requires` in more places
 - More explicit exclusion of failing tests in `test/Test/Test.jl`. 

Part of #1398 