### PR TITLE
Migrate tests of mockoptimizer.jl

### DIFF
--- a/src/DeprecatedTest/contlinear.jl
+++ b/src/DeprecatedTest/contlinear.jl
@@ -263,9 +263,6 @@ function linear1test(model::MOI.ModelLike, config::Config{T}) where {T}
         end
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [-1, 0, 2] atol = atol rtol =
             rtol
-        if config.duals
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-        end
     end
     # put lb of x back to 0 and fix z to zero to get :
     # max x + 2z

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -2488,7 +2488,7 @@ function setup_test(
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             MOI.INFEASIBLE,
-            tuple(),
+            MOI.NO_SOLUTION,
             (MOI.SingleVariable, MOI.LessThan{Float64}) => [-1],
             (MOI.SingleVariable, MOI.EqualTo{Float64}) => [-1],
             (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [1],

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -2489,6 +2489,7 @@ function setup_test(
             mock,
             MOI.INFEASIBLE,
             MOI.NO_SOLUTION,
+            MOI.INFEASIBILITY_CERTIFICATE,
             (MOI.SingleVariable, MOI.LessThan{Float64}) => [-1],
             (MOI.SingleVariable, MOI.EqualTo{Float64}) => [-1],
             (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [1],

--- a/src/Test/test_linear.jl
+++ b/src/Test/test_linear.jl
@@ -265,9 +265,6 @@ function test_linear_integration(
         end
         @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [-1, 0, 2] atol = atol rtol =
             rtol
-        if _supports(config, MOI.ConstraintDual)
-            @test MOI.get(model, MOI.DualStatus()) == MOI.FEASIBLE_POINT
-        end
     end
     # put lb of x back to 0 and fix z to zero to get :
     # max x + 2z
@@ -1511,6 +1508,7 @@ function setup_test(
             mock,
             MOI.INFEASIBLE,
             MOI.NO_SOLUTION,
+            MOI.INFEASIBILITY_CERTIFICATE,
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [-1],
         ),
@@ -2432,6 +2430,7 @@ function setup_test(
             mock,
             MOI.INFEASIBLE,
             MOI.NO_SOLUTION,
+            MOI.INFEASIBILITY_CERTIFICATE,
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [-1, -1],
         ),

--- a/src/Test/test_linear.jl
+++ b/src/Test/test_linear.jl
@@ -656,10 +656,10 @@ function setup_test(
             [1, 0],
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [-1],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.NONBASIC],
             ],
-            var_basis = [MOI.BASIC, MOI.NONBASIC_AT_LOWER],
+            variable_basis_status = [MOI.BASIC, MOI.NONBASIC_AT_LOWER],
         ),
     )
     return
@@ -813,18 +813,18 @@ function setup_test(
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [3],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.NONBASIC],
             ],
-            var_basis = [MOI.BASIC],
+            variable_basis_status = [MOI.BASIC],
         ),
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [0],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.BASIC],
             ],
-            var_basis = [MOI.NONBASIC_AT_UPPER],
+            variable_basis_status = [MOI.NONBASIC_AT_UPPER],
         ),
     )
     return
@@ -1826,11 +1826,11 @@ function setup_test(
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [650 / 11, 400 / 11],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.NONBASIC, MOI.NONBASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.BASIC],
             ],
-            var_basis = [MOI.BASIC, MOI.BASIC],
+            variable_basis_status = [MOI.BASIC, MOI.BASIC],
         ),
     )
     return
@@ -2039,20 +2039,20 @@ function setup_test(
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [5.0, 5.0],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [MOI.NONBASIC_AT_UPPER],
             ],
-            var_basis = [MOI.BASIC, MOI.BASIC],
+            variable_basis_status = [MOI.BASIC, MOI.BASIC],
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [-1],
         ),
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [2.5, 2.5],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [MOI.NONBASIC_AT_LOWER],
             ],
-            var_basis = [MOI.BASIC, MOI.BASIC],
+            variable_basis_status = [MOI.BASIC, MOI.BASIC],
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [1],
         ),
@@ -2061,20 +2061,20 @@ function setup_test(
             [1.0, 1.0],
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [1],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [MOI.NONBASIC_AT_LOWER],
             ],
-            var_basis = [MOI.BASIC, MOI.BASIC],
+            variable_basis_status = [MOI.BASIC, MOI.BASIC],
         ),
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [6.0, 6.0],
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [-1],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [MOI.NONBASIC_AT_UPPER],
             ],
-            var_basis = [MOI.BASIC, MOI.BASIC],
+            variable_basis_status = [MOI.BASIC, MOI.BASIC],
         ),
     )
     return
@@ -2184,10 +2184,13 @@ function setup_test(
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [0.0, 0.0],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [MOI.BASIC],
             ],
-            var_basis = [MOI.NONBASIC_AT_LOWER, MOI.NONBASIC_AT_LOWER],
+            variable_basis_status = [
+                MOI.NONBASIC_AT_LOWER,
+                MOI.NONBASIC_AT_LOWER,
+            ],
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [0],
         ),
@@ -2698,10 +2701,10 @@ function setup_test(
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [0, 1 / 2, 1],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.NONBASIC],
             ],
-            var_basis = [
+            variable_basis_status = [
                 MOI.NONBASIC_AT_LOWER,
                 MOI.BASIC,
                 MOI.NONBASIC_AT_UPPER,

--- a/src/Test/test_linear.jl
+++ b/src/Test/test_linear.jl
@@ -1510,7 +1510,7 @@ function setup_test(
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             MOI.INFEASIBLE,
-            tuple(),
+            MOI.NO_SOLUTION,
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [-1],
         ),
@@ -2431,7 +2431,7 @@ function setup_test(
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             MOI.INFEASIBLE,
-            tuple(),
+            MOI.NO_SOLUTION,
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [-1, -1],
         ),

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -1115,7 +1115,7 @@ function _set_mock_primal(
 end
 
 function _set_mock_primal(mock::MockOptimizer, primal::MOI.ResultStatusCode)
-    MOI.set(mock, MOI.PrimalStatus(), MOI.primal)
+    MOI.set(mock, MOI.PrimalStatus(), primal)
     return
 end
 

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -1057,9 +1057,8 @@ function mock_optimize!(
     _set_mock_dual(mock, dual_status_constraint_duals...)
     for con_basis_pair in con_basis
         F, S = con_basis_pair.first
-        for (i, ci) in enumerate(
-            MOI.get(mock, MOI.ListOfConstraintIndices{F,S}())
-        )
+        indices = MOI.get(mock, MOI.ListOfConstraintIndices{F,S}())
+        for (i, ci) in enumerate(indices)
             MOI.set(
                 mock,
                 MOI.ConstraintBasisStatus(),

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -915,62 +915,6 @@ function final_touch(uf::MockOptimizer, index_map)
     return final_touch(uf.inner_model, index_map)
 end
 
-# Allocate-Load Interface
-function supports_allocate_load(mock::MockOptimizer, copy_names::Bool)
-    return supports_allocate_load(mock.inner_model, copy_names)
-end
-
-function allocate_variables(mock::MockOptimizer, nvars)
-    return xor_index.(allocate_variables(mock.inner_model, nvars))
-end
-
-function allocate(mock::MockOptimizer, attr::MOI.AnyAttribute, value)
-    return allocate(mock.inner_model, attr, xor_indices(value))
-end
-
-function allocate(
-    mock::MockOptimizer,
-    attr::MOI.AnyAttribute,
-    idx::MOI.Index,
-    value,
-)
-    return allocate(mock.inner_model, attr, xor_index(idx), xor_indices(value))
-end
-
-function allocate_constraint(
-    mock::MockOptimizer,
-    f::MOI.AbstractFunction,
-    s::MOI.AbstractSet,
-)
-    return xor_index(allocate_constraint(mock.inner_model, xor_indices(f), s))
-end
-
-function load_variables(mock::MockOptimizer, nvars)
-    return load_variables(mock.inner_model, nvars)
-end
-
-function load(mock::MockOptimizer, attr::MOI.AnyAttribute, value)
-    return load(mock.inner_model, attr, xor_indices(value))
-end
-
-function load(
-    mock::MockOptimizer,
-    attr::MOI.AnyAttribute,
-    idx::MOI.Index,
-    value,
-)
-    return load(mock.inner_model, attr, xor_index(idx), xor_indices(value))
-end
-
-function load_constraint(
-    mock::MockOptimizer,
-    ci::CI,
-    f::MOI.AbstractFunction,
-    s::MOI.AbstractSet,
-)
-    return load_constraint(mock.inner_model, xor_index(ci), xor_indices(f), s)
-end
-
 """
     set_mock_optimize!(mock::MockOptimizer, opt::Function...)
 

--- a/test/Bridges/Constraint/functionize.jl
+++ b/test/Bridges/Constraint/functionize.jl
@@ -57,7 +57,7 @@ config_with_basis = MOIT.Config(basis = true)
                 [1, 0],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1],
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [0, 1],
-                con_basis = [
+                constraint_basis_status = [
                     (
                         MOI.ScalarAffineFunction{Float64},
                         MOI.LessThan{Float64},
@@ -67,7 +67,7 @@ config_with_basis = MOIT.Config(basis = true)
                         MOI.GreaterThan{Float64},
                     ) => [MOI.BASIC, MOI.NONBASIC],
                 ],
-                var_basis = [MOI.BASIC, MOI.NONBASIC_AT_LOWER],
+                variable_basis_status = [MOI.BASIC, MOI.NONBASIC_AT_LOWER],
             ),
         )
         MOIT.linear2test(bridged_mock, config_with_basis)

--- a/test/Bridges/Constraint/interval.jl
+++ b/test/Bridges/Constraint/interval.jl
@@ -39,11 +39,11 @@ end
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [5.0, 5.0],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.BASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.NONBASIC],
             ],
-            var_basis = [MOI.BASIC, MOI.BASIC],
+            variable_basis_status = [MOI.BASIC, MOI.BASIC],
             (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) =>
                 [0],
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
@@ -52,11 +52,11 @@ end
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [2.5, 2.5],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.NONBASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.BASIC],
             ],
-            var_basis = [MOI.BASIC, MOI.BASIC],
+            variable_basis_status = [MOI.BASIC, MOI.BASIC],
             (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) =>
                 [1],
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
@@ -69,20 +69,20 @@ end
                 [1],
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [0],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.NONBASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.BASIC],
             ],
-            var_basis = [MOI.BASIC, MOI.BASIC],
+            variable_basis_status = [MOI.BASIC, MOI.BASIC],
         ),
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [6.0, 6.0],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.BASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.NONBASIC],
             ],
-            var_basis = [MOI.BASIC, MOI.BASIC],
+            variable_basis_status = [MOI.BASIC, MOI.BASIC],
         ),
     )
     MOIT.linear10test(bridged_mock, config_with_basis)
@@ -95,11 +95,14 @@ end
                 [0],
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [-1],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) => [MOI.BASIC],
                 (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [MOI.BASIC],
             ],
-            var_basis = [MOI.NONBASIC_AT_LOWER, MOI.NONBASIC_AT_LOWER],
+            variable_basis_status = [
+                MOI.NONBASIC_AT_LOWER,
+                MOI.NONBASIC_AT_LOWER,
+            ],
             (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) =>
                 [0],
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>

--- a/test/Bridges/Constraint/slack.jl
+++ b/test/Bridges/Constraint/slack.jl
@@ -83,11 +83,11 @@ config = MOIT.Config()
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             [1, 0, 1],
-            con_basis = [
+            constraint_basis_status = [
                 (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}) =>
                     [MOI.NONBASIC],
             ],
-            var_basis = [
+            variable_basis_status = [
                 MOI.BASIC,
                 MOI.NONBASIC_AT_LOWER,
                 MOI.NONBASIC_AT_UPPER,

--- a/test/DeprecatedTest/contconic.jl
+++ b/test/DeprecatedTest/contconic.jl
@@ -227,6 +227,7 @@ end
             mock,
             MOI.INFEASIBLE,
             MOI.NO_SOLUTION,
+            MOI.INFEASIBILITY_CERTIFICATE,
             (MOI.SingleVariable, MOI.LessThan{Float64}) => [-1],
             (MOI.SingleVariable, MOI.EqualTo{Float64}) => [-1],
             (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [1],

--- a/test/DeprecatedTest/contconic.jl
+++ b/test/DeprecatedTest/contconic.jl
@@ -226,7 +226,7 @@ end
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             MOI.INFEASIBLE,
-            tuple(),
+            MOI.NO_SOLUTION,
             (MOI.SingleVariable, MOI.LessThan{Float64}) => [-1],
             (MOI.SingleVariable, MOI.EqualTo{Float64}) => [-1],
             (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [1],

--- a/test/DeprecatedTest/contlinear.jl
+++ b/test/DeprecatedTest/contlinear.jl
@@ -127,7 +127,7 @@ MOIU.set_mock_optimize!(
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         MOI.INFEASIBLE,
-        tuple(),
+        MOI.NO_SOLUTION,
         (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1],
     ),
 )
@@ -252,7 +252,7 @@ MOIU.set_mock_optimize!(
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         MOI.INFEASIBLE,
-        tuple(),
+        MOI.NO_SOLUTION,
         (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
             [-1, -1],
     ),

--- a/test/DeprecatedTest/contlinear.jl
+++ b/test/DeprecatedTest/contlinear.jl
@@ -53,11 +53,11 @@ MOIU.set_mock_optimize!(
         mock,
         [1, 0],
         (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1],
-        con_basis = [
+        constraint_basis_status = [
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [MOI.NONBASIC],
         ],
-        var_basis = [MOI.BASIC, MOI.NONBASIC_AT_LOWER],
+        variable_basis_status = [MOI.BASIC, MOI.NONBASIC_AT_LOWER],
     ),
 )
 MOIT.linear2test(mock, config)
@@ -66,20 +66,20 @@ MOIU.set_mock_optimize!(
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         [3],
-        con_basis = [
+        constraint_basis_status = [
             (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) =>
                 [MOI.NONBASIC],
         ],
-        var_basis = [MOI.BASIC],
+        variable_basis_status = [MOI.BASIC],
     ),
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         [0],
-        con_basis = [
+        constraint_basis_status = [
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [MOI.BASIC],
         ],
-        var_basis = [MOI.NONBASIC_AT_UPPER],
+        variable_basis_status = [MOI.NONBASIC_AT_UPPER],
     ),
 )
 MOIT.linear3test(mock, config)
@@ -173,13 +173,13 @@ MOIU.set_mock_optimize!(
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         [650 / 11, 400 / 11],
-        con_basis = [
+        constraint_basis_status = [
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [MOI.NONBASIC, MOI.NONBASIC],
             (MOI.ScalarAffineFunction{Float64}, MOI.GreaterThan{Float64}) =>
                 [MOI.BASIC],
         ],
-        var_basis = [MOI.BASIC, MOI.BASIC],
+        variable_basis_status = [MOI.BASIC, MOI.BASIC],
     ),
 )
 MOIT.linear9test(mock, config)
@@ -188,42 +188,42 @@ MOIU.set_mock_optimize!(
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         [5.0, 5.0],
-        con_basis = [
+        constraint_basis_status = [
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [MOI.NONBASIC_AT_UPPER],
         ],
-        var_basis = [MOI.BASIC, MOI.BASIC],
+        variable_basis_status = [MOI.BASIC, MOI.BASIC],
         (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [-1],
     ),
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         [2.5, 2.5],
-        con_basis = [
+        constraint_basis_status = [
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [MOI.NONBASIC_AT_LOWER],
         ],
-        var_basis = [MOI.BASIC, MOI.BASIC],
+        variable_basis_status = [MOI.BASIC, MOI.BASIC],
         (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [1],
     ),
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         [1.0, 1.0],
         (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [1],
-        con_basis = [
+        constraint_basis_status = [
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [MOI.NONBASIC_AT_LOWER],
         ],
-        var_basis = [MOI.BASIC, MOI.BASIC],
+        variable_basis_status = [MOI.BASIC, MOI.BASIC],
     ),
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         [6.0, 6.0],
         (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [-1],
-        con_basis = [
+        constraint_basis_status = [
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [MOI.NONBASIC_AT_UPPER],
         ],
-        var_basis = [MOI.BASIC, MOI.BASIC],
+        variable_basis_status = [MOI.BASIC, MOI.BASIC],
     ),
 )
 MOIT.linear10test(mock, config)
@@ -232,11 +232,11 @@ MOIU.set_mock_optimize!(
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         [0.0, 0.0],
-        con_basis = [
+        constraint_basis_status = [
             (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) =>
                 [MOI.BASIC],
         ],
-        var_basis = [MOI.NONBASIC_AT_LOWER, MOI.NONBASIC_AT_LOWER],
+        variable_basis_status = [MOI.NONBASIC_AT_LOWER, MOI.NONBASIC_AT_LOWER],
         (MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}) => [0],
     ),
 )
@@ -281,11 +281,15 @@ MOIU.set_mock_optimize!(
     (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
         mock,
         [0, 1 / 2, 1],
-        con_basis = [
+        constraint_basis_status = [
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
                 [MOI.NONBASIC],
         ],
-        var_basis = [MOI.NONBASIC_AT_LOWER, MOI.BASIC, MOI.NONBASIC_AT_UPPER],
+        variable_basis_status = [
+            MOI.NONBASIC_AT_LOWER,
+            MOI.BASIC,
+            MOI.NONBASIC_AT_UPPER,
+        ],
         (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1],
         (MOI.SingleVariable, MOI.GreaterThan{Float64}) => [2, 0, 0],
         (MOI.SingleVariable, MOI.LessThan{Float64}) => [-2],

--- a/test/DeprecatedTest/contlinear.jl
+++ b/test/DeprecatedTest/contlinear.jl
@@ -128,6 +128,7 @@ MOIU.set_mock_optimize!(
         mock,
         MOI.INFEASIBLE,
         MOI.NO_SOLUTION,
+        MOI.INFEASIBILITY_CERTIFICATE,
         (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) => [-1],
     ),
 )
@@ -253,6 +254,7 @@ MOIU.set_mock_optimize!(
         mock,
         MOI.INFEASIBLE,
         MOI.NO_SOLUTION,
+        MOI.INFEASIBILITY_CERTIFICATE,
         (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
             [-1, -1],
     ),

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -1,86 +1,22 @@
+module TestMockOptimizer
+
 using Test
 import MathOptInterface
 const MOI = MathOptInterface
-const MOIT = MOI.DeprecatedTest
 const MOIU = MOI.Utilities
 
-@testset "Default objective sense" begin
-    MOIT.default_objective_test(MOIU.MockOptimizer(MOIU.Model{Float64}()))
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
 end
 
-@testset "Default statuses" begin
-    model = MOIU.MockOptimizer(MOIU.Model{Float64}())
-    MOIT.default_status_test(model)
-    MOI.empty!(model)
-    MOIT.default_status_test(model)
-end
-
-@testset "Name test" begin
-    MOIT.nametest(MOIU.MockOptimizer(MOIU.Model{Float64}()))
-end
-
-struct NoFreeModel <: MOI.ModelLike end
-MOI.supports_add_constrained_variables(::NoFreeModel, ::Type{MOI.Reals}) = false
-
-@testset "supports_add_constrained_variable" begin
-    optimizer = MOIU.MockOptimizer(MOIU.Model{Float64}())
-    @test MOI.supports_add_constrained_variable(
-        optimizer,
-        MOI.GreaterThan{Float64},
-    )
-    @test !MOI.supports_add_constrained_variable(
-        optimizer,
-        MOIT.UnknownScalarSet{Float64},
-    )
-    @test MOI.supports_add_constrained_variables(optimizer, MOI.Nonnegatives)
-    @test !MOI.supports_add_constrained_variables(
-        optimizer,
-        MOIT.UnknownVectorSet,
-    )
-
-    nofree_optimizer = MOIU.MockOptimizer(NoFreeModel())
-    @test !MOI.supports_add_constrained_variable(
-        nofree_optimizer,
-        MOI.GreaterThan{Float64},
-    )
-    @test !MOI.supports_add_constrained_variables(
-        nofree_optimizer,
-        MOI.Nonnegatives,
-    )
-    @test !MOI.supports_add_constrained_variables(nofree_optimizer, MOI.Reals)
-end
-
-@testset "Optimizer attributes" begin
-    optimizer = MOIU.MockOptimizer(MOIU.Model{Float64}())
-    @test MOI.supports(optimizer, MOIU.MockModelAttribute())
-    MOI.set(optimizer, MOIU.MockModelAttribute(), 10)
-    @test MOI.get(optimizer, MOIU.MockModelAttribute()) == 10
-
-    v1 = MOI.add_variable(optimizer)
-    @test MOI.supports(optimizer, MOIU.MockVariableAttribute(), typeof(v1))
-    MOI.set(optimizer, MOIU.MockVariableAttribute(), v1, 11)
-    @test MOI.get(optimizer, MOIU.MockVariableAttribute(), v1) == 11
-    MOI.set(optimizer, MOIU.MockVariableAttribute(), [v1], [-11])
-    @test MOI.get(optimizer, MOIU.MockVariableAttribute(), [v1]) == [-11]
-
-    @test MOI.supports_constraint(
-        optimizer,
-        MOI.SingleVariable,
-        MOI.GreaterThan{Float64},
-    )
-    c1 = MOI.add_constraint(
-        optimizer,
-        MOI.SingleVariable(v1),
-        MOI.GreaterThan(1.0),
-    )
-    @test MOI.supports(optimizer, MOIU.MockConstraintAttribute(), typeof(c1))
-    MOI.set(optimizer, MOIU.MockConstraintAttribute(), c1, 12)
-    @test MOI.get(optimizer, MOIU.MockConstraintAttribute(), c1) == 12
-    MOI.set(optimizer, MOIU.MockConstraintAttribute(), [c1], [-12])
-    @test MOI.get(optimizer, MOIU.MockConstraintAttribute(), [c1]) == [-12]
-end
-
-@testset "Optimizer solve no result" begin
+function test_optimizer_solve_no_result()
     optimizer = MOIU.MockOptimizer(MOIU.Model{Float64}())
 
     v1 = MOI.add_variable(optimizer)
@@ -95,7 +31,7 @@ end
     @test MOI.get(optimizer, MOI.ConflictStatus()) == MOI.CONFLICT_FOUND
 end
 
-@testset "Optimizer solve with result" begin
+function test_optimizer_solve_with_result()
     optimizer = MOIU.MockOptimizer(
         MOIU.Model{Float64}(),
         eval_objective_value = false,
@@ -200,12 +136,7 @@ end
     )
 end
 
-@testset "Delete" begin
-    mock = MOIU.MockOptimizer(MOIU.Model{Float64}())
-    MOIT.delete_test(mock)
-end
-
-@testset "CanonicalConstraintFunction" begin
+function test_CanonicalConstraintFunction()
     mock = MOIU.MockOptimizer(MOIU.Model{Int}())
     fx, fy = MOI.SingleVariable.(MOI.add_variables(mock, 2))
     cx = MOI.add_constraint(mock, fx, MOI.LessThan(0))
@@ -223,7 +154,7 @@ end
     end
 end
 
-@testset "Conflict access" begin
+function test_conflict_access()
     mock = MOIU.MockOptimizer(MOIU.Model{Int}())
     fx, fy = MOI.SingleVariable.(MOI.add_variables(mock, 2))
     cx = MOI.add_constraint(mock, fx, MOI.LessThan(0))
@@ -236,3 +167,7 @@ end
           MOI.NOT_IN_CONFLICT
     @test MOI.get(mock, MOI.ConstraintConflictStatus(), c) == MOI.IN_CONFLICT
 end
+
+end  # module
+
+TestMockOptimizer.runtests()

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -209,9 +209,10 @@ function test_mock_deprecated()
             MOI.NO_SOLUTION,
             var_basis = [MOI.BASIC],
             con_basis = [
-                (MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64}) => [MOI.BASIC],
+                (MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}) =>
+                    [MOI.BASIC],
             ],
-        )
+        ),
     )
     @test_logs (:warn,) (:warn,) MOI.optimize!(mock)
     return


### PR DESCRIPTION
Part of #1398

Cleans up the interface, improves the documentation, and migrates the tests to functional form.