### PR TITLE
Refactor Utilities.default_copy_to

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -382,8 +382,7 @@ function MOIU.pass_nonvariable_constraints(
     dest::AbstractBridgeOptimizer,
     src::MOI.ModelLike,
     idxmap::MOIU.IndexMap,
-    constraint_types,
-    pass_cons;
+    constraint_types;
     filter_constraints::Union{Nothing,Function} = nothing,
 )
     if Variable.has_bridges(Variable.bridges(dest))
@@ -393,8 +392,7 @@ function MOIU.pass_nonvariable_constraints(
             dest,
             src,
             idxmap,
-            constraint_types,
-            pass_cons;
+            constraint_types;
             filter_constraints = filter_constraints,
         )
     end
@@ -411,16 +409,14 @@ function MOIU.pass_nonvariable_constraints(
         dest.model,
         src,
         idxmap,
-        not_bridged_types,
-        pass_cons;
+        not_bridged_types;
         filter_constraints = filter_constraints,
     )
     MOIU.pass_nonvariable_constraints_fallback(
         dest,
         src,
         idxmap,
-        bridged_types,
-        pass_cons;
+        bridged_types;
         filter_constraints = filter_constraints,
     )
     return

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -22,8 +22,6 @@ function MOI.get(::BadModel, ::MOI.ListOfModelAttributesSet)
     return MOI.AbstractModelAttribute[]
 end
 
-MOI.get(::BadModel, ::MOI.NumberOfVariables) = 1
-
 MOI.get(::BadModel, ::MOI.ListOfVariableIndices) = [MOI.VariableIndex(1)]
 
 function MOI.get(::BadModel, ::MOI.ListOfVariableAttributesSet)
@@ -52,10 +50,6 @@ function MOI.get(
     ::MOI.ConstraintIndex{MOI.SingleVariable,MOI.EqualTo{Float64}},
 )
     return MOI.EqualTo(0.0)
-end
-
-function MOI.get(::BadModel, ::MOI.ListOfConstraintAttributesSet)
-    return MOI.AbstractConstraintAttribute[]
 end
 
 struct BadConstraintModel <: BadModel end

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -252,8 +252,7 @@ function pass_nonvariable_constraints(
     dest::CachingOptimizer,
     src::MOI.ModelLike,
     idxmap::IndexMap,
-    constraint_types,
-    pass_cons;
+    constraint_types;
     filter_constraints::Union{Nothing,Function} = nothing,
 )
     dest.state == ATTACHED_OPTIMIZER && reset_optimizer(dest)
@@ -261,8 +260,7 @@ function pass_nonvariable_constraints(
         dest.model_cache,
         src,
         idxmap,
-        constraint_types,
-        pass_cons;
+        constraint_types;
         filter_constraints = filter_constraints,
     )
 end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -146,7 +146,7 @@ function _pass_attribute(
     if attr == MOI.ConstraintName() && !copy_names
         return
     elseif attr == MOI.ConstraintPrimalStart() ||
-            attr == MOI.ConstraintDualStart()
+           attr == MOI.ConstraintDualStart()
         # As starting values are simply *hints* for the optimization, not
         # supporting them gives a warning, not an error
         if !MOI.supports(dest, attr, MOI.ConstraintIndex{F,S})
@@ -187,10 +187,8 @@ function _try_constrain_variables_on_creation(
     ::Type{S},
 ) where {S<:MOI.AbstractVectorSet}
     not_added = MOI.ConstraintIndex{MOI.VectorOfVariables,S}[]
-    for ci_src in MOI.get(
-        src,
-        MOI.ListOfConstraintIndices{MOI.VectorOfVariables,S}(),
-    )
+    for ci_src in
+        MOI.get(src, MOI.ListOfConstraintIndices{MOI.VectorOfVariables,S}())
         f_src = MOI.get(src, MOI.ConstraintFunction(), ci_src)
         if !allunique(f_src.variables)
             # Can't add it because there are duplicate variables
@@ -231,10 +229,8 @@ function _try_constrain_variables_on_creation(
     ::Type{S},
 ) where {S<:MOI.AbstractScalarSet}
     not_added = MOI.ConstraintIndex{MOI.SingleVariable,S}[]
-    for ci_src in MOI.get(
-        src,
-        MOI.ListOfConstraintIndices{MOI.SingleVariable,S}(),
-    )
+    for ci_src in
+        MOI.get(src, MOI.ListOfConstraintIndices{MOI.SingleVariable,S}())
         f_src = MOI.get(src, MOI.ConstraintFunction(), ci_src)
         if haskey(index_map, f_src.variable)
             # Can't add it because it contains a variable previously added
@@ -368,11 +364,7 @@ function _pass_constraints(
     return
 end
 
-function _copy_free_variables(
-    dest::MOI.ModelLike,
-    index_map::IndexMap,
-    vis_src,
-)
+function _copy_free_variables(dest::MOI.ModelLike, index_map::IndexMap, vis_src)
     if length(vis_src) == length(index_map.var_map)
         return  # All variables already added
     end
@@ -488,8 +480,8 @@ function default_copy_to(
         ]
     else
         Any[
-            _try_constrain_variables_on_creation(dest, src, index_map, S) for
-            (_, F, S) in _sorted_variable_sets_by_cost(dest, src)
+            _try_constrain_variables_on_creation(dest, src, index_map, S)
+            for (_, F, S) in _sorted_variable_sets_by_cost(dest, src)
         ]
     end
     _copy_free_variables(dest, index_map, vis_src)

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -124,7 +124,7 @@ function pass_attributes(
     copy_names::Bool,
     index_map::IndexMap,
     cis_src::Vector{MOI.ConstraintIndex{F,S}},
-    filter_constraints::Union{Nothing,Function},
+    filter_constraints::Union{Nothing,Function} = nothing,
 ) where {F,S}
     if filter_constraints !== nothing
         filter!(filter_constraints, cis_src)
@@ -279,7 +279,7 @@ function _copy_constraints(
     for ci in cis_src
         f = MOI.get(src, MOI.ConstraintFunction(), ci)
         s = MOI.get(src, MOI.ConstraintSet(), ci)
-        index_map[ci] = MOI.add_constraints(dest, f, s)
+        index_map[ci] = MOI.add_constraints(dest, map_indices(index_map, f), s)
     end
     return
 end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -130,7 +130,7 @@ function pass_attributes(
         filter!(filter_constraints, cis_src)
     end
     for attr in MOI.get(src, MOI.ListOfConstraintAttributesSet{F,S}())
-        _pass_attributes(dest, src, copy_names, index_map, cis_src, attr)
+        _pass_attribute(dest, src, copy_names, index_map, cis_src, attr)
     end
     return
 end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -275,7 +275,7 @@ function _copy_constraints(
     for ci in cis_src
         f = MOI.get(src, MOI.ConstraintFunction(), ci)
         s = MOI.get(src, MOI.ConstraintSet(), ci)
-        index_map[ci] = MOI.add_constraints(dest, map_indices(index_map, f), s)
+        index_map[ci] = MOI.add_constraint(dest, map_indices(index_map, f), s)
     end
     return
 end

--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -459,8 +459,7 @@ function pass_nonvariable_constraints(
     dest::MatrixOfConstraints,
     src::MOI.ModelLike,
     index_map::IndexMap,
-    constraint_types,
-    pass_cons = copy_constraints;
+    constraint_types;
     filter_constraints::Union{Nothing,Function} = nothing,
 )
     for (F, S) in constraint_types

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -530,16 +530,14 @@ function pass_nonvariable_constraints(
     dest::AbstractModel,
     src::MOI.ModelLike,
     idxmap::IndexMap,
-    constraint_types,
-    pass_cons;
+    constraint_types;
     filter_constraints::Union{Nothing,Function} = nothing,
 )
     return pass_nonvariable_constraints(
         dest.constraints,
         src,
         idxmap,
-        constraint_types,
-        pass_cons;
+        constraint_types;
         filter_constraints = filter_constraints,
     )
 end

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -97,8 +97,7 @@ function pass_nonvariable_constraints(
     dest::UniversalFallback,
     src::MOI.ModelLike,
     idxmap::IndexMap,
-    constraint_types,
-    pass_cons;
+    constraint_types;
     filter_constraints::Union{Nothing,Function} = nothing,
 )
     supported_types = eltype(constraint_types)[]
@@ -114,16 +113,14 @@ function pass_nonvariable_constraints(
         dest.model,
         src,
         idxmap,
-        supported_types,
-        pass_cons;
+        supported_types;
         filter_constraints = filter_constraints,
     )
     return pass_nonvariable_constraints_fallback(
         dest,
         src,
         idxmap,
-        unsupported_types,
-        pass_cons;
+        unsupported_types;
         filter_constraints = filter_constraints,
     )
 end

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -464,11 +464,8 @@ function test_create_variables_using_supports_add_constrained_variable()
 
     dest = OrderConstrainedVariablesModel()
     bridged_dest = MOI.Bridges.full_bridge_optimizer(dest, Float64)
-    @test MOIU._sorted_variable_sets_by_cost(bridged_dest, src) == Any[
-        (bridged_dest, MOI.VectorOfVariables, MOI.Zeros),
-        (bridged_dest, MOI.VectorOfVariables, MOI.Nonnegatives),
-        (bridged_dest, MOI.VectorOfVariables, MOI.Nonpositives),
-    ]
+    @test MOIU.sorted_variable_sets_by_cost(bridged_dest, src) ==
+          Type[MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives]
     @test MOI.supports_add_constrained_variables(bridged_dest, MOI.Nonnegatives)
     @test MOI.get(bridged_dest, MOI.VariableBridgingCost{MOI.Nonnegatives}()) ==
           0.0
@@ -509,11 +506,8 @@ function test_create_variables_using_supports_add_constrained_variable()
 
     dest = ReverseOrderConstrainedVariablesModel()
     bridged_dest = MOI.Bridges.full_bridge_optimizer(dest, Float64)
-    @test MOIU._sorted_variable_sets_by_cost(bridged_dest, src) == Any[
-        (bridged_dest, MOI.VectorOfVariables, MOI.Zeros),
-        (bridged_dest, MOI.VectorOfVariables, MOI.Nonpositives),
-        (bridged_dest, MOI.VectorOfVariables, MOI.Nonnegatives),
-    ]
+    @test MOIU.sorted_variable_sets_by_cost(bridged_dest, src) ==
+          Type[MOI.Zeros, MOI.Nonpositives, MOI.Nonnegatives]
     @test MOI.supports_add_constrained_variables(bridged_dest, MOI.Nonnegatives)
     @test MOI.get(bridged_dest, MOI.VariableBridgingCost{MOI.Nonnegatives}()) ==
           2.0

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -464,10 +464,10 @@ function test_create_variables_using_supports_add_constrained_variable()
 
     dest = OrderConstrainedVariablesModel()
     bridged_dest = MOI.Bridges.full_bridge_optimizer(dest, Float64)
-    @test MOIU.sorted_variable_sets_by_cost(bridged_dest, src) == [
-        (MOI.VectorOfVariables, MOI.Zeros),
-        (MOI.VectorOfVariables, MOI.Nonnegatives),
-        (MOI.VectorOfVariables, MOI.Nonpositives),
+    @test MOIU._sorted_variable_sets_by_cost(bridged_dest, src) == Any[
+        (bridged_dest, MOI.VectorOfVariables, MOI.Zeros),
+        (bridged_dest, MOI.VectorOfVariables, MOI.Nonnegatives),
+        (bridged_dest, MOI.VectorOfVariables, MOI.Nonpositives),
     ]
     @test MOI.supports_add_constrained_variables(bridged_dest, MOI.Nonnegatives)
     @test MOI.get(bridged_dest, MOI.VariableBridgingCost{MOI.Nonnegatives}()) ==
@@ -509,10 +509,10 @@ function test_create_variables_using_supports_add_constrained_variable()
 
     dest = ReverseOrderConstrainedVariablesModel()
     bridged_dest = MOI.Bridges.full_bridge_optimizer(dest, Float64)
-    @test MOIU.sorted_variable_sets_by_cost(bridged_dest, src) == [
-        (MOI.VectorOfVariables, MOI.Zeros),
-        (MOI.VectorOfVariables, MOI.Nonpositives),
-        (MOI.VectorOfVariables, MOI.Nonnegatives),
+    @test MOIU._sorted_variable_sets_by_cost(bridged_dest, src) == Any[
+        (bridged_dest, MOI.VectorOfVariables, MOI.Zeros),
+        (bridged_dest, MOI.VectorOfVariables, MOI.Nonpositives),
+        (bridged_dest, MOI.VectorOfVariables, MOI.Nonnegatives),
     ]
     @test MOI.supports_add_constrained_variables(bridged_dest, MOI.Nonnegatives)
     @test MOI.get(bridged_dest, MOI.VariableBridgingCost{MOI.Nonnegatives}()) ==
@@ -741,16 +741,14 @@ function MOIU.pass_nonvariable_constraints(
     dest::OnlyCopyConstraints,
     src::MOI.ModelLike,
     idxmap::MOIU.IndexMap,
-    constraint_types,
-    pass_cons;
+    constraint_types;
     filter_constraints::Union{Nothing,Function} = nothing,
 )
     return MOIU.pass_nonvariable_constraints(
         dest.constraints,
         src,
         idxmap,
-        constraint_types,
-        pass_cons;
+        constraint_types;
         filter_constraints = filter_constraints,
     )
 end


### PR DESCRIPTION
Part of #1313, using that same script with GLPK.

Now that allocate-load is gone, we can refactor a lot of `Utilities.default_copy_to`.

## Before

```
julia> tinf
InferenceTimingNode: 4.981569/10.378739 on InferenceFrameInfo for Core.Compiler.Timings.ROOT() with 79 direct children
```

![image](https://user-images.githubusercontent.com/8177701/129136968-14477db5-6fce-4095-ba20-d360f7b80631.png)

## After

```
julia> tinf
InferenceTimingNode: 3.927378/8.255136 on InferenceFrameInfo for Core.Compiler.Timings.ROOT() with 61 direct children
```

![image](https://user-images.githubusercontent.com/8177701/129137091-fb78c4a0-2208-4418-968f-24ff15370351.png)


## Takeaways

We now have 61 entries into runtime dispatch instead of 79, and time drops from ~10 seconds to ~8 seconds.


There are 29 methods remaining where this happens:
```Julia
julia> mtrigs
29-element Vector{SnoopCompile.TaggedTriggers{Method}}:
 MathOptInterface.Utilities.CachingOptimizer(model_cache::MathOptInterface.ModelLike, optimizer::MathOptInterface.AbstractOptimizer) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:89 (1 callees from 1 callers)
 get(model::MathOptInterface.Utilities.StructOfConstraints, attr::MathOptInterface.ListOfConstraintIndices{F, S}) where {F, S} in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/struct_of_constraints.jl:127 (1 callees from 1 callers)
 (::MathOptInterface.Utilities.var"#180#181")(constrs) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/struct_of_constraints.jl:110 (1 callees from 1 callers)
 (::MathOptInterface.var"#instantiate##kw")(::Any, ::typeof(MathOptInterface.instantiate), optimizer_constructor) in MathOptInterface at /Users/oscar/.julia/dev/MathOptInterface/src/instantiate.jl:117 (1 callees from 1 callers)
 broadcastvcat(f::Function, model::MathOptInterface.Utilities.ModelScalarConstraints) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/struct_of_constraints.jl:284 (1 callees from 1 callers)
 _reverse_dict(dest::MathOptInterface.Utilities.DoubleDicts.IndexDoubleDict, src::MathOptInterface.Utilities.DoubleDicts.IndexDoubleDict) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:227 (1 callees from 1 callers)
 add_variables(m::MathOptInterface.Utilities.CachingOptimizer, n) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:335 (1 callees from 1 callers)
 (::MathOptInterface.Utilities.var"#138#140")(::Any) in MathOptInterface.Utilities (1 callees from 1 callers)
 _try_constrain_variables_on_creation(dest::MathOptInterface.ModelLike, src::MathOptInterface.ModelLike, index_map::MathOptInterface.Utilities.IndexMap, ::Type{S}) where S<:MathOptInterface.AbstractScalarSet in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/copy.jl:227 (1 callees from 1 callers)
 get(model::Union{MathOptInterface.Utilities.AbstractModelLike{T}, MathOptInterface.Utilities.AbstractOptimizer{T}} where T, ::MathOptInterface.ListOfVariableAttributesSet) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/model.jl:191 (1 callees from 1 callers)
 sort!(v::AbstractVector{T} where T, lo::Integer, hi::Integer, ::Base.Sort.InsertionSortAlg, o::Base.Order.Ordering) in Base.Sort at sort.jl:527 (1 callees from 1 callers)
 broadcastvcat(f::Function, model::MathOptInterface.Utilities.ModelFunctionConstraints) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/struct_of_constraints.jl:284 (1 callees from 1 callers)
 _cost_of_bridging(arg::Tuple) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/copy.jl:409 (2 callees from 1 callers)
 pass_attributes(dest::MathOptInterface.ModelLike, src::MathOptInterface.ModelLike, copy_names::Bool, index_map::MathOptInterface.Utilities.IndexMap) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/copy.jl:21 (2 callees from 1 callers)
 iterate(f::Base.Iterators.Filter, state...) in Base.Iterators at iterators.jl:448 (2 callees from 2 callers)
 get(uf::MathOptInterface.Utilities.UniversalFallback, attr::Union{MathOptInterface.ConstraintFunction, MathOptInterface.ConstraintSet}, ci::MathOptInterface.ConstraintIndex) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/universalfallback.jl:814 (2 callees from 2 callers)
 example_diet(optimizer, bridge) in Main at /Users/oscar/Documents/JuMP/performance/auto-cache/bench.jl:4 (2 callees from 1 callers)
 findnext(testf::Function, A, start) in Base at array.jl:1850 (2 callees from 2 callers)
 constraints(model::MathOptInterface.Utilities.ModelScalarConstraints{T, var"#453#C1", var"#454#C2", var"#455#C3", var"#456#C4", var"#457#C5", var"#458#C6", var"#459#C7", var"#460#C8"}, ::Type{var"#s261"} where var"#s261"<:MathOptInterface.AbstractFunction, ::Type{var"#s260"} where var"#s260"<:MathOptInterface.LessThan{T}) where {T, var"#453#C1", var"#454#C2", var"#455#C3", var"#456#C4", var"#457#C5", var"#458#C6", var"#459#C7", var"#460#C8"} in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/struct_of_constraints.jl:304 (2 callees from 1 callers)
 constraints(model::MathOptInterface.Utilities.ModelScalarConstraints{T, var"#433#C1", var"#434#C2", var"#435#C3", var"#436#C4", var"#437#C5", var"#438#C6", var"#439#C7", var"#440#C8"}, ::Type{var"#s291"} where var"#s291"<:MathOptInterface.AbstractFunction, ::Type{var"#s290"} where var"#s290"<:MathOptInterface.EqualTo{T}) where {T, var"#433#C1", var"#434#C2", var"#435#C3", var"#436#C4", var"#437#C5", var"#438#C6", var"#439#C7", var"#440#C8"} in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/struct_of_constraints.jl:304 (2 callees from 1 callers)
 promote_typeof(x, xs...) in Base at promotion.jl:272 (2 callees from 2 callers)
 _example_diet(model) in Main at /Users/oscar/Documents/JuMP/performance/auto-cache/bench.jl:17 (3 callees from 1 callers)
 var"#pass_nonvariable_constraints_fallback#131"(filter_constraints::Union{Nothing, Function}, ::typeof(MathOptInterface.Utilities.pass_nonvariable_constraints_fallback), dest::MathOptInterface.ModelLike, src::MathOptInterface.ModelLike, index_map::MathOptInterface.Utilities.IndexMap, constraint_types) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/copy.jl:287 (3 callees from 1 callers)
 get(uf::MathOptInterface.Utilities.UniversalFallback, listattr::MathOptInterface.ListOfConstraintTypesPresent) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/universalfallback.jl:389 (3 callees from 1 callers)
 _reverse_dict(src::D) where D<:Dict in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/cachingoptimizer.jl:237 (3 callees from 1 callers)
 var"#instantiate#21"(with_bridge_type::Union{Nothing, Type}, with_names::Bool, ::typeof(MathOptInterface.instantiate), optimizer_constructor) in MathOptInterface at /Users/oscar/.julia/dev/MathOptInterface/src/instantiate.jl:117 (3 callees from 1 callers)
 var"#default_copy_to#141"(copy_names::Bool, filter_constraints::Union{Nothing, Function}, ::typeof(MathOptInterface.Utilities.default_copy_to), dest::MathOptInterface.ModelLike, src::MathOptInterface.ModelLike) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/copy.jl:463 (4 callees from 1 callers)
 _pass_constraints(dest::MathOptInterface.ModelLike, src::MathOptInterface.ModelLike, copy_names::Bool, index_map::MathOptInterface.Utilities.IndexMap, variable_constraints_not_added::Vector{Any}, filter_constraints::Union{Nothing, Function}) in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/copy.jl:336 (5 callees from 1 callers)
 get(uf::MathOptInterface.Utilities.UniversalFallback, listattr::MathOptInterface.ListOfConstraintAttributesSet{F, S}) where {F, S} in MathOptInterface.Utilities at /Users/oscar/.julia/dev/MathOptInterface/src/Utilities/universalfallback.jl:440 (6 callees from 3 callers)
```