### PR TITLE
Fix Bridges.Constraint.ScalarizeBridge with unset starting values

### DIFF
--- a/src/Bridges/Constraint/scalarize.jl
+++ b/src/Bridges/Constraint/scalarize.jl
@@ -128,10 +128,32 @@ end
 
 function MOI.get(
     model::MOI.ModelLike,
-    attr::Union{MOI.ConstraintPrimal,MOI.ConstraintPrimalStart},
+    attr::MOI.ConstraintPrimal,
     bridge::ScalarizeBridge,
 )
     return MOI.get.(model, attr, bridge.scalar_constraints) .+ bridge.constants
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintPrimalStart,
+    bridge::ScalarizeBridge,
+)
+    values = MOI.get.(model, attr, bridge.scalar_constraints)
+    any(value -> value === nothing, values) && return nothing
+    return values .+ bridge.constants
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintPrimalStart,
+    bridge::ScalarizeBridge,
+    ::Nothing,
+)
+    for ci in bridge.scalar_constraints
+        MOI.set(model, attr, ci, nothing)
+    end
+    return
 end
 
 function MOI.set(
@@ -147,10 +169,20 @@ end
 
 function MOI.get(
     model::MOI.ModelLike,
-    attr::Union{MOI.ConstraintDual,MOI.ConstraintDualStart},
+    attr::MOI.ConstraintDual,
     bridge::ScalarizeBridge,
 )
     return MOI.get.(model, attr, bridge.scalar_constraints)
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintDualStart,
+    bridge::ScalarizeBridge,
+)
+    values = MOI.get.(model, attr, bridge.scalar_constraints)
+    any(value -> value === nothing, values) && return nothing
+    return values
 end
 
 function MOI.set(

--- a/src/Bridges/Constraint/scalarize.jl
+++ b/src/Bridges/Constraint/scalarize.jl
@@ -140,7 +140,9 @@ function MOI.get(
     bridge::ScalarizeBridge,
 )
     values = MOI.get.(model, attr, bridge.scalar_constraints)
-    any(value -> value === nothing, values) && return nothing
+    if any(value -> value === nothing, values)
+        return
+    end
     return values .+ bridge.constants
 end
 
@@ -181,7 +183,9 @@ function MOI.get(
     bridge::ScalarizeBridge,
 )
     values = MOI.get.(model, attr, bridge.scalar_constraints)
-    any(value -> value === nothing, values) && return nothing
+    if any(value -> value === nothing, values)
+        return
+    end
     return values
 end
 

--- a/test/Bridges/Constraint/scalarize.jl
+++ b/test/Bridges/Constraint/scalarize.jl
@@ -198,4 +198,15 @@ config = MOIT.Config()
                 [7, 2, -4, 7],
         )
     MOIT.lin2ftest(bridged_mock, config)
+
+    @testset "constraint_ConstraintPrimalStart" begin
+        MOI.Test.test_constraint_ConstraintPrimalStart(
+            bridged_mock,
+            MOI.Test.Config(),
+        )
+        MOI.Test.test_constraint_ConstraintDualStart(
+            bridged_mock,
+            MOI.Test.Config(),
+        )
+    end
 end


### PR DESCRIPTION
I like these new tests.

Closes https://github.com/jump-dev/MathOptInterface.jl/issues/1433