### PR TITLE
Define copy_to_and_optimize!

### DIFF
--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -165,6 +165,8 @@ function copy_to end
 Same as [`copy_to`](@ref) followed [`optimize!`](@ref). An optimizer
 can decide to implement this function and not implement [`copy_to`](@ref) and
 [`optimize!`](@ref).
+
+**WARNING** This is an experimental new feature of MOI v0.10 that may break in MOI v1.0.
 """
 function copy_to_and_optimize!(dest, src; kws...)
     index_map = copy_to(dest, src; kws...)

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -159,6 +159,19 @@ is_valid(dest, index_map[x]) # true
 """
 function copy_to end
 
+"""
+    copy_to_and_optimize!(dest::ModelLike, src::ModelLike; copy_names=true, warn_attributes=true)
+
+Same as [`copy_to`](@ref) followed [`optimize!`](@ref). An optimizer
+can decide to implement this function and not implement [`copy_to`](@ref) and
+[`optimize!`](@ref).
+"""
+function copy_to_and_optimize!(dest, src; kws...)
+    index_map = copy_to(dest, src; kws...)
+    optimize!(dest)
+    return index_map
+end
+
 include("error.jl")
 include("indextypes.jl")
 include("functions.jl")

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -189,7 +189,10 @@ function attach_optimizer(model::CachingOptimizer)
     return _attach_optimizer(model, MOI.copy_to)
 end
 
-function _attach_optimizer(model::CachingOptimizer, copy_to::F) where {F<:Function}
+function _attach_optimizer(
+    model::CachingOptimizer,
+    copy_to::F,
+) where {F<:Function}
     @assert model.state == EMPTY_OPTIMIZER
     # We do not need to copy names because name-related operations are handled
     # by `m.model_cache`

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -733,8 +733,7 @@ function test_status_codes()
     return
 end
 
-struct CopyToAndOptimizer <: MOI.AbstractOptimizer
-end
+struct CopyToAndOptimizer <: MOI.AbstractOptimizer end
 MOI.is_empty(::CopyToAndOptimizer) = true
 function MOI.copy_to_and_optimize!(::CopyToAndOptimizer, src; kws...)
     return MOI.Utilities.IndexMap()

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -733,6 +733,24 @@ function test_status_codes()
     return
 end
 
+struct CopyToAndOptimizer <: MOI.AbstractOptimizer
+end
+MOI.is_empty(::CopyToAndOptimizer) = true
+function MOI.copy_to_and_optimize!(::CopyToAndOptimizer, src; kws...)
+    return MOI.Utilities.IndexMap()
+end
+
+function test_copy_to_and_optimize!()
+    optimizer = CopyToAndOptimizer()
+    model = MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.Model{Float64}(),
+        optimizer,
+    )
+    MOI.optimize!(model)
+    @test MOI.Utilities.state(model) == MOI.Utilities.ATTACHED_OPTIMIZER
+    return
+end
+
 end  # module
 
 TestCachingOptimizer.runtests()


### PR DESCRIPTION
I've just refactored ECOS with MatrixOfConstraints (https://github.com/jump-dev/ECOS.jl/pull/121/).
There is something tricky that will also be problematic for other similar solvers.
When you implement `copy_to!(dest::Optimizer, src::OptimizerCache)`, `src` contains exactly the data you need to call the solver directly. However, you cannot call it yet, you need to wait for `optimize!` to be called.
So you need to store a cache `src` in `dest`. You need to store a copy since `src` could be modified or its data could be free'd before `optimize!` is called.
This create a lot of edge cases that kind of defeat the purpose of https://github.com/jump-dev/MathOptInterface.jl/pull/1381 to remove the need for the optimizer to have a cache as this is handled by the `CachingOptimizer`.
This PR defines a one-shot optimization function that both gives `src` and optimizes.
For one-shot solver such as most conic solvers, this will considerably simplify the MOI wrapper. It would prevent using these wrapper with `copy_to` and `optimize!` separately without any other MOI layer but it does not matter much.
99% of the use cases would be using it with JuMP or with `MOI.instantiate` with bridges which would add a CachingOptimizer layer anyone.
So there shouldn't be much difference for the user. It would just simplify a lot the writing of these solvers. No need to complicate it to cover the case where `src` is modified between copy and optimizer while we know this will almost only be used by the CachingOptimizer's `optimize!` method which just calls optimize directly after the copy.

The docstring might be clarified to insist that this is a very particular use case. We could even move the function in `MOI.Utilities` if that would clarify it.