### PR TITLE
Remove redundant optimize call

### DIFF
--- a/src/DeprecatedTest/UnitTests/constraints.jl
+++ b/src/DeprecatedTest/UnitTests/constraints.jl
@@ -539,7 +539,6 @@ function solve_start_soc(model::MOI.ModelLike, config::Config{T}) where {T}
         MOI.set(model, MOI.ConstraintDualStart(), c, T[2, -2])
     end
     if config.solve
-        MOI.optimize!(model)
         test_model_solution(
             model,
             config;

--- a/src/Test/test_constraint.jl
+++ b/src/Test/test_constraint.jl
@@ -680,7 +680,6 @@ function test_constraint_PrimalStart_DualStart_SecondOrderCone(
     if MOI.supports(model, MOI.ConstraintDualStart(), typeof(c))
         MOI.set(model, MOI.ConstraintDualStart(), c, T[2, -2])
     end
-    MOI.optimize!(model)
     _test_model_solution(
         model,
         config;


### PR DESCRIPTION
`optimize!` is already called by `test_model_solution`. I was a bit confused when this test was causing ECOS to segfault because it's not obvious that it's calling `optimize!` twice.