### PR TITLE
Refactor .objective field of Utilities.Model into a struct

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -59,6 +59,7 @@ include("copy.jl")
 include("results.jl")
 include("variables.jl")
 
+include("objective_function_container.jl")
 include("vector_bounds.jl")
 include("vector_of_constraints.jl")
 include("struct_of_constraints.jl")

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -322,7 +322,7 @@ end
 
 function MOI.set(
     model::AbstractModel,
-    ::MOI.ObjectiveSense,
+    attr::MOI.ObjectiveSense,
     sense::MOI.OptimizationSense,
 )
     MOI.set(model.objective, attr, sense)

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -334,6 +334,9 @@ function MOI.set(
     attr::MOI.ObjectiveFunction{F},
     f::F,
 ) where {F<:MOI.AbstractFunction}
+    if !MOI.supports(model, attr)
+        throw(MOI.UnsupportedAttribute(attr))
+    end
     MOI.set(model.objective, attr, f)
     return
 end

--- a/src/Utilities/objective_function_container.jl
+++ b/src/Utilities/objective_function_container.jl
@@ -192,11 +192,13 @@ end
 
 function MOI.delete(o::ObjectiveFunctionContainer, x::Vector{MOI.VariableIndex})
     keep = v -> !(v in x)
-    if o.single_variable !== nothing && o.single_variable.variable in x
-        sense = o.sense
-        MOI.empty!(o)
-        if o.is_sense_set
-            MOI.set(o, MOI.ObjectiveSense(), sense)
+    if o.single_variable !== nothing
+        if o.single_variable.variable in x
+            sense = o.sense
+            MOI.empty!(o)
+            if o.is_sense_set
+                MOI.set(o, MOI.ObjectiveSense(), sense)
+            end
         end
     elseif o.scalar_quadratic !== nothing
         o.scalar_quadratic = filter_variables(keep, o.scalar_quadratic)

--- a/src/Utilities/objective_function_container.jl
+++ b/src/Utilities/objective_function_container.jl
@@ -1,0 +1,208 @@
+"""
+    ObjectiveFunctionContainer{T}
+
+A helper struct to simplify the handling of objective functions in
+Utilities.Model.
+"""
+mutable struct ObjectiveFunctionContainer{T}
+    is_sense_set::Bool
+    sense::MOI.OptimizationSense
+    is_function_set::Bool
+    single_variable::Union{Nothing,MOI.SingleVariable}
+    scalar_affine::Union{Nothing,MOI.ScalarAffineFunction{T}}
+    scalar_quadratic::Union{Nothing,MOI.ScalarQuadraticFunction{T}}
+    function ObjectiveFunctionContainer{T}() where {T}
+        o = new{T}()
+        MOI.empty!(o)
+        return o
+    end
+end
+
+function MOI.empty!(o::ObjectiveFunctionContainer{T}) where {T}
+    o.is_sense_set = false
+    o.sense = MOI.FEASIBILITY_SENSE
+    o.is_function_set = false
+    o.single_variable = nothing
+    o.scalar_affine =
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
+    o.scalar_quadratic = nothing
+    return
+end
+
+function MOI.is_empty(o::ObjectiveFunctionContainer)
+    return !o.is_sense_set && !o.is_function_set
+end
+
+###
+### ObjectiveSense
+###
+
+MOI.supports(::ObjectiveFunctionContainer, ::MOI.ObjectiveSense) = true
+
+MOI.get(o::ObjectiveFunctionContainer, ::MOI.ObjectiveSense) = o.sense
+
+function MOI.set(o::ObjectiveFunctionContainer, ::MOI.ObjectiveSense, value)
+    if value == MOI.FEASIBILITY_SENSE
+        MOI.empty!(o)
+    end
+    o.is_sense_set = true
+    o.sense = value
+    return
+end
+
+###
+### ObjectiveFunctionType
+###
+
+function MOI.get(
+    o::ObjectiveFunctionContainer{T},
+    ::MOI.ObjectiveFunctionType,
+) where {T}
+    if o.single_variable !== nothing
+        return MOI.SingleVariable
+    elseif o.scalar_quadratic !== nothing
+        return MOI.ScalarQuadraticFunction{T}
+    end
+    @assert o.scalar_affine !== nothing
+    return MOI.ScalarAffineFunction{T}
+end
+
+###
+### ObjectiveFunction
+###
+
+function MOI.supports(
+    ::ObjectiveFunctionContainer{T},
+    ::MOI.ObjectiveFunction{
+        <:Union{
+            MOI.SingleVariable,
+            MOI.ScalarAffineFunction{T},
+            MOI.ScalarQuadraticFunction{T},
+        },
+    },
+) where {T}
+    return true
+end
+
+function MOI.get(
+    o::ObjectiveFunctionContainer{T},
+    ::MOI.ObjectiveFunction{F},
+) where {T,F}
+    if o.single_variable !== nothing
+        return convert(F, o.single_variable)
+    elseif o.scalar_quadratic !== nothing
+        return convert(F, o.scalar_quadratic)
+    end
+    @assert o.scalar_affine !== nothing
+    return convert(F, o.scalar_affine)
+end
+
+function MOI.set(
+    o::ObjectiveFunctionContainer,
+    ::MOI.ObjectiveFunction{MOI.SingleVariable},
+    f::MOI.SingleVariable,
+)
+    o.is_function_set = true
+    o.single_variable = copy(f)
+    o.scalar_affine = nothing
+    o.scalar_quadratic = nothing
+    return
+end
+
+function MOI.set(
+    o::ObjectiveFunctionContainer{T},
+    ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}},
+    f::MOI.ScalarAffineFunction{T},
+) where {T}
+    o.is_function_set = true
+    o.single_variable = nothing
+    o.scalar_affine = copy(f)
+    o.scalar_quadratic = nothing
+    return
+end
+
+function MOI.set(
+    o::ObjectiveFunctionContainer{T},
+    ::MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{T}},
+    f::MOI.ScalarQuadraticFunction{T},
+) where {T}
+    o.is_function_set = true
+    o.single_variable = nothing
+    o.scalar_affine = nothing
+    o.scalar_quadratic = copy(f)
+    return
+end
+
+###
+### MOI.ListOfModelAttributesSet
+###
+
+function MOI.get(o::ObjectiveFunctionContainer, ::MOI.ListOfModelAttributesSet)
+    ret = MOI.AbstractModelAttribute[]
+    if o.is_sense_set
+        push!(ret, MOI.ObjectiveSense())
+    end
+    if o.is_function_set
+        F = MOI.get(o, MOI.ObjectiveFunctionType())
+        push!(ret, MOI.ObjectiveFunction{F}())
+    end
+    return ret
+end
+
+###
+### MOI.modify
+###
+
+function MOI.modify(
+    o::ObjectiveFunctionContainer,
+    ::MOI.ObjectiveFunction,
+    change::MOI.AbstractFunctionModification,
+)
+    if o.single_variable !== nothing
+        o.single_variable = modify_function(o.single_variable, change)
+    elseif o.scalar_quadratic !== nothing
+        o.scalar_quadratic = modify_function(o.scalar_quadratic, change)
+    else
+        @assert o.scalar_affine !== nothing
+        o.is_function_set = true
+        o.scalar_affine = modify_function(o.scalar_affine, change)
+    end
+    return
+end
+
+###
+### MOI.delete
+###
+
+function MOI.delete(o::ObjectiveFunctionContainer, x::MOI.VariableIndex)
+    if o.single_variable !== nothing
+        sense = o.sense
+        MOI.empty!(o)
+        if o.is_sense_set
+            MOI.set(o, MOI.ObjectiveSense(), sense)
+        end
+    elseif o.scalar_quadratic !== nothing
+        o.scalar_quadratic = remove_variable(o.scalar_quadratic, x)
+    else
+        @assert o.scalar_affine !== nothing
+        o.scalar_affine = remove_variable(o.scalar_affine, x)
+    end
+    return
+end
+
+function MOI.delete(o::ObjectiveFunctionContainer, x::Vector{MOI.VariableIndex})
+    keep = v -> !(v in x)
+    if o.single_variable !== nothing && o.single_variable.variable in x
+        sense = o.sense
+        MOI.empty!(o)
+        if o.is_sense_set
+            MOI.set(o, MOI.ObjectiveSense(), sense)
+        end
+    elseif o.scalar_quadratic !== nothing
+        o.scalar_quadratic = filter_variables(keep, o.scalar_quadratic)
+    else
+        @assert o.scalar_affine !== nothing
+        o.scalar_affine = filter_variables(keep, o.scalar_affine)
+    end
+    return
+end

--- a/src/Utilities/objective_function_container.jl
+++ b/src/Utilities/objective_function_container.jl
@@ -4,7 +4,7 @@
 A helper struct to simplify the handling of objective functions in
 Utilities.Model.
 """
-mutable struct ObjectiveFunctionContainer{T}
+mutable struct ObjectiveFunctionContainer{T} <: MOI.ModelLike
     is_sense_set::Bool
     sense::MOI.OptimizationSense
     is_function_set::Bool

--- a/src/Utilities/objective_function_container.jl
+++ b/src/Utilities/objective_function_container.jl
@@ -176,10 +176,12 @@ end
 
 function MOI.delete(o::ObjectiveFunctionContainer, x::MOI.VariableIndex)
     if o.single_variable !== nothing
-        sense = o.sense
-        MOI.empty!(o)
-        if o.is_sense_set
-            MOI.set(o, MOI.ObjectiveSense(), sense)
+        if x == o.single_variable.variable
+            sense = o.sense
+            MOI.empty!(o)
+            if o.is_sense_set
+                MOI.set(o, MOI.ObjectiveSense(), sense)
+            end
         end
     elseif o.scalar_quadratic !== nothing
         o.scalar_quadratic = remove_variable(o.scalar_quadratic, x)

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -175,6 +175,9 @@ end
 # Nothing to do as it's not `VectorOfVariables` constraints
 _throw_if_cannot_delete(::VectorOfConstraints, vis, fast_in_vis) = nothing
 
+_fast_in(vi1::MOI.VariableIndex, vi2::MOI.VariableIndex) = vi1 == vi2
+_fast_in(vi::MOI.VariableIndex, vis::Set{MOI.VariableIndex}) = vi in vis
+
 function _throw_if_cannot_delete(
     v::VectorOfConstraints{MOI.VectorOfVariables,S},
     vis,

--- a/test/Utilities/objective_function_container.jl
+++ b/test/Utilities/objective_function_container.jl
@@ -80,7 +80,7 @@ function test_delete_ScalarAffineFunction()
     MOI.set(o, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.delete(o, x)
     @test MOI.get(o, MOI.ObjectiveFunctionType()) == typeof(f)
-    @test_broken !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
+    @test !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
     return
 end
 
@@ -91,7 +91,7 @@ function test_delete_ScalarQuadraticFunction()
     MOI.set(o, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.delete(o, x)
     @test MOI.get(o, MOI.ObjectiveFunctionType()) == typeof(f)
-    @test_broken !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
+    @test !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
     return
 end
 
@@ -112,7 +112,7 @@ function test_delete_ScalarAffineFunction_plural()
     MOI.set(o, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.delete(o, [x])
     @test MOI.get(o, MOI.ObjectiveFunctionType()) == typeof(f)
-    @test_broken !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
+    @test !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
     return
 end
 
@@ -123,7 +123,7 @@ function test_delete_ScalarQuadraticFunction_plural()
     MOI.set(o, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.delete(o, [x])
     @test MOI.get(o, MOI.ObjectiveFunctionType()) == typeof(f)
-    @test_broken !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
+    @test !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
     return
 end
 

--- a/test/Utilities/objective_function_container.jl
+++ b/test/Utilities/objective_function_container.jl
@@ -1,0 +1,132 @@
+module TestObjectiveFunctionContainer
+
+using Test
+
+import MathOptInterface
+
+const MOI = MathOptInterface
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function test_ObjectiveSense()
+    o = MOI.Utilities.ObjectiveFunctionContainer{Float16}()
+    @test MOI.get(o, MOI.ListOfModelAttributesSet()) == []
+    @test MOI.supports(o, MOI.ObjectiveSense())
+    for val in (MOI.MIN_SENSE, MOI.MAX_SENSE, MOI.FEASIBILITY_SENSE)
+        MOI.set(o, MOI.ObjectiveSense(), val)
+        @test MOI.get(o, MOI.ObjectiveSense()) == val
+    end
+    return
+end
+
+function test_FEASIBILITY_SENSE_clears_objective()
+    o = MOI.Utilities.ObjectiveFunctionContainer{Float16}()
+    x = MOI.VariableIndex(1234)
+    f = MOI.SingleVariable(x)
+    MOI.set(o, MOI.ObjectiveFunction{MOI.SingleVariable}(), f)
+    @test MOI.get(o, MOI.ObjectiveFunction{MOI.SingleVariable}()) ≈ f
+    MOI.set(o, MOI.ObjectiveSense(), MOI.FEASIBILITY_SENSE)
+    @test !MOI.is_empty(o)
+    @test o.is_function_set == false
+    return
+end
+
+function _test_basic_objective(F, T)
+    o = MOI.Utilities.ObjectiveFunctionContainer{T}()
+    @test MOI.is_empty(o)
+    @test MOI.supports(o, MOI.ObjectiveFunction{F}())
+    x = MOI.VariableIndex(1234)
+    f = convert(F, MOI.SingleVariable(x))
+    MOI.set(o, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(o, MOI.ObjectiveFunctionType()) == F
+    @test !MOI.is_empty(o)
+    @test MOI.get(o, MOI.ListOfModelAttributesSet()) ==
+          Any[MOI.ObjectiveFunction{F}()]
+    MOI.empty!(o)
+    @test MOI.is_empty(o)
+    return
+end
+
+function test_basic_objective()
+    _test_basic_objective(MOI.SingleVariable, Float32)
+    _test_basic_objective(MOI.ScalarAffineFunction{Float32}, Float32)
+    _test_basic_objective(MOI.ScalarQuadraticFunction{Float32}, Float32)
+    return
+end
+
+function test_delete_SingleVariable()
+    o = MOI.Utilities.ObjectiveFunctionContainer{Float16}()
+    x = MOI.VariableIndex(1234)
+    f = MOI.SingleVariable(x)
+    MOI.set(o, MOI.ObjectiveFunction{MOI.SingleVariable}(), f)
+    MOI.delete(o, x)
+    @test MOI.is_empty(o)
+    return
+end
+
+function test_delete_ScalarAffineFunction()
+    o = MOI.Utilities.ObjectiveFunctionContainer{Float16}()
+    x = MOI.VariableIndex(1234)
+    f = convert(MOI.ScalarAffineFunction{Float16}, MOI.SingleVariable(x))
+    MOI.set(o, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.delete(o, x)
+    @test MOI.get(o, MOI.ObjectiveFunctionType()) == typeof(f)
+    @test_broken !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
+    return
+end
+
+function test_delete_ScalarQuadraticFunction()
+    o = MOI.Utilities.ObjectiveFunctionContainer{Float16}()
+    x = MOI.VariableIndex(1234)
+    f = convert(MOI.ScalarQuadraticFunction{Float16}, MOI.SingleVariable(x))
+    MOI.set(o, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.delete(o, x)
+    @test MOI.get(o, MOI.ObjectiveFunctionType()) == typeof(f)
+    @test_broken !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
+    return
+end
+
+function test_delete_SingleVariable_plural()
+    o = MOI.Utilities.ObjectiveFunctionContainer{Float16}()
+    x = MOI.VariableIndex(1234)
+    f = MOI.SingleVariable(x)
+    MOI.set(o, MOI.ObjectiveFunction{MOI.SingleVariable}(), f)
+    MOI.delete(o, [x])
+    @test MOI.is_empty(o)
+    return
+end
+
+function test_delete_ScalarAffineFunction_plural()
+    o = MOI.Utilities.ObjectiveFunctionContainer{Float16}()
+    x = MOI.VariableIndex(1234)
+    f = convert(MOI.ScalarAffineFunction{Float16}, MOI.SingleVariable(x))
+    MOI.set(o, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.delete(o, [x])
+    @test MOI.get(o, MOI.ObjectiveFunctionType()) == typeof(f)
+    @test_broken !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
+    return
+end
+
+function test_delete_ScalarQuadraticFunction_plural()
+    o = MOI.Utilities.ObjectiveFunctionContainer{Float16}()
+    x = MOI.VariableIndex(1234)
+    f = convert(MOI.ScalarQuadraticFunction{Float16}, MOI.SingleVariable(x))
+    MOI.set(o, MOI.ObjectiveFunction{typeof(f)}(), f)
+    MOI.delete(o, [x])
+    @test MOI.get(o, MOI.ObjectiveFunctionType()) == typeof(f)
+    @test_broken !(MOI.get(o, MOI.ObjectiveFunction{typeof(f)}()) ≈ f)
+    return
+end
+
+end  # module
+
+TestObjectiveFunctionContainer.runtests()


### PR DESCRIPTION
This simplifies the `Utilities.Model` quite a bit.

Currently needs test_broken due to the isapprox issue #1484