### PR TITLE
Fix StackOverflow with self-loop bridges

### DIFF
--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -98,7 +98,12 @@ function MOI.set(
     bridge::SetMapBridge{T,S2,S1,F,G},
     func::G,
 ) where {T,S2,S1,F,G}
-    MOI.set(model, attr, bridge.constraint, MOIB.map_function(typeof(bridge), func))
+    MOI.set(
+        model,
+        attr,
+        bridge.constraint,
+        MOIB.map_function(typeof(bridge), func),
+    )
     return
 end
 
@@ -201,7 +206,7 @@ function MOI.modify(
     bridge::SetMapBridge,
     change::MOI.AbstractFunctionModification,
 )
-    MOI.modify(model, bridge.constraint, _map_change(typeof(bridge),  change))
+    MOI.modify(model, bridge.constraint, _map_change(typeof(bridge), change))
     return
 end
 

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -92,6 +92,16 @@ function MOI.get(
     return MOIU.convert_approx(G, func)
 end
 
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintFunction,
+    bridge::SetMapBridge{T,S2,S1,F,G},
+    func::G,
+) where {T,S2,S1,F,G}
+    MOI.set(model, attr, bridge.constraint, map_function(typeof(bridge), func))
+    return
+end
+
 function MOI.get(
     model::MOI.ModelLike,
     attr::MOI.ConstraintSet,

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -98,7 +98,7 @@ function MOI.set(
     bridge::SetMapBridge{T,S2,S1,F,G},
     func::G,
 ) where {T,S2,S1,F,G}
-    MOI.set(model, attr, bridge.constraint, map_function(typeof(bridge), func))
+    MOI.set(model, attr, bridge.constraint, MOIB.map_function(typeof(bridge), func))
     return
 end
 
@@ -174,14 +174,34 @@ function MOI.set(
     return
 end
 
+# By linearity of the map, we can just change the constant/coefficient
+function _map_change(::Type{BT}, change::MOI.ScalarConstantChange) where {BT}
+    constant = MOIB.map_function(BT, change.new_constant)
+    return MOI.ScalarConstantChange(constant)
+end
+function _map_change(::Type{BT}, change::MOI.VectorConstantChange) where {BT}
+    constant = MOIB.map_function(BT, change.new_constant)
+    return MOI.VectorConstantChange(constant)
+end
+function _map_change(::Type{BT}, change::MOI.ScalarCoefficientChange) where {BT}
+    coefficient = MOIB.map_function(BT, change.new_coefficient)
+    return MOI.ScalarCoefficientChange(change.variable, coefficient)
+end
+function _map_change(::Type{BT}, change::MOI.MultirowChange) where {BT}
+    # It is important here that `change.new_coefficients` contains
+    # the complete new sparse column associated to the variable.
+    # Calling modify twice with part of the column won't work since
+    # the linear map might reset all the column each time.
+    coefficients = MOIB.map_function(BT, change.new_coefficients)
+    return MOI.MultirowChange(change.variable, coefficients)
+end
+
 function MOI.modify(
     model::MOI.ModelLike,
     bridge::SetMapBridge,
-    change::MOI.VectorConstantChange,
+    change::MOI.AbstractFunctionModification,
 )
-    # By linearity of the map, we can just change the constant
-    constant = MOIB.map_function(typeof(bridge), change.new_constant)
-    MOI.modify(model, bridge.constraint, MOI.VectorConstantChange(constant))
+    MOI.modify(model, bridge.constraint, _map_change(typeof(bridge),  change))
     return
 end
 

--- a/src/Bridges/Constraint/single_bridge_optimizer.jl
+++ b/src/Bridges/Constraint/single_bridge_optimizer.jl
@@ -103,3 +103,5 @@ function MOIB.bridge_type(
 end
 
 MOIB.bridging_cost(::SingleBridgeOptimizer, args...) = 1.0
+
+MOIB.recursive_model(b::SingleBridgeOptimizer) = b.model

--- a/src/Bridges/Objective/single_bridge_optimizer.jl
+++ b/src/Bridges/Objective/single_bridge_optimizer.jl
@@ -70,3 +70,5 @@ function MOIB.bridge_type(
 ) where {BT}
     return BT
 end
+
+MOIB.recursive_model(b::SingleBridgeOptimizer) = b.model

--- a/src/Bridges/Variable/set_map.jl
+++ b/src/Bridges/Variable/set_map.jl
@@ -197,7 +197,7 @@ function unbridged_map(bridge::SetMapBridge{T}, vi::MOI.VariableIndex) where {T}
     F = MOI.ScalarAffineFunction{T}
     func = MOI.SingleVariable(vi)
     mapped = MOIB.inverse_map_function(typeof(bridge), func)
-    return Pair{MOI.VariableIndex,F}[bridge.variable => mapped]
+    return Pair{MOI.VariableIndex,F}[bridge.variable=>mapped]
 end
 
 function unbridged_map(

--- a/src/Bridges/Variable/set_map.jl
+++ b/src/Bridges/Variable/set_map.jl
@@ -193,10 +193,7 @@ function MOIB.bridged_function(
     return convert(MOI.ScalarAffineFunction{T}, func)
 end
 
-function unbridged_map(
-    bridge::SetMapBridge{T},
-    vi::MOI.VariableIndex,
-) where {T}
+function unbridged_map(bridge::SetMapBridge{T}, vi::MOI.VariableIndex) where {T}
     F = MOI.ScalarAffineFunction{T}
     func = MOI.SingleVariable(vi)
     mapped = MOIB.inverse_map_function(typeof(bridge), func)

--- a/src/Bridges/Variable/set_map.jl
+++ b/src/Bridges/Variable/set_map.jl
@@ -23,13 +23,21 @@ bridge.
 """
 abstract type SetMapBridge{T,S1,S2} <: AbstractBridge end
 
+function _add_constrained_var(model, set::MOI.AbstractScalarSet)
+    return MOI.add_constrained_variable(model, set)
+end
+
+function _add_constrained_var(model, set::MOI.AbstractVectorSet)
+    return MOI.add_constrained_variables(model, set)
+end
+
 function bridge_constrained_variable(
     BT::Type{<:SetMapBridge{T,S1,S2}},
     model::MOI.ModelLike,
     set::S2,
 ) where {T,S1,S2}
     variables, constraint =
-        MOI.add_constrained_variables(model, MOIB.inverse_map_set(BT, set))
+        _add_constrained_var(model, MOIB.inverse_map_set(BT, set))
     return BT(variables, constraint)
 end
 
@@ -88,7 +96,17 @@ function MOI.get(
 end
 
 # References
-function MOI.delete(model::MOI.ModelLike, bridge::SetMapBridge)
+function MOI.delete(
+    model::MOI.ModelLike,
+    bridge::SetMapBridge{T,S1,S2},
+) where {T,S1,S2<:MOI.AbstractScalarSet}
+    MOI.delete(model, bridge.variable)
+    return
+end
+function MOI.delete(
+    model::MOI.ModelLike,
+    bridge::SetMapBridge{T,S1,S2},
+) where {T,S1,S2<:MOI.AbstractVectorSet}
     MOI.delete(model, bridge.variables)
     return
 end
@@ -102,6 +120,17 @@ function MOI.get(
 )
     set = MOI.get(model, attr, bridge.constraint)
     return MOIB.map_set(typeof(bridge), set)
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintSet,
+    bridge::SetMapBridge{T,S1},
+    set::S1,
+) where {T,S1}
+    mapped = MOIB.inverse_map_set(typeof(bridge), set)
+    MOI.set(model, attr, bridge.constraint, mapped)
+    return
 end
 
 function MOI.get(
@@ -162,6 +191,16 @@ function MOIB.bridged_function(
         i,
     )
     return convert(MOI.ScalarAffineFunction{T}, func)
+end
+
+function unbridged_map(
+    bridge::SetMapBridge{T},
+    vi::MOI.VariableIndex,
+) where {T}
+    F = MOI.ScalarAffineFunction{T}
+    func = MOI.SingleVariable(vi)
+    mapped = MOIB.inverse_map_function(typeof(bridge), func)
+    return Pair{MOI.VariableIndex,F}[bridge.variable => mapped]
 end
 
 function unbridged_map(

--- a/src/Bridges/Variable/single_bridge_optimizer.jl
+++ b/src/Bridges/Variable/single_bridge_optimizer.jl
@@ -82,3 +82,5 @@ function MOIB.bridge_type(
 end
 
 MOIB.bridging_cost(::SingleBridgeOptimizer, args...) = 1.0
+
+MOIB.recursive_model(b::SingleBridgeOptimizer) = b.model

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -579,7 +579,7 @@ end
 function MOI.delete(b::AbstractBridgeOptimizer, ci::MOI.ConstraintIndex)
     if is_bridged(b, ci)
         MOI.throw_if_not_valid(b, ci)
-        bridge = bridge(b, ci)
+        br = bridge(b, ci)
         if is_variable_bridged(b, ci)
             error(
                 "Cannot delete constraint index of bridged constrained",
@@ -592,7 +592,7 @@ function MOI.delete(b::AbstractBridgeOptimizer, ci::MOI.ConstraintIndex)
         Variable.call_in_context(
             Variable.bridges(b),
             ci,
-            () -> MOI.delete(recursive_model(b), bridge),
+            () -> MOI.delete(recursive_model(b), br),
         )
         b.name_to_con = nothing
         delete!(b.con_to_name, ci)

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -920,10 +920,16 @@ struct ObjectiveFunctionValue{F<:MOI.AbstractScalarFunction}
     result_index::Int
 end
 
+# `recursive_model(b::Objective.SingleBridgeOptimizer)` returns
+# `b.model` so any model should implement `ObjectiveFunctionValue`.
+function MOI.get(model::MOI.ModelLike, attr::ObjectiveFunctionValue)
+    return MOI.get(model, MOI.ObjectiveValue())
+end
+
 function MOI.get(
     b::AbstractBridgeOptimizer,
     attr::ObjectiveFunctionValue{F},
-) where {F}
+) where {F<:MOI.AbstractScalarFunction} # Need `<:` to avoid ambiguity
     obj_attr = MOI.ObjectiveFunction{F}()
     if is_bridged(b, obj_attr)
         return MOI.get(recursive_model(b), attr, bridge(b, obj_attr))

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -579,7 +579,7 @@ end
 function MOI.delete(b::AbstractBridgeOptimizer, ci::MOI.ConstraintIndex)
     if is_bridged(b, ci)
         MOI.throw_if_not_valid(b, ci)
-        bridge = Constraint.bridges(b)[ci]
+        bridge = bridge(b, ci)
         if is_variable_bridged(b, ci)
             error(
                 "Cannot delete constraint index of bridged constrained",
@@ -923,7 +923,7 @@ end
 # `recursive_model(b::Objective.SingleBridgeOptimizer)` returns
 # `b.model` so any model should implement `ObjectiveFunctionValue`.
 function MOI.get(model::MOI.ModelLike, attr::ObjectiveFunctionValue)
-    return MOI.get(model, MOI.ObjectiveValue())
+    return MOI.get(model, MOI.ObjectiveValue(attr.result_index))
 end
 
 function MOI.get(

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -513,7 +513,7 @@ function bridging_cost(b::LazyBridgeOptimizer, args...)
     return bridging_cost(b.graph, node(b, args...))
 end
 
-MOIB.recursive_model(b::SingleBridgeOptimizer) = b
+recursive_model(b::LazyBridgeOptimizer) = b
 
 function MOI.compute_conflict!(model::LazyBridgeOptimizer)
     return MOI.compute_conflict!(model.model)

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -513,6 +513,8 @@ function bridging_cost(b::LazyBridgeOptimizer, args...)
     return bridging_cost(b.graph, node(b, args...))
 end
 
+MOIB.recursive_model(b::SingleBridgeOptimizer) = b
+
 function MOI.compute_conflict!(model::LazyBridgeOptimizer)
     return MOI.compute_conflict!(model.model)
 end

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -708,10 +708,10 @@ include("identity_bridge.jl")
 function test_recursive_model_variable(::Type{T} = Int) where {T}
     model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}())
     BT = IdentityBridges.VariableBridge{T}
-    b = MOIB.Variable.SingleBridgeOptimizer{BT}(model)
+    b = MOI.Bridges.Variable.SingleBridgeOptimizer{BT}(model)
     x, cx = MOI.add_constrained_variable(b, MOI.EqualTo(one(T)))
-    @test MOIB.is_bridged(b, x)
-    @test MOIB.is_bridged(b, cx)
+    @test MOI.Bridges.is_bridged(b, x)
+    @test MOI.Bridges.is_bridged(b, cx)
     @test MOI.get(b, MOI.ConstraintFunction(), cx) == MOI.SingleVariable(x)
     @test MOI.get(b, MOI.ConstraintSet(), cx) == MOI.EqualTo(one(T))
     MOI.set(b, MOI.ConstraintSet(), cx, MOI.EqualTo(zero(T)))
@@ -724,13 +724,13 @@ end
 function test_recursive_model_constraint(::Type{T} = Int) where {T}
     model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}())
     BT = IdentityBridges.ConstraintBridge{T}
-    b = MOIB.Constraint.SingleBridgeOptimizer{BT}(model)
+    b = MOI.Bridges.Constraint.SingleBridgeOptimizer{BT}(model)
     x = MOI.add_variable(b)
     fx = MOI.SingleVariable(x)
     func = one(T) * fx
     set = MOI.EqualTo(zero(T))
     c = MOI.add_constraint(b, func, set)
-    @test MOIB.is_bridged(b, c)
+    @test MOI.Bridges.is_bridged(b, c)
     @test MOI.get(b, MOI.ConstraintFunction(), c) ≈ func
     new_func = T(2) * fx
     MOI.set(b, MOI.ConstraintFunction(), c, new_func)
@@ -753,19 +753,19 @@ end
 function test_recursive_model_objective(::Type{T} = Int) where {T}
     model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}())
     BT = IdentityBridges.ObjectiveBridge{T}
-    b = MOIB.Objective.SingleBridgeOptimizer{BT}(model)
+    b = MOI.Bridges.Objective.SingleBridgeOptimizer{BT}(model)
     x = MOI.add_variable(b)
     fx = MOI.SingleVariable(x)
     func = one(T) * fx
     MOI.set(b, MOI.ObjectiveSense(), MOI.MIN_SENSE)
-    @test !MOIB.is_objective_bridged(b)
+    @test !MOI.Bridges.is_objective_bridged(b)
     attr = MOI.ObjectiveFunction{typeof(func)}()
     MOI.set(b, attr, func)
-    @test MOIB.is_objective_bridged(b)
+    @test MOI.Bridges.is_objective_bridged(b)
     @test MOI.get(b, attr) ≈ func
     attr = MOI.ObjectiveFunction{typeof(fx)}()
     MOI.set(b, attr, fx)
-    @test !MOIB.is_objective_bridged(b)
+    @test !MOI.Bridges.is_objective_bridged(b)
     @test MOI.get(b, attr) ≈ fx
 end
 

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -703,6 +703,8 @@ function test_get_ObjectiveFunctionType()
     return
 end
 
+include("identity_bridge.jl")
+
 function test_recursive_model_variable(::Type{T} = Int) where {T}
     model = MOIU.UniversalFallback(MOIU.Model{T}())
     BT = IdentityBridges.VariableBridge{T}

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -706,7 +706,7 @@ end
 include("identity_bridge.jl")
 
 function test_recursive_model_variable(::Type{T} = Int) where {T}
-    model = MOIU.UniversalFallback(MOIU.Model{T}())
+    model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}())
     BT = IdentityBridges.VariableBridge{T}
     b = MOIB.Variable.SingleBridgeOptimizer{BT}(model)
     x, cx = MOI.add_constrained_variable(b, MOI.EqualTo(one(T)))
@@ -722,7 +722,7 @@ function test_recursive_model_variable(::Type{T} = Int) where {T}
 end
 
 function test_recursive_model_constraint(::Type{T} = Int) where {T}
-    model = MOIU.UniversalFallback(MOIU.Model{T}())
+    model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}())
     BT = IdentityBridges.ConstraintBridge{T}
     b = MOIB.Constraint.SingleBridgeOptimizer{BT}(model)
     x = MOI.add_variable(b)
@@ -751,7 +751,7 @@ function test_recursive_model_constraint(::Type{T} = Int) where {T}
 end
 
 function test_recursive_model_objective(::Type{T} = Int) where {T}
-    model = MOIU.UniversalFallback(MOIU.Model{T}())
+    model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}())
     BT = IdentityBridges.ObjectiveBridge{T}
     b = MOIB.Objective.SingleBridgeOptimizer{BT}(model)
     x = MOI.add_variable(b)

--- a/test/Bridges/identity_bridge.jl
+++ b/test/Bridges/identity_bridge.jl
@@ -1,0 +1,120 @@
+# Dummy bridges used for testing
+module IdentityBridges
+
+import MathOptInterface
+const MOI = MathOptInterface
+const MOIB = MOI.Bridges
+const MOIBV = MOIB.Variable
+const MOIBC = MOIB.Constraint
+
+const F{T} = MOI.ScalarAffineFunction{T}
+const S{T} = MOI.EqualTo{T}
+
+struct VariableBridge{T} <: MOIBV.AbstractBridge
+    variables::Vector{MOI.VariableIndex}
+    constraint::MOI.ConstraintIndex{MOI.SingleVariable,S{T}}
+end
+
+function MOIBV.bridge_constrained_variable(
+    ::Type{VariableBridge{T}},
+    model::MOI.ModelLike,
+    set::S{T},
+) where {T}
+    variable, constraint = MOI.add_constrained_variable(model, set)
+    return VariableBridge{T}(variable, constraint)
+end
+
+function MOIBV.supports_constrained_variable(
+    ::Type{VariableBridge{T}},
+    ::Type{S{T}},
+) where {T}
+    return true
+end
+
+function MOIB.added_constrained_variable_types(
+    ::Type{VariableBridge{T}},
+) where {T}
+    return [(S{T},)]
+end
+
+function MOIB.added_constraint_types(::Type{<:VariableBridge})
+    return Tuple{DataType,DataType}[]
+end
+
+# Attributes, Bridge acting as a model
+MOI.get(bridge::VariableBridge, ::MOI.NumberOfVariables) = 1
+MOI.get(bridge::VariableBridge, ::MOI.ListOfVariableIndices) = [bridge.variable]
+
+function MOI.get(
+    bridge::VariableBridge,
+    ::MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.RotatedSecondOrderCone},
+)
+    return 1
+end
+
+function MOI.get(
+    bridge::VariableBridge,
+    ::MOI.ListOfConstraintIndices{
+        MOI.VectorOfVariables,
+        MOI.RotatedSecondOrderCone,
+    },
+)
+    return [bridge.constraint]
+end
+
+# References
+function MOI.delete(model::MOI.ModelLike, bridge::VariableBridge)
+    MOI.delete(model, bridge.variable)
+    return
+end
+
+# Attributes, Bridge acting as a constraint
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintSet,
+    bridge::VariableBridge{T},
+) where {T}
+    return MOI.get(model, attr, bridge.constraint)
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintPrimal,MOI.ConstraintDual},
+    bridge::VariableBridge,
+)
+    return MOI.get(model, attr, bridge.constraint)
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::MOI.VariablePrimal,
+    bridge::VariableBridge,
+)
+    return MOI.get(model, attr, bridge.variable)
+end
+
+function MOIB.bridged_function(bridge::VariableBridge{T}) where {T}
+    return MOI.SingleVariable(bridge.variable)
+end
+
+function unbridged_map(
+    bridge::VariableBridge{T},
+    vi::MOI.VariableIndex,
+) where {T}
+    func = convert(F{T}, MOI.SingleVariable(vi))
+    return (bridge.variable => func,)
+end
+
+struct ConstraintBridge{T} <: MOIBC.SetMapBridge{T,S{T},S{T},F{T},F{T}}
+    constraint::MOI.ConstraintIndex{F{T},S{T}}
+end
+
+MOIBC.map_set(::Type{<:ConstraintBridge}, set::S) = set
+MOIBC.inverse_map_set(::Type{<:ConstraintBridge}, set::S) = set
+MOIBC.map_function(::Type{<:ConstraintBridge}, func) = func
+MOIBC.inverse_map_function(::Type{<:ConstraintBridge}, func) = func
+MOIBC.adjoint_map_function(::Type{<:ConstraintBridge}, func) = func
+MOIBC.inverse_adjoint_map_function(::Type{<:ConstraintBridge}, func) = func
+
+end


### PR DESCRIPTION
This is breaking for a user relying on the fact that SingleBridgeOptimizer was creating the constraint to the same model recursively.
It would have been used in a non-stackoverflow situation in case a bridge would create a constraint of the same time as the constraint being transformed twice and then not. I would guess no user was doing that but we never know.

Closes https://github.com/jump-dev/MathOptInterface.jl/issues/1015