### PR TITLE
Remove warn_attributes

### DIFF
--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -128,7 +128,6 @@ supports_incremental_interface(::ModelLike, ::Bool) = false
         dest::ModelLike,
         src::ModelLike;
         copy_names::Bool = true,
-        warn_attributes::Bool = true,
     )::IndexMap
 
 Copy the model from `src` into `dest`.
@@ -149,9 +148,8 @@ indices from the `src` model to the corresponding indices in the `dest` model.
  * If an [`AbstractModelAttribute`](@ref), [`AbstractVariableAttribute`](@ref),
    or [`AbstractConstraintAttribute`](@ref) is set in `src` but not supported by
    `dest`, then an [`UnsupportedAttribute`](@ref) error is thrown.
- * Unsupported [`AbstractOptimizerAttribute`](@ref)s are treated differently:
-   * If `warn_attributes == true`, a warning is displayed, otherwise, the
-     attribute is silently ignored.
+
+[`AbstractOptimizerAttribute`](@ref)s are _not_ copied  to the `dest` model.
 
 ## IndexMap
 


### PR DESCRIPTION
Technically breaking, but I think this only ever existed in the documentation.

Looks like Hypatia has it as an argument (cc @chriscoey), but didn't do anything with it:

<img width="1066" alt="image" src="https://user-images.githubusercontent.com/8177701/129432654-2597ade8-0de0-4a3c-8bf4-6a8dcfc7a9ee.png">