### PR TITLE
[Utilities] Remove .set field of CleverDict

### DIFF
--- a/test/Utilities/CleverDicts.jl
+++ b/test/Utilities/CleverDicts.jl
@@ -255,7 +255,7 @@ function test_dense_operations()
     @test haskey(d, 4)
     @test !haskey(d, 6)
     @test length(d) == 2
-    @test collect(d) == [2 => 1.5, 4 => 0.25]
+    @test collect(d) == [4 => 0.25, 2 => 1.5]
     @test d[2] == 1.5
     @test d[4] == 0.25
 
@@ -264,7 +264,7 @@ function test_dense_operations()
     @test haskey(d, 4)
     @test haskey(d, 6)
     @test length(d) == 3
-    @test collect(d) == [2 => 1.5, 4 => 0.25, 6 => 0.75]
+    @test collect(d) == [4 => 0.25, 2 => 1.5, 6 => 0.75]
     @test d[2] == 1.5
     @test d[4] == 0.25
     @test d[6] == 0.75


### PR DESCRIPTION
Closes #1326

This simplifies things by removing `.set` field. It also fixes an inference issue in `keys`.

The downside is that it breaks the iteration order for items in a `CleverDict` initialized with storage but not yet filled. 

To be honest, I don't really understand the need for pre-initializing the CleverDict. I've left the option, but it now calls `size hint` instead of pre-allocating the space.