### PR TITLE
[Test] remove supports_optimize in favor of standard exclude

### DIFF
--- a/docs/src/submodules/Test/overview.md
+++ b/docs/src/submodules/Test/overview.md
@@ -172,12 +172,6 @@ function test_unit_optimize!_twice(
     model::MOI.ModelLike,
     config::Config{T},
 ) where {T}
-    if !config.supports_optimize
-        # Use `config` to modify the behavior of the tests. Since this test is
-        # concerned with `optimize!`, we should skip the test if
-        # `config.solve == false`.
-        return
-    end
     # Use the `@requires` macro to check conditions that the test function
     # requires in order to run. Models failing this `@requires` check will
     # silently skip the test.
@@ -186,6 +180,7 @@ function test_unit_optimize!_twice(
         MOI.SingleVariable,
         MOI.GreaterThan{Float64},
     )
+    @requires _supports(config, MOI.optimize!)
     # If needed, you can test that the model is empty at the start of the test.
     # You can assume that this will be the case for tests run via `runtests`.
     # User's calling tests individually need to call `MOI.empty!` themselves.

--- a/src/Test/test_attribute.jl
+++ b/src/Test/test_attribute.jl
@@ -33,9 +33,8 @@ Test that the [`MOI.RawStatusString`](@ref) attribute is implemented for
 `model`.
 """
 function test_attribute_RawStatusString(model::MOI.ModelLike, config::Config)
-    if !config.supports_optimize || !_supports(config, MOI.RawStatusString)
-        return
-    end
+    @requires _supports(config, MOI.optimize!)
+    @requires _supports(config, MOI.RawStatusString)
     MOI.add_variable(model)
     MOI.optimize!(model)
     @test MOI.get(model, MOI.RawStatusString()) isa AbstractString
@@ -106,9 +105,8 @@ end
 Test that the [`MOI.SolveTimeSec`](@ref) attribute is implemented for `model`.
 """
 function test_attribute_SolveTimeSec(model::MOI.ModelLike, config::Config)
-    if !config.supports_optimize || !_supports(config, MOI.SolveTimeSec)
-        return
-    end
+    @requires _supports(config, MOI.optimize!)
+    @requires _supports(config, MOI.SolveTimeSec)
     MOI.add_variable(model)
     MOI.optimize!(model)
     @test MOI.get(model, MOI.SolveTimeSec()) >= 0.0

--- a/src/Test/test_modification.jl
+++ b/src/Test/test_modification.jl
@@ -795,7 +795,7 @@ function test_modification_delete_variables_in_a_batch(
     @test MOI.is_valid(model, x)
     @test MOI.is_valid(model, y)
     @test MOI.is_valid(model, z)
-    if config.supports_optimize
+    if _supports(config, MOI.optimize!)
         MOI.optimize!(model)
         @test isapprox(MOI.get(model, MOI.ObjectiveValue()), 6.0, config)
     end
@@ -803,7 +803,7 @@ function test_modification_delete_variables_in_a_batch(
     @test !MOI.is_valid(model, x)
     @test MOI.is_valid(model, y)
     @test !MOI.is_valid(model, z)
-    if config.supports_optimize
+    if _supports(config, MOI.optimize!)
         MOI.optimize!(model)
         @test isapprox(MOI.get(model, MOI.ObjectiveValue()), 2.0, config)
     end

--- a/src/Test/test_objective.jl
+++ b/src/Test/test_objective.jl
@@ -136,9 +136,7 @@ function test_objective_ObjectiveFunction_blank(
     model::MOI.ModelLike,
     config::Config,
 )
-    if !_supports(config, MOI.optimize!)
-        return
-    end
+    @requires _supports(config, MOI.optimize!)
     obj_attr = MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}()
     @requires MOI.supports(model, obj_attr)
     x = MOI.add_variable(model)


### PR DESCRIPTION
I distinctly remember removing `supports_optimize`, but it seems like that commit never reached `master`...

Part of #1398