### PR TITLE
Add support for Union on StructOfConstraints

### DIFF
--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -323,10 +323,10 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
     end
     if !isempty(types)
         is_func = any(types) do t
-            t isa Union{SymbolFun,_UnionSymbolFS{SymbolFun}}
+            return t isa Union{SymbolFun,_UnionSymbolFS{SymbolFun}}
         end
         is_set = any(types) do t
-            t isa Union{SymbolSet,_UnionSymbolFS{SymbolSet}}
+            return t isa Union{SymbolSet,_UnionSymbolFS{SymbolSet}}
         end
         @assert xor(is_func, is_set)
         if is_func

--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -335,7 +335,7 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
             SuperF = :(MOI.AbstractFunction)
         end
         if is_set
-            :(Union{$(_typed.(types)...)})
+            SuperS = :(Union{$(_typed.(types)...)})
         else
             SuperS = :(MOI.AbstractSet)
         end

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -557,11 +557,7 @@ function test_multicone()
     fx = MOI.SingleVariable(x)
     y = MOI.add_variable(model)
     fy = MOI.SingleVariable(y)
-    MOI.add_constraint(
-        model,
-        MOIU.vectorize([T(5) * fx + T(2)]),
-        MOI.Zeros(1),
-    )
+    MOI.add_constraint(model, MOIU.vectorize([T(5) * fx + T(2)]), MOI.Zeros(1))
     MOI.add_constraint(
         model,
         MOIU.vectorize([T(3) * fy + T(1)]),
@@ -575,12 +571,12 @@ function test_multicone()
     MOIU.final_touch(model, nothing)
     _test_matrix_equal(
         model.constraints.moi_zeros.coefficients,
-        sparse([1], [1], T[5], 1, 2)
+        sparse([1], [1], T[5], 1, 2),
     )
     @test model.constraints.moi_zeros.constants == T[2]
     _test_matrix_equal(
         model.constraints.moi_nonnegatives.coefficients,
-        sparse([1, 3], [2, 1], T[3, 7], 4, 2)
+        sparse([1, 3], [2, 1], T[3, 7], 4, 2),
     )
     @test model.constraints.moi_nonnegatives.constants == T[1, 6, 0, 4]
 end


### PR DESCRIPTION
Needed by ECOS since it needs a `StructOfConstraints` with `MOI.Zeros` on one side and `Union{MOI.Nonnegatives,MOI.SecondOrderCone,MOI.ExponentialCone}` on the other side.