### PR TITLE
[breaking] s/DataType/Type

### DIFF
--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -32,8 +32,8 @@ VectorQuadraticFunction
 output_dimension
 constant(f::Union{ScalarAffineFunction, ScalarQuadraticFunction})
 constant(f::Union{VectorAffineFunction, VectorQuadraticFunction})
-constant(f::SingleVariable, ::DataType)
-constant(f::VectorOfVariables, T::DataType)
+constant(f::SingleVariable, ::Type)
+constant(f::VectorOfVariables, T::Type)
 ```
 
 ## Sets

--- a/docs/src/submodules/Bridges/overview.md
+++ b/docs/src/submodules/Bridges/overview.md
@@ -136,11 +136,11 @@ julia> MOI.add_constraint(optimizer, MOI.SingleVariable(x), MOI.Interval(0.0, 1.
 MathOptInterface.ConstraintIndex{MathOptInterface.SingleVariable,MathOptInterface.Interval{Float64}}(1)
 
 julia> MOI.get(optimizer, MOI.ListOfConstraintTypesPresent())
-1-element Array{Tuple{DataType,DataType},1}:
+1-element Array{Tuple{Type,Type},1}:
  (MathOptInterface.SingleVariable, MathOptInterface.Interval{Float64})
 
 julia> MOI.get(inner_optimizer, MOI.ListOfConstraintTypesPresent())
-2-element Array{Tuple{DataType,DataType},1}:
+2-element Array{Tuple{Type,Type},1}:
  (MathOptInterface.SingleVariable, MathOptInterface.GreaterThan{Float64})
  (MathOptInterface.SingleVariable, MathOptInterface.LessThan{Float64})
 ```
@@ -180,10 +180,10 @@ julia> MOI.add_constraint(optimizer, MOI.SingleVariable(x), MOI.Interval(0.0, 1.
 MathOptInterface.ConstraintIndex{MathOptInterface.SingleVariable,MathOptInterface.Interval{Float64}}(1)
 
 julia> MOI.get(optimizer, MOI.ListOfConstraintTypesPresent())
-1-element Array{Tuple{DataType,DataType},1}:
+1-element Array{Tuple{Type,Type},1}:
  (MathOptInterface.SingleVariable, MathOptInterface.Interval{Float64})
 
 julia> MOI.get(inner_optimizer, MOI.ListOfConstraintTypesPresent())
-1-element Array{Tuple{DataType,DataType},1}:
+1-element Array{Tuple{Type,Type},1}:
  (MathOptInterface.SingleVariable, MathOptInterface.Interval{Float64})
 ```

--- a/src/Bridges/Constraint/bridge.jl
+++ b/src/Bridges/Constraint/bridge.jl
@@ -99,7 +99,7 @@ end
         BT::Type{<:AbstractBridge},
         F::Type{<:MOI.AbstractFunction},
         S::Type{<:MOI.AbstractSet}
-    )::DataType
+    )::Type
 
 Return the concrete type of the bridge supporting `F`-in-`S` constraints. This
 function can only be called if `MOI.supports_constraint(BT, F, S)` is `true`.
@@ -126,7 +126,7 @@ MathOptInterface.Bridges.Constraint.SplitIntervalBridge{Float64,MathOptInterface
 ```
 """
 function concrete_bridge_type(
-    bridge_type::DataType,
+    bridge_type::Type,
     ::Type{<:MOI.AbstractFunction},
     ::Type{<:MOI.AbstractSet},
 )

--- a/src/Bridges/Constraint/det.jl
+++ b/src/Bridges/Constraint/det.jl
@@ -150,7 +150,7 @@ function MOIB.added_constrained_variable_types(::Type{<:LogDetBridge})
 end
 
 function MOIB.added_constraint_types(::Type{LogDetBridge{T}}) where {T}
-    return [
+    return Tuple{Type,Type}[
         (MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle),
         (MOI.VectorAffineFunction{T}, MOI.ExponentialCone),
         (MOI.ScalarAffineFunction{T}, MOI.LessThan{T}),
@@ -400,7 +400,7 @@ function MOIB.added_constrained_variable_types(::Type{<:RootDetBridge})
 end
 
 function MOIB.added_constraint_types(::Type{RootDetBridge{T}}) where {T}
-    return [
+    return Tuple{Type,Type}[
         (MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeTriangle),
         (MOI.VectorAffineFunction{T}, MOI.GeometricMeanCone),
     ]

--- a/src/Bridges/Constraint/det.jl
+++ b/src/Bridges/Constraint/det.jl
@@ -146,7 +146,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:LogDetBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(::Type{LogDetBridge{T}}) where {T}
@@ -396,7 +396,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:RootDetBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(::Type{RootDetBridge{T}}) where {T}

--- a/src/Bridges/Constraint/functionize.jl
+++ b/src/Bridges/Constraint/functionize.jl
@@ -33,7 +33,7 @@ end
 function MOIB.added_constrained_variable_types(
     ::Type{<:ScalarFunctionizeBridge},
 )
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(
@@ -130,7 +130,7 @@ end
 function MOIB.added_constrained_variable_types(
     ::Type{<:VectorFunctionizeBridge},
 )
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(

--- a/src/Bridges/Constraint/functionize.jl
+++ b/src/Bridges/Constraint/functionize.jl
@@ -39,7 +39,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{ScalarFunctionizeBridge{T,S}},
 ) where {T,S}
-    return [(MOI.ScalarAffineFunction{T}, S)]
+    return Tuple{Type,Type}[(MOI.ScalarAffineFunction{T}, S)]
 end
 
 function concrete_bridge_type(
@@ -136,7 +136,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{VectorFunctionizeBridge{T,S}},
 ) where {T,S}
-    return [(MOI.VectorAffineFunction{T}, S)]
+    return Tuple{Type,Type}[(MOI.VectorAffineFunction{T}, S)]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/geomean.jl
+++ b/src/Bridges/Constraint/geomean.jl
@@ -144,7 +144,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{<:GeoMeanBridge{T,F,G}},
 ) where {T,F,G}
-    return [
+    return Tuple{Type,Type}[
         (F, MOI.LessThan{T}),
         (G, MOI.RotatedSecondOrderCone),
         (G, MOI.Nonnegatives),

--- a/src/Bridges/Constraint/geomean.jl
+++ b/src/Bridges/Constraint/geomean.jl
@@ -138,7 +138,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:GeoMeanBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(

--- a/src/Bridges/Constraint/geomean_to_relentr.jl
+++ b/src/Bridges/Constraint/geomean_to_relentr.jl
@@ -59,13 +59,13 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:GeoMeantoRelEntrBridge})
-    return [(MOI.Nonnegatives,)]
+    return Tuple{Type}[(MOI.Nonnegatives,)]
 end
 
 function MOIB.added_constraint_types(
     ::Type{<:GeoMeantoRelEntrBridge{T,F,G}},
 ) where {T,F,G}
-    return [(G, MOI.RelativeEntropyCone)]
+    return Tuple{Type,Type}[(G, MOI.RelativeEntropyCone)]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/indicator_activate_on_zero.jl
+++ b/src/Bridges/Constraint/indicator_activate_on_zero.jl
@@ -61,13 +61,13 @@ end
 function MOIB.added_constrained_variable_types(
     ::Type{<:IndicatorActiveOnFalseBridge},
 )
-    return [(MOI.ZeroOne,)]
+    return Tuple{Type}[(MOI.ZeroOne,)]
 end
 
 function MOIB.added_constraint_types(
     ::Type{IndicatorActiveOnFalseBridge{T,F,S}},
 ) where {T,F,S}
-    return [
+    return Tuple{Type,Type}[
         (MOI.ScalarAffineFunction{T}, MOI.EqualTo{T}),
         (F, MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE,S}),
     ]

--- a/src/Bridges/Constraint/indicator_sos.jl
+++ b/src/Bridges/Constraint/indicator_sos.jl
@@ -109,19 +109,19 @@ end
 function MOIB.added_constrained_variable_types(
     ::Type{<:IndicatorSOS1Bridge{T,BC}},
 ) where {T,BC<:Union{MOI.LessThan{T},MOI.GreaterThan{T}}}
-    return [(BC,)]
+    return Tuple{Type}[(BC,)]
 end
 
 function MOIB.added_constrained_variable_types(
     ::Type{<:IndicatorSOS1Bridge{T,BC}},
 ) where {T,BC}
-    return []
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(
     ::Type{<:IndicatorSOS1Bridge{T,BC}},
 ) where {T,BC<:Union{MOI.LessThan{T},MOI.GreaterThan{T}}}
-    return [
+    return Tuple{Type,Type}[
         (MOI.VectorOfVariables, MOI.SOS1{T}),
         (MOI.ScalarAffineFunction{T}, BC),
     ]
@@ -130,7 +130,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{<:IndicatorSOS1Bridge{T,S}},
 ) where {T,S<:MOI.AbstractScalarSet}
-    return [
+    return Tuple{Type,Type}[
         (MOI.VectorOfVariables, MOI.SOS1{T}),
         (MOI.ScalarAffineFunction{T}, S),
     ]

--- a/src/Bridges/Constraint/interval.jl
+++ b/src/Bridges/Constraint/interval.jl
@@ -63,7 +63,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{SplitIntervalBridge{T,F,S,LS,US}},
 ) where {T,F,S,LS,US}
-    return [(F, LS), (F, US)]
+    return Tuple{Type,Type}[(F, LS), (F, US)]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/interval.jl
+++ b/src/Bridges/Constraint/interval.jl
@@ -57,7 +57,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:SplitIntervalBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(

--- a/src/Bridges/Constraint/map.jl
+++ b/src/Bridges/Constraint/map.jl
@@ -8,22 +8,19 @@ struct Map <: AbstractDict{MOI.ConstraintIndex,AbstractBridge}
     # It is set to `nothing` when the constraint is deleted.
     bridges::Vector{Union{Nothing,AbstractBridge}}
     # Constraint Index of bridged constraint -> Constraint type.
-    constraint_types::Vector{Tuple{DataType,DataType}}
+    constraint_types::Vector{Tuple{Type,Type}}
     # The order of the keys is used in `keys_of_type` which is used by
     # `ListOfConstraintIndices`. Therefore they need to be in the order
     # of creation so we need `OrderedDict` and not `Dict`.
     # For `SingleVariable` constraints: (variable, set type) -> bridge
-    single_variable_constraints::OrderedDict{
-        Tuple{Int64,DataType},
-        AbstractBridge,
-    }
+    single_variable_constraints::OrderedDict{Tuple{Int64,Type},AbstractBridge}
 end
 
 function Map()
     return Map(
         Union{Nothing,AbstractBridge}[],
-        Tuple{DataType,DataType}[],
-        OrderedDict{Tuple{Int64,DataType},AbstractBridge}(),
+        Tuple{Type,Type}[],
+        OrderedDict{Tuple{Int64,Type},AbstractBridge}(),
     )
 end
 
@@ -194,7 +191,7 @@ end
 Return a list of all the different concrete type of keys in `map`.
 """
 function list_of_key_types(map::Map)
-    list = Set{Tuple{DataType,DataType}}()
+    list = Set{Tuple{Type,Type}}()
     for i in eachindex(map.bridges)
         if map.bridges[i] !== nothing
             push!(list, map.constraint_types[i])

--- a/src/Bridges/Constraint/norm_spec_nuc_to_psd.jl
+++ b/src/Bridges/Constraint/norm_spec_nuc_to_psd.jl
@@ -56,7 +56,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{NormSpectralBridge{T,F,G}},
 ) where {T,F,G}
-    return [(F, MOI.PositiveSemidefiniteConeTriangle)]
+    return Tuple{Type,Type}[(F, MOI.PositiveSemidefiniteConeTriangle)]
 end
 
 function concrete_bridge_type(
@@ -259,7 +259,10 @@ end
 function MOIB.added_constraint_types(
     ::Type{NormNuclearBridge{T,F,G,H}},
 ) where {T,F,G,H}
-    return [(F, MOI.GreaterThan{T}), (G, MOI.PositiveSemidefiniteConeTriangle)]
+    return Tuple{Type,Type}[
+        (F, MOI.GreaterThan{T}),
+        (G, MOI.PositiveSemidefiniteConeTriangle),
+    ]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/norm_spec_nuc_to_psd.jl
+++ b/src/Bridges/Constraint/norm_spec_nuc_to_psd.jl
@@ -50,7 +50,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:NormSpectralBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(
@@ -253,7 +253,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:NormNuclearBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(

--- a/src/Bridges/Constraint/norm_to_lp.jl
+++ b/src/Bridges/Constraint/norm_to_lp.jl
@@ -131,7 +131,7 @@ function MOIB.added_constrained_variable_types(::Type{<:NormOneBridge})
 end
 
 function MOIB.added_constraint_types(::Type{<:NormOneBridge{T,F}}) where {T,F}
-    return [(F, MOI.Nonnegatives)]
+    return Tuple{Type,Type}[(F, MOI.Nonnegatives)]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/norm_to_lp.jl
+++ b/src/Bridges/Constraint/norm_to_lp.jl
@@ -127,7 +127,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:NormOneBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(::Type{<:NormOneBridge{T,F}}) where {T,F}

--- a/src/Bridges/Constraint/quad_to_soc.jl
+++ b/src/Bridges/Constraint/quad_to_soc.jl
@@ -168,7 +168,10 @@ function MOIB.added_constrained_variable_types(::Type{<:QuadtoSOCBridge})
 end
 
 function MOIB.added_constraint_types(::Type{QuadtoSOCBridge{T}}) where {T}
-    return [(MOI.VectorAffineFunction{T}, MOI.RotatedSecondOrderCone)]
+    return Tuple{Type,Type}[(
+        MOI.VectorAffineFunction{T},
+        MOI.RotatedSecondOrderCone,
+    ),]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/quad_to_soc.jl
+++ b/src/Bridges/Constraint/quad_to_soc.jl
@@ -164,7 +164,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:QuadtoSOCBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(::Type{QuadtoSOCBridge{T}}) where {T}

--- a/src/Bridges/Constraint/relentr_to_exp.jl
+++ b/src/Bridges/Constraint/relentr_to_exp.jl
@@ -62,7 +62,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{RelativeEntropyBridge{T,F,G,H}},
 ) where {T,F,G,H}
-    return [(F, MOI.GreaterThan{T}), (G, MOI.ExponentialCone)]
+    return Tuple{Type,Type}[(F, MOI.GreaterThan{T}), (G, MOI.ExponentialCone)]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/relentr_to_exp.jl
+++ b/src/Bridges/Constraint/relentr_to_exp.jl
@@ -56,7 +56,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:RelativeEntropyBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(

--- a/src/Bridges/Constraint/scalarize.jl
+++ b/src/Bridges/Constraint/scalarize.jl
@@ -43,7 +43,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{ScalarizeBridge{T,F,S}},
 ) where {T,F,S}
-    return [(F, S)]
+    return Tuple{Type,Type}[(F, S)]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/scalarize.jl
+++ b/src/Bridges/Constraint/scalarize.jl
@@ -37,7 +37,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:ScalarizeBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(

--- a/src/Bridges/Constraint/semi_to_binary.jl
+++ b/src/Bridges/Constraint/semi_to_binary.jl
@@ -75,13 +75,13 @@ end
 function MOIB.added_constrained_variable_types(
     ::Type{<:SemiToBinaryBridge{T,S}},
 ) where {T,S}
-    return [(MOI.ZeroOne,)]
+    return Tuple{Type}[(MOI.ZeroOne,)]
 end
 
 function MOIB.added_constraint_types(
     ::Type{<:SemiToBinaryBridge{T,S}},
 ) where {T,S<:MOI.Semicontinuous{T}}
-    return [
+    return Tuple{Type,Type}[
         (MOI.ScalarAffineFunction{T}, MOI.LessThan{T}),
         (MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T}),
     ]
@@ -90,7 +90,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{<:SemiToBinaryBridge{T,S}},
 ) where {T,S<:MOI.Semiinteger{T}}
-    return [
+    return Tuple{Type,Type}[
         (MOI.ScalarAffineFunction{T}, MOI.LessThan{T}),
         (MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T}),
         (MOI.SingleVariable, MOI.Integer),

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -51,7 +51,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:SetMapBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -57,7 +57,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{<:SetMapBridge{T,S2,S1,F}},
 ) where {T,S2,S1,F}
-    return [(F, S2)]
+    return Tuple{Type,Type}[(F, S2)]
 end
 
 # Attributes, Bridge acting as a model

--- a/src/Bridges/Constraint/slack.jl
+++ b/src/Bridges/Constraint/slack.jl
@@ -3,13 +3,13 @@ abstract type AbstractSlackBridge{T,VF,ZS,F,S} <: AbstractBridge end
 function MOIB.added_constrained_variable_types(
     ::Type{<:AbstractSlackBridge{T,VF,ZS,F,S}},
 ) where {T,VF,ZS,F,S}
-    return [(S,)]
+    return Tuple{Type}[(S,)]
 end
 
 function MOIB.added_constraint_types(
     ::Type{<:AbstractSlackBridge{T,VF,ZS,F}},
 ) where {T,VF,ZS,F}
-    return [(F, ZS)]
+    return Tuple{Type,Type}[(F, ZS)]
 end
 
 function MOI.get(

--- a/src/Bridges/Constraint/soc_to_nonconvex_quad.jl
+++ b/src/Bridges/Constraint/soc_to_nonconvex_quad.jl
@@ -140,7 +140,7 @@ end
 function MOIB.added_constrained_variable_types(
     ::Type{<:AbstractSOCtoNonConvexQuadBridge},
 )
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(

--- a/src/Bridges/Constraint/soc_to_nonconvex_quad.jl
+++ b/src/Bridges/Constraint/soc_to_nonconvex_quad.jl
@@ -146,7 +146,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{<:AbstractSOCtoNonConvexQuadBridge{T}},
 ) where {T}
-    return [
+    return Tuple{Type,Type}[
         (MOI.ScalarQuadraticFunction{T}, MOI.LessThan{T}),
         (MOI.ScalarAffineFunction{T}, MOI.GreaterThan{T}),
     ]

--- a/src/Bridges/Constraint/square.jl
+++ b/src/Bridges/Constraint/square.jl
@@ -149,7 +149,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{SquareBridge{T,F,G,TT,ST}},
 ) where {T,F,G,TT,ST}
-    return [(F, TT), (G, MOI.EqualTo{T})]
+    return Tuple{Type,Type}[(F, TT), (G, MOI.EqualTo{T})]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/square.jl
+++ b/src/Bridges/Constraint/square.jl
@@ -143,7 +143,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:SquareBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(

--- a/src/Bridges/Constraint/vectorize.jl
+++ b/src/Bridges/Constraint/vectorize.jl
@@ -56,7 +56,7 @@ end
 function MOIB.added_constraint_types(
     ::Type{<:VectorizeBridge{T,F,S}},
 ) where {T,F,S}
-    return [(F, S)]
+    return Tuple{Type,Type}[(F, S)]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/vectorize.jl
+++ b/src/Bridges/Constraint/vectorize.jl
@@ -50,7 +50,7 @@ function MOI.supports_constraint(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:VectorizeBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(

--- a/src/Bridges/Constraint/zero_one.jl
+++ b/src/Bridges/Constraint/zero_one.jl
@@ -23,7 +23,7 @@ function bridge_constraint(
 end
 
 function MOIB.added_constraint_types(::Type{<:ZeroOneBridge{T}}) where {T}
-    return [
+    return Tuple{Type,Type}[
         (MOI.SingleVariable, MOI.Interval{T}),
         (MOI.SingleVariable, MOI.Integer),
     ]

--- a/src/Bridges/Constraint/zero_one.jl
+++ b/src/Bridges/Constraint/zero_one.jl
@@ -30,7 +30,7 @@ function MOIB.added_constraint_types(::Type{<:ZeroOneBridge{T}}) where {T}
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:ZeroOneBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Objective/bridge.jl
+++ b/src/Bridges/Objective/bridge.jl
@@ -170,14 +170,14 @@ end
     concrete_bridge_type(
         BT::Type{<:MOI.Bridges.Objective.AbstractBridge},
         F::Type{<:MOI.AbstractScalarFunction},
-    )::DataType
+    )::Type
 
 Return the concrete type of the bridge supporting objective functions of type
 `F`. This function can only be called if `MOI.supports_objective_function(BT, F)`
 is `true`.
 """
 function concrete_bridge_type(
-    bridge_type::DataType,
+    bridge_type::Type,
     ::Type{<:MOI.AbstractScalarFunction},
 )
     return bridge_type

--- a/src/Bridges/Objective/functionize.jl
+++ b/src/Bridges/Objective/functionize.jl
@@ -24,11 +24,11 @@ function supports_objective_function(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:FunctionizeBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(::Type{<:FunctionizeBridge})
-    return Tuple{DataType,DataType}[]
+    return Tuple{Type,Type}[]
 end
 
 function MOIB.set_objective_function_type(

--- a/src/Bridges/Objective/slack.jl
+++ b/src/Bridges/Objective/slack.jl
@@ -62,7 +62,7 @@ end
 MOIB.added_constrained_variable_types(::Type{<:SlackBridge}) = Tuple{Type}[]
 
 function MOIB.added_constraint_types(::Type{<:SlackBridge{T,F}}) where {T,F}
-    return [(F, MOI.GreaterThan{T}), (F, MOI.LessThan{T})]
+    return Tuple{Type,Type}[(F, MOI.GreaterThan{T}), (F, MOI.LessThan{T})]
 end
 
 function MOIB.set_objective_function_type(::Type{<:SlackBridge})

--- a/src/Bridges/Objective/slack.jl
+++ b/src/Bridges/Objective/slack.jl
@@ -59,7 +59,7 @@ function supports_objective_function(
     return true
 end
 
-MOIB.added_constrained_variable_types(::Type{<:SlackBridge}) = Tuple{DataType}[]
+MOIB.added_constrained_variable_types(::Type{<:SlackBridge}) = Tuple{Type}[]
 
 function MOIB.added_constraint_types(::Type{<:SlackBridge{T,F}}) where {T,F}
     return [(F, MOI.GreaterThan{T}), (F, MOI.LessThan{T})]

--- a/src/Bridges/Variable/bridge.jl
+++ b/src/Bridges/Variable/bridge.jl
@@ -150,7 +150,7 @@ MOI.Bridges.added_constrained_variable_types(
 
 # output
 
-1-element Array{Tuple{DataType},1}:
+1-element Array{Tuple{Type},1}:
  (MathOptInterface.Nonnegatives,)
 ```
 """
@@ -189,7 +189,7 @@ MOI.Bridges.added_constraint_types(
 
 # output
 
-2-element Array{Tuple{DataType,DataType},1}:
+2-element Array{Tuple{Type,Type},1}:
  (MathOptInterface.SingleVariable, MathOptInterface.EqualTo{Float64})
  (MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.EqualTo{Float64})
 ```
@@ -205,7 +205,7 @@ end
     concrete_bridge_type(
         BT::Type{<:AbstractBridge},
         S::Type{<:MOI.AbstractSet},
-    )::DataType
+    )::Type
 
 Return the concrete type of the bridge supporting variables in `S` constraints.
 This function can only be called if `MOI.supports_constrained_variable(BT, S)`
@@ -228,7 +228,7 @@ MOI.Bridges.Variable.concrete_bridge_type(
 MathOptInterface.Bridges.Variable.VectorizeBridge{Float64,MathOptInterface.Nonnegatives}
 ```
 """
-function concrete_bridge_type(bridge_type::DataType, ::Type{<:MOI.AbstractSet})
+function concrete_bridge_type(bridge_type::Type, ::Type{<:MOI.AbstractSet})
     return bridge_type
 end
 

--- a/src/Bridges/Variable/free.jl
+++ b/src/Bridges/Variable/free.jl
@@ -30,7 +30,7 @@ function MOIB.added_constrained_variable_types(::Type{<:FreeBridge})
 end
 
 function MOIB.added_constraint_types(::Type{FreeBridge{T}}) where {T}
-    return Tuple{DataType,DataType}[]
+    return Tuple{Type,Type}[]
 end
 
 # Attributes, Bridge acting as a model

--- a/src/Bridges/Variable/free.jl
+++ b/src/Bridges/Variable/free.jl
@@ -26,7 +26,7 @@ function supports_constrained_variable(::Type{<:FreeBridge}, ::Type{MOI.Reals})
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:FreeBridge})
-    return [(MOI.Nonnegatives,)]
+    return Tuple{Type}[(MOI.Nonnegatives,)]
 end
 
 function MOIB.added_constraint_types(::Type{FreeBridge{T}}) where {T}

--- a/src/Bridges/Variable/map.jl
+++ b/src/Bridges/Variable/map.jl
@@ -18,7 +18,7 @@ mutable struct Map <: AbstractDict{MOI.VariableIndex,AbstractBridge}
     index_in_vector::Vector{Int64}
     # `i` -> `bridge`: `VariableIndex(-i)` was bridged by `bridge`.
     bridges::Vector{Union{Nothing,AbstractBridge}}
-    sets::Vector{Union{Nothing,DataType}}
+    sets::Vector{Union{Nothing,Type}}
     # If `nothing`, it cannot be computed because some bridges does not support it
     unbridged_function::Union{
         Nothing,
@@ -37,7 +37,7 @@ function Map()
         Int64[],
         Int64[],
         Union{Nothing,AbstractBridge}[],
-        Union{Nothing,DataType}[],
+        Union{Nothing,Type}[],
         Dict{MOI.VariableIndex,MOI.AbstractScalarFunction}(),
         Int64[],
         0,
@@ -219,7 +219,7 @@ Return a list of all the different types `(F, S)` of `F`-in-`S` constraints in
 `map`.
 """
 function list_of_constraint_types(map::Map)
-    list = Set{Tuple{DataType,DataType}}()
+    list = Set{Tuple{Type,Type}}()
     for i in eachindex(map.bridges)
         if map.bridges[i] !== nothing
             S = map.sets[i]

--- a/src/Bridges/Variable/rsoc_to_psd.jl
+++ b/src/Bridges/Variable/rsoc_to_psd.jl
@@ -75,7 +75,7 @@ function supports_constrained_variable(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:RSOCtoPSDBridge})
-    return Tuple{Type,Type}[
+    return Tuple{Type}[
         (MOI.PositiveSemidefiniteConeTriangle,),
         (MOI.Nonnegatives,),
     ]

--- a/src/Bridges/Variable/rsoc_to_psd.jl
+++ b/src/Bridges/Variable/rsoc_to_psd.jl
@@ -75,11 +75,14 @@ function supports_constrained_variable(
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:RSOCtoPSDBridge})
-    return [(MOI.PositiveSemidefiniteConeTriangle,), (MOI.Nonnegatives,)]
+    return Tuple{Type,Type}[
+        (MOI.PositiveSemidefiniteConeTriangle,),
+        (MOI.Nonnegatives,),
+    ]
 end
 
 function MOIB.added_constraint_types(::Type{RSOCtoPSDBridge{T}}) where {T}
-    return [
+    return Tuple{Type,Type}[
         (MOI.SingleVariable, MOI.EqualTo{T}),
         (MOI.ScalarAffineFunction{T}, MOI.EqualTo{T}),
     ]

--- a/src/Bridges/Variable/set_map.jl
+++ b/src/Bridges/Variable/set_map.jl
@@ -43,7 +43,7 @@ end
 function MOIB.added_constrained_variable_types(
     ::Type{<:SetMapBridge{T,S1}},
 ) where {T,S1}
-    return [(S1,)]
+    return Tuple{Type}[(S1,)]
 end
 
 function MOIB.added_constraint_types(::Type{<:SetMapBridge})

--- a/src/Bridges/Variable/set_map.jl
+++ b/src/Bridges/Variable/set_map.jl
@@ -47,7 +47,7 @@ function MOIB.added_constrained_variable_types(
 end
 
 function MOIB.added_constraint_types(::Type{<:SetMapBridge})
-    return Tuple{DataType,DataType}[]
+    return Tuple{Type,Type}[]
 end
 
 # Attributes, Bridge acting as a model

--- a/src/Bridges/Variable/vectorize.jl
+++ b/src/Bridges/Variable/vectorize.jl
@@ -37,7 +37,7 @@ function MOIB.added_constrained_variable_types(
 end
 
 function MOIB.added_constraint_types(::Type{<:VectorizeBridge})
-    return Tuple{DataType,DataType}[]
+    return Tuple{Type,Type}[]
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Variable/vectorize.jl
+++ b/src/Bridges/Variable/vectorize.jl
@@ -33,7 +33,7 @@ end
 function MOIB.added_constrained_variable_types(
     ::Type{VectorizeBridge{T,S}},
 ) where {T,S}
-    return [(S,)]
+    return Tuple{Type}[(S,)]
 end
 
 function MOIB.added_constraint_types(::Type{<:VectorizeBridge})

--- a/src/Bridges/Variable/zeros.jl
+++ b/src/Bridges/Variable/zeros.jl
@@ -32,11 +32,11 @@ function supports_constrained_variable(::Type{<:ZerosBridge}, ::Type{MOI.Zeros})
 end
 
 function MOIB.added_constrained_variable_types(::Type{<:ZerosBridge})
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOIB.added_constraint_types(::Type{<:ZerosBridge})
-    return Tuple{DataType,DataType}[]
+    return Tuple{Type,Type}[]
 end
 
 # Attributes, Bridge acting as a model

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -133,7 +133,7 @@ end
 """
     added_constrained_variable_types(
         BT::Type{<:Variable.AbstractBridge},
-    )::Vector{Tuple{DataType}}
+    )::Vector{Tuple{Type}}
 
 Return a list of the types of constrained variables that bridges of concrete
 type `BT` add. This is used by the [`LazyBridgeOptimizer`](@ref).
@@ -143,7 +143,7 @@ function added_constrained_variable_types end
 """
     added_constraint_types(
         BT::Type{<:Constraint.AbstractBridge},
-    )::Vector{Tuple{DataType, DataType}}
+    )::Vector{Tuple{Type, Type}}
 
 Return a list of the types of constraints that bridges of concrete type `BT`
 add. This is used by the [`LazyBridgeOptimizer`](@ref).

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -37,19 +37,19 @@ mutable struct LazyBridgeOptimizer{OT<:MOI.ModelLike} <: AbstractBridgeOptimizer
     graph::Graph
     # List of types of available bridges
     variable_bridge_types::Vector{Any}
-    variable_node::OrderedDict{Tuple{DataType},VariableNode}
-    variable_types::Vector{Tuple{DataType}}
+    variable_node::OrderedDict{Tuple{Type},VariableNode}
+    variable_types::Vector{Tuple{Type}}
     # List of types of available bridges
     constraint_bridge_types::Vector{Any}
-    constraint_node::OrderedDict{Tuple{DataType,DataType},ConstraintNode}
-    constraint_types::Vector{Tuple{DataType,DataType}}
+    constraint_node::OrderedDict{Tuple{Type,Type},ConstraintNode}
+    constraint_types::Vector{Tuple{Type,Type}}
     # List of types of available bridges
     objective_bridge_types::Vector{Any}
-    objective_node::OrderedDict{Tuple{DataType},ObjectiveNode}
-    objective_types::Vector{Tuple{DataType}}
+    objective_node::OrderedDict{Tuple{Type},ObjectiveNode}
+    objective_types::Vector{Tuple{Type}}
     # Cache for (F, S) -> BridgeType. Avoids having to look up
     # `concrete_bridge_type` at runtime, which is slow.
-    cached_bridge_type::Dict{Any,DataType}
+    cached_bridge_type::Dict{Any,Type}
 end
 
 function LazyBridgeOptimizer(model::MOI.ModelLike)
@@ -64,15 +64,15 @@ function LazyBridgeOptimizer(model::MOI.ModelLike)
         Objective.Map(),
         Graph(),
         Any[],
-        OrderedDict{Tuple{DataType},VariableNode}(),
-        Tuple{DataType}[],
+        OrderedDict{Tuple{Type},VariableNode}(),
+        Tuple{Type}[],
         Any[],
-        OrderedDict{Tuple{DataType,DataType},ConstraintNode}(),
-        Tuple{DataType,DataType}[],
+        OrderedDict{Tuple{Type,Type},ConstraintNode}(),
+        Tuple{Type,Type}[],
         Any[],
-        OrderedDict{Tuple{DataType},ObjectiveNode}(),
-        Tuple{DataType}[],
-        Dict{Any,DataType}(),
+        OrderedDict{Tuple{Type},ObjectiveNode}(),
+        Tuple{Type}[],
+        Dict{Any,Type}(),
     )
 end
 
@@ -416,7 +416,7 @@ end
 function bridge_type(b::LazyBridgeOptimizer, S::Type{<:MOI.AbstractSet})
     bt = get(b.cached_bridge_type, (S,), nothing)
     if bt !== nothing
-        return bt::DataType
+        return bt::Type
     end
     index = bridge_index(b, S)
     if iszero(index)
@@ -424,7 +424,7 @@ function bridge_type(b::LazyBridgeOptimizer, S::Type{<:MOI.AbstractSet})
     end
     new_bt = Variable.concrete_bridge_type(b.variable_bridge_types[index], S)
     b.cached_bridge_type[(S,)] = new_bt
-    return new_bt::DataType
+    return new_bt::Type
 end
 
 function bridge_type(
@@ -434,7 +434,7 @@ function bridge_type(
 )
     bt = get(b.cached_bridge_type, (F, S), nothing)
     if bt !== nothing
-        return bt::DataType
+        return bt::Type
     end
     index = bridge_index(b, F, S)
     if iszero(index)
@@ -443,7 +443,7 @@ function bridge_type(
     new_bt =
         Constraint.concrete_bridge_type(b.constraint_bridge_types[index], F, S)
     b.cached_bridge_type[(F, S)] = new_bt
-    return new_bt::DataType
+    return new_bt::Type
 end
 
 function bridge_type(
@@ -452,7 +452,7 @@ function bridge_type(
 )
     bt = get(b.cached_bridge_type, (F,), nothing)
     if bt !== nothing
-        return bt::DataType
+        return bt::Type
     end
     index = bridge_index(b, F)
     if iszero(index)
@@ -460,7 +460,7 @@ function bridge_type(
     end
     new_bt = Objective.concrete_bridge_type(b.objective_bridge_types[index], F)
     b.cached_bridge_type[(F,)] = new_bt
-    return new_bt::DataType
+    return new_bt::Type
 end
 
 function _func_name(::Type{Constraint.ScalarFunctionizeBridge})

--- a/src/Utilities/DoubleDicts.jl
+++ b/src/Utilities/DoubleDicts.jl
@@ -38,9 +38,9 @@ inner = dict[F, S]
 to return a type-stable [`DoubleDictInner`](@ref).
 """
 struct DoubleDict{V} <: AbstractDoubleDict{V}
-    dict::Dict{Tuple{DataType,DataType},Dict{Int64,V}}
+    dict::Dict{Tuple{Type,Type},Dict{Int64,V}}
     function DoubleDict{V}() where {V}
-        return new{V}(Dict{Tuple{DataType,DataType},Dict{Int64,V}}())
+        return new{V}(Dict{Tuple{Type,Type},Dict{Int64,V}}())
     end
 end
 
@@ -73,9 +73,9 @@ inner = dict[F, S]
 to return a type-stable [`IndexDoubleDictInner`](@ref).
 """
 struct IndexDoubleDict <: AbstractDoubleDict{MOI.ConstraintIndex}
-    dict::Dict{Tuple{DataType,DataType},Dict{Int64,Int64}}
+    dict::Dict{Tuple{Type,Type},Dict{Int64,Int64}}
     function IndexDoubleDict()
-        return new(Dict{Tuple{DataType,DataType},Dict{Int64,Int64}}())
+        return new(Dict{Tuple{Type,Type},Dict{Int64,Int64}}())
     end
 end
 

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -87,7 +87,7 @@ end
 
 const ObjectWithoutIndex = Union{
     Nothing,
-    DataType,
+    Type,
     Number,
     Enum,
     AbstractString,

--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -218,7 +218,7 @@ function set_from_constants end
 ###
 
 """
-    set_types(sets)::Vector{DataType}
+    set_types(sets)::Vector{Type}
 
 Return the list of the types of the sets allowed in `sets`.
 """

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -511,8 +511,8 @@ function MOI.get(
     attr::MOI.ListOfConstraintTypesPresent,
 ) where {T}
     return vcat(
-        MOI.get(model.constraints, attr)::Vector{Tuple{DataType,DataType}},
-        MOI.get(model.variable_bounds, attr)::Vector{Tuple{DataType,DataType}},
+        MOI.get(model.constraints, attr)::Vector{Tuple{Type,Type}},
+        MOI.get(model.variable_bounds, attr)::Vector{Tuple{Type,Type}},
     )
 end
 

--- a/src/Utilities/product_of_sets.jl
+++ b/src/Utilities/product_of_sets.jl
@@ -91,7 +91,7 @@ function MOI.get(
     ::MOI.ListOfConstraintTypesPresent,
 ) where {T}
     present = Set(sets.set_ids)
-    return Tuple{DataType,DataType}[
+    return Tuple{Type,Type}[
         (_affine_function_type(T, S), S) for
         S in set_types(sets) if set_index(sets, S) in present
     ]
@@ -257,7 +257,7 @@ function MOI.get(
     sets::OrderedProductOfSets{T},
     ::MOI.ListOfConstraintTypesPresent,
 ) where {T}
-    return Tuple{DataType,DataType}[
+    return Tuple{Type,Type}[
         (_affine_function_type(T, S), S) for
         S in set_types(sets) if _num_rows(sets, S) > 0
     ]

--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -108,7 +108,7 @@ function MOI.get(
 )
     return broadcastvcat(model) do constrs
         if constrs === nothing
-            return Tuple{DataType,DataType}[]
+            return Tuple{Type,Type}[]
         end
         return MOI.get(constrs, attr)
     end

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -17,8 +17,8 @@ mutable struct UniversalFallback{MT} <: MOI.ModelLike
     # See https://github.com/jump-dev/JuMP.jl/issues/1152 and
     # https://github.com/jump-dev/JuMP.jl/issues/2238 for why we use an
     # `OrderedDict`
-    single_variable_constraints::OrderedDict{DataType,OrderedDict}
-    constraints::OrderedDict{Tuple{DataType,DataType},VectorOfConstraints}
+    single_variable_constraints::OrderedDict{Type,OrderedDict}
+    constraints::OrderedDict{Tuple{Type,Type},VectorOfConstraints}
     con_to_name::Dict{MOI.ConstraintIndex,String}
     name_to_con::Union{Dict{String,MOI.ConstraintIndex},Nothing}
     optattr::Dict{MOI.AbstractOptimizerAttribute,Any}
@@ -29,8 +29,8 @@ mutable struct UniversalFallback{MT} <: MOI.ModelLike
         return new{typeof(model)}(
             model,
             nothing,
-            OrderedDict{Tuple{DataType,DataType},OrderedDict}(),
-            OrderedDict{Tuple{DataType,DataType},VectorOfConstraints}(),
+            OrderedDict{Tuple{Type,Type},OrderedDict}(),
+            OrderedDict{Tuple{Type,Type},VectorOfConstraints}(),
             Dict{MOI.ConstraintIndex,String}(),
             nothing,
             Dict{MOI.AbstractOptimizerAttribute,Any}(),

--- a/src/Utilities/vector_bounds.jl
+++ b/src/Utilities/vector_bounds.jl
@@ -327,7 +327,7 @@ function MOI.get(
     b::SingleVariableConstraints{T},
     ::MOI.ListOfConstraintTypesPresent,
 ) where {T}
-    list = Tuple{DataType,DataType}[]
+    list = Tuple{Type,Type}[]
     _add_constraint_type(list, b, MOI.EqualTo{T})
     _add_constraint_type(list, b, MOI.GreaterThan{T})
     _add_constraint_type(list, b, MOI.LessThan{T})

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -117,7 +117,7 @@ end
 function MOI.get(
     v::VectorOfConstraints{F,S},
     ::MOI.ListOfConstraintTypesPresent,
-)::Vector{Tuple{DataType,DataType}} where {F,S}
+)::Vector{Tuple{Type,Type}} where {F,S}
     return isempty(v.constraints) ? [] : [(F, S)]
 end
 

--- a/src/instantiate.jl
+++ b/src/instantiate.jl
@@ -11,7 +11,7 @@ struct OptimizerWithAttributes
     # Function that takes zero arguments and returns a new optimizer.
     # The type of the function could be
     # * `Function`: a function, or
-    # * `DataType`: a type, or
+    # * `Type`: a type, or
     # * `UnionAll`: a type with missing parameters.
     optimizer_constructor::Any
     params::Vector{Pair{AbstractOptimizerAttribute,Any}}

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -1512,11 +1512,11 @@ struct BridgeAddingNoConstraint{T} <: MOI.Bridges.Constraint.AbstractBridge end
 function MOI.Bridges.added_constrained_variable_types(
     ::Type{<:BridgeAddingNoConstraint},
 )
-    return Tuple{DataType}[]
+    return Tuple{Type}[]
 end
 
 function MOI.Bridges.added_constraint_types(::Type{<:BridgeAddingNoConstraint})
-    return Tuple{DataType,DataType}[]
+    return Tuple{Type,Type}[]
 end
 
 function MOI.supports_constraint(

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -348,7 +348,7 @@ function test_quadratic_functions()
         MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.SecondOrderCone}(),
     )
     loc1 = MOI.get(model, MOI.ListOfConstraintTypesPresent())
-    loc2 = Vector{Tuple{DataType,DataType}}()
+    loc2 = Vector{Tuple{Type,Type}}()
     function _pushloc(v::MOI.Utilities.VectorOfConstraints{F,S}) where {F,S}
         if !MOI.is_empty(v)
             push!(loc2, (F, S))


### PR DESCRIPTION
Closes https://github.com/jump-dev/MathOptInterface.jl/issues/783

We should use `Type` instead of `DataType`.

The issue is that `DataType` is a concrete type of Type (confusing right) that causes the compiler problems (to quote Jeff "this sort of stuff drives the compiler crazy" and "if you're doing that, please stop").

```julia
julia> isconcretetype(DataType)
true

julia> subtypes(Type)
4-element Vector{Any}:
 Core.TypeofBottom
 DataType
 Union
 UnionAll
```

I tried a few other things, such as `Tuple{Type{<:MOI.AbstractFunction},Type{<:MOI.AbstractSet}}` but couldn't get them to work. It seems for a lot of these things, we want simpler type signatures with some run-time asserts to reduce our latency. These paths aren't hot and time-critical.