### PR TITLE
Refactor DoubleDicts.jl

### DIFF
--- a/docs/src/submodules/Utilities/overview.md
+++ b/docs/src/submodules/Utilities/overview.md
@@ -495,13 +495,14 @@ end
 ## DoubleDicts
 
 When writing MOI interfaces, we often need to handle situations in which we map
-[`MOI.ConstraintIndex`](@ref)s to different values. For example, to a string
-for [`MOI.ConstraintName`](@ref).
+[`ConstraintIndex`](@ref)s to different values. For example, to a string
+for [`ConstraintName`](@ref).
 
 One option is to use a dictionary like `Dict{MOI.ConstraintIndex,String}`.
 However, this incurs a performance cost because the key is not a concrete type.
 
 The DoubleDicts submodule helps this situation by providing two types main
-types [`DoubleDict`](@ref) and [`IndexDoubleDict`](@ref). These types act like
-normal dictionaries, but internally they use more efficient dictionaries
-specialized to the type of the function-set pair.
+types [`Utilities.DoubleDicts.DoubleDict`](@ref) and
+[`Utilities.DoubleDicts.IndexDoubleDict`](@ref). These types act like normal
+dictionaries, but internally they use more efficient dictionaries specialized to
+the type of the function-set pair.

--- a/docs/src/submodules/Utilities/overview.md
+++ b/docs/src/submodules/Utilities/overview.md
@@ -491,3 +491,17 @@ function MOI.get(model::Optimizer, attr::MOI.ObjectiveFunction)
     return MOI.Utilities.get_fallback(model, attr)
 end
 ```
+
+## DoubleDicts
+
+When writing MOI interfaces, we often need to handle situations in which we map
+[`MOI.ConstraintIndex`](@ref)s to different values. For example, to a string
+for [`MOI.ConstraintName`](@ref).
+
+One option is to use a dictionary like `Dict{MOI.ConstraintIndex,String}`.
+However, this incurs a performance cost because the key is not a concrete type.
+
+The DoubleDicts submodule helps this situation by providing two types main
+types [`DoubleDict`](@ref) and [`IndexDoubleDict`](@ref). These types act like
+normal dictionaries, but internally they use more efficient dictionaries
+specialized to the type of the function-set pair.

--- a/docs/src/submodules/Utilities/overview.md
+++ b/docs/src/submodules/Utilities/overview.md
@@ -524,13 +524,10 @@ use instead:
 function function_barrier(
     dest,
     src,
-    index_map,
-    ::Type{F},
-    ::Type{S},
+    index_map::MOI.Utilities.DoubleDicts.IndexDoubleDictInner{F,S},
 ) where {F,S}
-    type_stable_map = index_map[F, S]
     for ci in MOI.get(src, MOI.ListOfConstraintIndices{F,S}())
-        dest_ci = type_stable_map[ci]
+        dest_ci = index_map[ci]
         # ...
     end
     return
@@ -538,6 +535,6 @@ end
 
 index_map = MOI.copy_to(dest, src)
 for (F, S) in MOI.get(src, MOI.ListOfConstraintTypesPresent())
-    function_barrier(dest, src, index_map, F, S)
+    function_barrier(dest, src, index_map[F, S])
 end
 ```

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -199,7 +199,6 @@ Utilities.is_diagonal_vectorized_index
 Utilities.side_dimension_for_vectorized_dimension
 ```
 
-
 ## DoubleDicts
 
 ```@docs

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -198,3 +198,13 @@ The following utilities are useful when working with symmetric matrix cones.
 Utilities.is_diagonal_vectorized_index
 Utilities.side_dimension_for_vectorized_dimension
 ```
+
+
+## DoubleDicts
+
+```@docs
+DoubleDict
+DoubleDictInner
+IndexDoubleDict
+IndexDoubleDictInner
+```

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -202,8 +202,8 @@ Utilities.side_dimension_for_vectorized_dimension
 ## DoubleDicts
 
 ```@docs
-DoubleDict
-DoubleDictInner
-IndexDoubleDict
-IndexDoubleDictInner
+Utilities.DoubleDicts.DoubleDict
+Utilities.DoubleDicts.DoubleDictInner
+Utilities.DoubleDicts.IndexDoubleDict
+Utilities.DoubleDicts.IndexDoubleDictInner
 ```

--- a/src/Utilities/DoubleDicts.jl
+++ b/src/Utilities/DoubleDicts.jl
@@ -16,9 +16,7 @@ Convert the `value` stored inside `dict` to the equivalent on the outer
 `DoubleDict`. This is useful when the value type `V` of the inner dict is
 different to the outer dict. (See, e.g., [`IndexDoubleDict`](@ref).)
 """
-function typed_value(::AbstractDoubleDictInner{F,S,V}, value::V) where {F,S,V}
-    return value
-end
+typed_value(::AbstractDoubleDictInner, value) = value
 
 """
     DoubleDict{V}
@@ -164,10 +162,7 @@ function Base.get(
     key::MOI.ConstraintIndex{F,S},
     default,
 ) where {F,S}
-    if !haskey(d, key)
-        return default
-    end
-    return typed_value(d, d.inner[key.value])
+    return typed_value(d, get(d.inner, key.value, default))
 end
 
 # Base.getindex
@@ -184,10 +179,10 @@ function Base.getindex(
     d::AbstractDoubleDictInner{F,S},
     key::MOI.ConstraintIndex{F,S},
 ) where {F,S}
-    if !haskey(d, key)
+    x = get(d.inner, key.value) do
         throw(KeyError(key))
     end
-    return typed_value(d, d.inner[key.value])
+    return typed_value(d, x)
 end
 
 # Base.setindex!

--- a/src/Utilities/DoubleDicts.jl
+++ b/src/Utilities/DoubleDicts.jl
@@ -180,7 +180,7 @@ function Base.getindex(
     key::MOI.ConstraintIndex{F,S},
 ) where {F,S}
     x = get(d.inner, key.value) do
-        throw(KeyError(key))
+        return throw(KeyError(key))
     end
     return typed_value(d, x)
 end

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -217,6 +217,16 @@ function _reverse_dict(dest::AbstractDict, src::AbstractDict)
     return
 end
 
+function _reverse_dict(
+    dest::DoubleDicts.IndexDoubleDict,
+    src::DoubleDicts.IndexDoubleDict,
+)
+    for (key, value) in src.dict
+        dest.dict[key] = MOI.Utilities._reverse_dict(value)
+    end
+    return
+end
+
 function _reverse_dict(src::D) where {D<:Dict}
     return D(values(src) .=> keys(src))
 end

--- a/src/Utilities/copy/index_map.jl
+++ b/src/Utilities/copy/index_map.jl
@@ -5,7 +5,7 @@ struct IndexMap <: AbstractDict{MOI.Index,MOI.Index}
         typeof(CleverDicts.key_to_index),
         typeof(CleverDicts.index_to_key),
     }
-    con_map::DoubleDicts.MainIndexDoubleDict
+    con_map::DoubleDicts.IndexDoubleDict
 end
 
 """
@@ -46,7 +46,7 @@ end
 
 function _identity_constraints_map(
     model,
-    map::MOIU.DoubleDicts.IndexWithType{F,S},
+    map::MOIU.DoubleDicts.IndexDoubleDictInner{F,S},
 ) where {F,S}
     for c in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         map[c] = c

--- a/test/Utilities/DoubleDicts.jl
+++ b/test/Utilities/DoubleDicts.jl
@@ -140,7 +140,11 @@ end
 
 function test_DoubleDict()
     dict = DoubleDicts.DoubleDict{Float64}()
-    keys = [MOI.ConstraintIndex{MOI.SingleVariable,MOI.Integer}(1), MOI.ConstraintIndex{MOI.SingleVariable,MOI.Integer}(2), MOI.ConstraintIndex{MOI.SingleVariable,MOI.ZeroOne}(1)]
+    keys = [
+        MOI.ConstraintIndex{MOI.SingleVariable,MOI.Integer}(1),
+        MOI.ConstraintIndex{MOI.SingleVariable,MOI.Integer}(2),
+        MOI.ConstraintIndex{MOI.SingleVariable,MOI.ZeroOne}(1),
+    ]
     vals = [1.0, 2.0, 1.0]
     _test_basic_functionality(dict, keys, vals)
     return
@@ -148,7 +152,11 @@ end
 
 function test_IndexDoubleDict()
     dict = DoubleDicts.IndexDoubleDict()
-    keys = [MOI.ConstraintIndex{MOI.SingleVariable,MOI.Integer}(1), MOI.ConstraintIndex{MOI.SingleVariable,MOI.Integer}(2), MOI.ConstraintIndex{MOI.SingleVariable,MOI.ZeroOne}(1)]
+    keys = [
+        MOI.ConstraintIndex{MOI.SingleVariable,MOI.Integer}(1),
+        MOI.ConstraintIndex{MOI.SingleVariable,MOI.Integer}(2),
+        MOI.ConstraintIndex{MOI.SingleVariable,MOI.ZeroOne}(1),
+    ]
     vals = keys
     _test_basic_functionality(dict, keys, vals)
     src = DoubleDicts.IndexDoubleDict()

--- a/test/Utilities/DoubleDicts.jl
+++ b/test/Utilities/DoubleDicts.jl
@@ -90,8 +90,8 @@ function _test_basic_functionality(dict, k_values, v_values)
     @test length(dict) == 0
 
     dict[k_values[1]] = v_values[1]
-    idict = DoubleDicts.with_type(dict, MOI.SingleVariable, MOI.Integer)
-    bdict = DoubleDicts.with_type(dict, MOI.SingleVariable, MOI.ZeroOne)
+    idict = dict[MOI.SingleVariable, MOI.Integer]
+    bdict = dict[MOI.SingleVariable, MOI.ZeroOne]
     idict_ = dict[MOI.SingleVariable, MOI.Integer]
     @test idict.dict === idict_.dict
     sizehint!(idict, 2)
@@ -126,7 +126,7 @@ function _test_basic_functionality(dict, k_values, v_values)
     bdict[k_values[3]] = v_values[3]
     length(bdict) == 1
 
-    edict = DoubleDicts.with_type(dict, MOI.SingleVariable, MOI.EqualTo{Bool})
+    edict = dict[MOI.SingleVariable, MOI.EqualTo{Bool}]
     ek = MOI.ConstraintIndex{MOI.SingleVariable,MOI.EqualTo{Bool}}(1)
     delete!(edict, ek)
     @test_throws KeyError edict[ek]
@@ -160,18 +160,6 @@ function test_IndexDoubleDict()
     for (k, v) in src
         @test dest[v] == k
     end
-    return
-end
-
-function test_FunctionSetDoubleDict()
-    dict = DoubleDicts.FunctionSetDoubleDict()
-    keys = [MOI.ConstraintIndex{MOI.SingleVariable,MOI.Integer}(1), MOI.ConstraintIndex{MOI.SingleVariable,MOI.Integer}(2), MOI.ConstraintIndex{MOI.SingleVariable,MOI.ZeroOne}(1)]
-    vals = [
-        (MOI.SingleVariable(MOI.VariableIndex(1)), MOI.Integer()),
-        (MOI.SingleVariable(MOI.VariableIndex(2)), MOI.Integer()),
-        (MOI.SingleVariable(MOI.VariableIndex(1)), MOI.ZeroOne()),
-    ]
-    _test_basic_functionality(dict, keys, vals)
     return
 end
 


### PR DESCRIPTION
I took a look through DoubleDicts for the first time in a long time (ever?).

Why are there so many types and implementations? This is very complicated (600 lines!) for something that should be simple.

From what I can tell, the only type in DoubleDicts that is used is
https://github.com/jump-dev/MathOptInterface.jl/blob/667ad660b7766c526c7526eacbf256d0b9ec9104/src/Utilities/copy/index_map.jl#L8
With this constructor
https://github.com/jump-dev/MathOptInterface.jl/blob/667ad660b7766c526c7526eacbf256d0b9ec9104/src/Utilities/copy/index_map.jl#L24
And this related type which is used to access the inner dictionaries
https://github.com/jump-dev/MathOptInterface.jl/blob/667ad660b7766c526c7526eacbf256d0b9ec9104/src/Utilities/copy/index_map.jl#L49
called from here
https://github.com/jump-dev/MathOptInterface.jl/blob/667ad660b7766c526c7526eacbf256d0b9ec9104/src/Utilities/copy/index_map.jl#L70

Does that mean I can remove anything unused? Are other packages using this somewhere? If so, how?

Closes #1230 