### PR TITLE
Ask codecov to ignore DeprecatedTest module

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,3 @@
 comment: false
+ignore:
+  - 'src/DeprecatedTest'


### PR DESCRIPTION
Since this is now deprecated, it makes sense to remove it from codecov to stop distracting failures like https://github.com/jump-dev/MathOptInterface.jl/pull/1486#issuecomment-885390001