### PR TITLE
[breaking] remove isapprox for SOS sets

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -979,9 +979,6 @@ struct SOS2{T<:Real} <: AbstractVectorSet
 end
 
 Base.:(==)(a::T, b::T) where {T<:Union{SOS1,SOS2}} = a.weights == b.weights
-function Base.isapprox(a::T, b::T; kwargs...) where {T<:Union{SOS1,SOS2}}
-    return isapprox(a.weights, b.weights; kwargs...)
-end
 
 dimension(s::Union{SOS1,SOS2}) = length(s.weights)
 


### PR DESCRIPTION
This was added in https://github.com/jump-dev/MathOptInterface.jl/pull/711 because quote

> [it] was defined in Test for no apparent reason

Seems like we can safely remove. It isn't hit by code coverage, and we don't offer `isapprox` for other sets.