### PR TITLE
[breaking] Move test_models_equal to Test

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1,4 +1,11 @@
-using Test
+function  test_models_equal(args...)
+    @warn(
+        "`Utilities.test_models_equal` has been moved to " *
+        "`Test.test_models_equal`",
+        maxlog = 1,
+    )
+    return MOI.Test.test_models_equal(args...)
+end
 
 variable_function_type(::Type{<:MOI.AbstractScalarSet}) = MOI.SingleVariable
 variable_function_type(::Type{<:MOI.AbstractVectorSet}) = MOI.VectorOfVariables
@@ -801,56 +808,6 @@ function sort_and_compress!(x::AbstractVector, by, keep, combine)
     return x
 end
 
-function test_variablenames_equal(model, variablenames)
-    seen_name = Dict(name => false for name in variablenames)
-    for index in MOI.get(model, MOI.ListOfVariableIndices())
-        vname = MOI.get(model, MOI.VariableName(), index)
-        if !haskey(seen_name, vname)
-            error(
-                "Variable with name $vname present in model but not expected list of variable names.",
-            )
-        end
-        if seen_name[vname]
-            error(
-                "Variable with name $vname present twice in model (shouldn't happen!)",
-            )
-        end
-        seen_name[vname] = true
-    end
-    for (vname, seen) in seen_name
-        if !seen
-            error("Did not find variable with name $vname in instance.")
-        end
-    end
-end
-function test_constraintnames_equal(model, constraintnames)
-    seen_name = Dict(name => false for name in constraintnames)
-    for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
-        if F == MOI.SingleVariable
-            continue
-        end
-        for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-            cname = MOI.get(model, MOI.ConstraintName(), index)
-            if !haskey(seen_name, cname)
-                error(
-                    "Constraint with name $cname present in model but not expected list of constraint names.",
-                )
-            end
-            if seen_name[cname]
-                error(
-                    "Constraint with name $cname present twice in model (shouldn't happen!)",
-                )
-            end
-            seen_name[cname] = true
-        end
-    end
-    for (cname, seen) in seen_name
-        if !seen
-            error("Did not find constraint with name $cname in instance.")
-        end
-    end
-end
-
 """
     all_coefficients(p::Function, f::MOI.AbstractFunction)
 
@@ -912,81 +869,6 @@ function Base.isone(
     f::Union{MOI.ScalarAffineFunction,MOI.ScalarQuadraticFunction},
 )
     return isone(MOI.constant(f)) && _is_constant(canonical(f))
-end
-
-"""
-    test_models_equal(
-        model1::ModelLike,
-        model2::ModelLike,
-        variablenames::Vector{String},
-        constraintnames::Vector{String},
-        single_variable_constraints::Vector{Tuple{String,<:MOI.AbstractScalarSet}}
-    )
-
-Test that `model1` and `model2` are identical using `variablenames` as as keys
-for the variable names and `constraintnames` as keys for the constraint names.
-
-In addition, it checks that there is a SingleVariable-in-Set constraint for each
-`(name, set)` tuple in `single_variable_constraints`, where `name` is the name
-of the corresponding variable.
-
-Uses `Base.Test` macros.
-"""
-function test_models_equal(
-    model1::MOI.ModelLike,
-    model2::MOI.ModelLike,
-    variablenames::Vector{String},
-    constraintnames::Vector{String},
-    single_variable_constraints::Vector{<:Tuple} = Tuple[],
-)
-    for (x_name, set) in single_variable_constraints
-        x1 = MOI.get(model1, MOI.VariableIndex, x_name)
-        ci1 = MOI.ConstraintIndex{MOI.SingleVariable,typeof(set)}(x1.value)
-        @test MOI.is_valid(model1, ci1)
-        @test MOI.get(model1, MOI.ConstraintSet(), ci1) == set
-        x2 = MOI.get(model2, MOI.VariableIndex, x_name)
-        ci2 = MOI.ConstraintIndex{MOI.SingleVariable,typeof(set)}(x2.value)
-        @test MOI.is_valid(model2, ci2)
-        @test MOI.get(model2, MOI.ConstraintSet(), ci2) == set
-    end
-    # TODO: give test-friendly feedback instead of errors?
-    test_variablenames_equal(model1, variablenames)
-    test_variablenames_equal(model2, variablenames)
-    test_constraintnames_equal(model1, constraintnames)
-    test_constraintnames_equal(model2, constraintnames)
-
-    variablemap_2to1 = Dict{VI,VI}()
-    for vname in variablenames
-        index1 = MOI.get(model1, VI, vname)
-        index2 = MOI.get(model2, VI, vname)
-        variablemap_2to1[index2] = index1
-    end
-
-    for cname in constraintnames
-        index1 = MOI.get(model1, CI, cname)
-        index2 = MOI.get(model2, CI, cname)
-        f1 = MOI.get(model1, MOI.ConstraintFunction(), index1)
-        f2 = MOI.get(model2, MOI.ConstraintFunction(), index2)
-        s1 = MOI.get(model1, MOI.ConstraintSet(), index1)
-        s2 = MOI.get(model2, MOI.ConstraintSet(), index2)
-        @test isapprox(f1, map_indices(variablemap_2to1, f2))
-        @test s1 == s2
-    end
-    attrs1 = MOI.get(model1, MOI.ListOfModelAttributesSet())
-    attrs2 = MOI.get(model2, MOI.ListOfModelAttributesSet())
-    attr_list = attrs1 ∪ attrs2
-    for attr in attr_list
-        value1 = MOI.get(model1, attr)
-        value2 = MOI.get(model2, attr)
-        if value1 isa MOI.AbstractFunction
-            @test value2 isa MOI.AbstractFunction
-            @test isapprox(value1, map_indices(variablemap_2to1, value2))
-        else
-            @test !(value2 isa MOI.AbstractFunction)
-            @test value1 == value2
-        end
-    end
-    return
 end
 
 _keep_all(keep::Function, v::MOI.VariableIndex) = keep(v)

--- a/test/Bridges/Constraint/geomean.jl
+++ b/test/Bridges/Constraint/geomean.jl
@@ -96,7 +96,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         var_names,
@@ -135,7 +135,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,
@@ -273,7 +273,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_2()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         var_names,
@@ -322,7 +322,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_2()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,
@@ -416,7 +416,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_3()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         ["t", "x"],
@@ -455,7 +455,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_3()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         ["t", "x"],

--- a/test/Bridges/Constraint/geomean_to_relentr.jl
+++ b/test/Bridges/Constraint/geomean_to_relentr.jl
@@ -106,7 +106,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         vcat(var_names, "aux"),
@@ -139,7 +139,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,
@@ -258,7 +258,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_2()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         vcat(var_names, "aux"),
@@ -300,7 +300,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_2()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,
@@ -409,7 +409,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_3()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         vcat(var_names, "aux"),
@@ -442,7 +442,7 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_3()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,

--- a/test/Bridges/Constraint/indicator_sos.jl
+++ b/test/Bridges/Constraint/indicator_sos.jl
@@ -263,7 +263,7 @@ function test_model_equality()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         var_names,
@@ -292,7 +292,7 @@ function test_model_equality()
     maxobjective: z
     """
     MOI.Utilities.loadfromstring!(model, sbridged)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         ["z", "x"],

--- a/test/Bridges/Constraint/norm_spec_nuc_to_psd.jl
+++ b/test/Bridges/Constraint/norm_spec_nuc_to_psd.jl
@@ -88,7 +88,7 @@ function test_NormSpectral()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(mock, model, var_names, ["psd"])
+    MOI.Test.test_models_equal(mock, model, var_names, ["psd"])
     spec = MOI.get(
         bridged_mock,
         MOI.ListOfConstraintIndices{
@@ -106,7 +106,7 @@ function test_NormSpectral()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(bridged_mock, model, var_names, ["spec"])
+    MOI.Test.test_models_equal(bridged_mock, model, var_names, ["spec"])
     ci = first(
         MOI.get(
             bridged_mock,
@@ -234,7 +234,7 @@ function test_NormNuclear()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(mock, model, var_names, ["greater", "psd"])
+    MOI.Test.test_models_equal(mock, model, var_names, ["greater", "psd"])
     MOI.set(
         bridged_mock,
         MOI.VariableName(),
@@ -258,7 +258,7 @@ function test_NormNuclear()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(bridged_mock, model, ["t"], ["nuc"])
+    MOI.Test.test_models_equal(bridged_mock, model, ["t"], ["nuc"])
     ci = first(
         MOI.get(
             bridged_mock,

--- a/test/Bridges/Constraint/norm_to_lp.jl
+++ b/test/Bridges/Constraint/norm_to_lp.jl
@@ -92,7 +92,7 @@ function test_NormInfinity_1()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         var_names,
@@ -133,7 +133,7 @@ function test_NormInfinity_1()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,
@@ -216,12 +216,7 @@ function test_conic_NormInfinityCone_3()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
-        mock,
-        model,
-        var_names,
-        ["nonneg1", "nonneg2"],
-    )
+    MOI.Test.test_models_equal(mock, model, var_names, ["nonneg1", "nonneg2"])
     MOI.set(
         bridged_mock,
         MOI.VariableName(),
@@ -255,7 +250,7 @@ function test_conic_NormInfinityCone_3()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,
@@ -372,7 +367,7 @@ function test_conic_NormOneCone_VectorOfVariables()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         [var_names; "u"; "v"],
@@ -407,7 +402,7 @@ function test_conic_NormOneCone_VectorOfVariables()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,
@@ -484,7 +479,7 @@ function test_conic_NormOneCone()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         var_names_all,
@@ -522,7 +517,7 @@ function test_conic_NormOneCone()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,

--- a/test/Bridges/Constraint/relentr_to_exp.jl
+++ b/test/Bridges/Constraint/relentr_to_exp.jl
@@ -93,7 +93,7 @@ function test_RelativeEntropy()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         vcat(var_names, "y1", "y2"),
@@ -116,7 +116,7 @@ function test_RelativeEntropy()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(bridged_mock, model, var_names, ["relentr"])
+    MOI.Test.test_models_equal(bridged_mock, model, var_names, ["relentr"])
     ci = first(
         MOI.get(
             bridged_mock,

--- a/test/Bridges/Constraint/semi_to_binary.jl
+++ b/test/Bridges/Constraint/semi_to_binary.jl
@@ -176,7 +176,7 @@ function test_SemiToBinary()
     MOI.empty!(bridged_mock)
     @test MOI.is_empty(bridged_mock)
     MOI.Utilities.loadfromstring!(bridged_mock, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         ["x", "y"],
@@ -221,7 +221,7 @@ function test_SemiToBinary()
         ),
     )
     MOI.set(mock, MOI.ConstraintName(), ci, "cup")
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         modelb,
         ["x", "y", "z"],

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -107,14 +107,14 @@ function test_ZeroOne()
     MOI.empty!(bridged_mock)
     @test MOI.is_empty(bridged_mock)
     MOI.Utilities.loadfromstring!(bridged_mock, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         ["x", "y"],
         String[],
         [("y", MOI.EqualTo{Float64}(1.0)), ("x", MOI.ZeroOne())],
     )
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         modelb,
         ["x", "y"],

--- a/test/Bridges/Objective/slack.jl
+++ b/test/Bridges/Objective/slack.jl
@@ -266,7 +266,7 @@ function test_original()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         [var_names; "s"],
@@ -285,7 +285,7 @@ function test_original()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,
@@ -338,7 +338,7 @@ function test_original()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         [var_names; "s"],
@@ -356,7 +356,7 @@ function test_original()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         var_names,

--- a/test/Bridges/Variable/flip_sign.jl
+++ b/test/Bridges/Variable/flip_sign.jl
@@ -112,7 +112,7 @@ function test_NonposToNonneg()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         var_names,
@@ -128,7 +128,7 @@ function test_NonposToNonneg()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         ["x", "z", "w", "v"],

--- a/test/Bridges/Variable/free.jl
+++ b/test/Bridges/Variable/free.jl
@@ -85,7 +85,7 @@ function test_modification_multirow_vectoraffine_nonpos()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(mock, model, var_names, ["nonneg", "c"])
+    MOI.Test.test_models_equal(mock, model, var_names, ["nonneg", "c"])
     s = """
     variables: x
     c: [4.0x + -1.0, 3.0x + -1.0] in MathOptInterface.Nonpositives(2)
@@ -93,7 +93,7 @@ function test_modification_multirow_vectoraffine_nonpos()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(bridged_mock, model, ["x"], ["c"])
+    MOI.Test.test_models_equal(bridged_mock, model, ["x"], ["c"])
     return
 end
 
@@ -282,12 +282,7 @@ function test_linear_transform()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
-        mock,
-        model,
-        var_names,
-        ["nonneg", "c1", "c2"],
-    )
+    MOI.Test.test_models_equal(mock, model, var_names, ["nonneg", "c1", "c2"])
     var_names = ["v1", "v2"]
     MOI.set(bridged_mock, MOI.VariableName(), vis, var_names)
     s = """
@@ -298,12 +293,7 @@ function test_linear_transform()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
-        bridged_mock,
-        model,
-        var_names,
-        ["c1", "c2"],
-    )
+    MOI.Test.test_models_equal(bridged_mock, model, var_names, ["c1", "c2"])
     _test_delete_bridged_variable(
         bridged_mock,
         vis[1],

--- a/test/Bridges/Variable/rsoc_to_psd.jl
+++ b/test/Bridges/Variable/rsoc_to_psd.jl
@@ -71,7 +71,7 @@ function test_RSOC_of_dimension_2()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(mock, model, var_names, ["cab", "c"])
+    MOI.Test.test_models_equal(mock, model, var_names, ["cab", "c"])
     var_names = ["x", "y"]
     MOI.set(
         bridged_mock,
@@ -88,12 +88,7 @@ function test_RSOC_of_dimension_2()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
-        bridged_mock,
-        model,
-        var_names,
-        ["cxy", "c"],
-    )
+    MOI.Test.test_models_equal(bridged_mock, model, var_names, ["cxy", "c"])
     _test_delete_bridged_variables(
         bridged_mock,
         xy,
@@ -181,7 +176,7 @@ function test_RSOC4()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         var_names,
@@ -223,12 +218,7 @@ function test_RSOC4()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
-        bridged_mock,
-        model,
-        var_names,
-        ["rsoc", "c"],
-    )
+    MOI.Test.test_models_equal(bridged_mock, model, var_names, ["rsoc", "c"])
 
     v = MOI.get(bridged_mock, MOI.ListOfVariableIndices())
     @test length(v) == 4

--- a/test/Bridges/Variable/rsoc_to_soc.jl
+++ b/test/Bridges/Variable/rsoc_to_soc.jl
@@ -66,7 +66,7 @@ function test_rotatedsoc4()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(mock, model, var_names, ["soc", "c"])
+    MOI.Test.test_models_equal(mock, model, var_names, ["soc", "c"])
     var_names = ["t", "u", "x", "y"]
     MOI.set(
         bridged_mock,
@@ -92,12 +92,7 @@ function test_rotatedsoc4()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
-        bridged_mock,
-        model,
-        var_names,
-        ["rsoc", "c"],
-    )
+    MOI.Test.test_models_equal(bridged_mock, model, var_names, ["rsoc", "c"])
 
     tuxy = MOI.get(bridged_mock, MOI.ListOfVariableIndices())
 

--- a/test/Bridges/Variable/soc_to_rsoc.jl
+++ b/test/Bridges/Variable/soc_to_rsoc.jl
@@ -67,7 +67,7 @@ function test_soc1v()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(mock, model, var_names, ["rsoc", "ceq"])
+    MOI.Test.test_models_equal(mock, model, var_names, ["rsoc", "ceq"])
     var_names = ["x", "y", "z"]
     MOI.set(
         bridged_mock,
@@ -90,12 +90,7 @@ function test_soc1v()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
-        bridged_mock,
-        model,
-        var_names,
-        ["soc", "ceq"],
-    )
+    MOI.Test.test_models_equal(bridged_mock, model, var_names, ["soc", "ceq"])
     xyz = MOI.get(bridged_mock, MOI.ListOfVariableIndices())
 
     message = string(

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -62,7 +62,7 @@ function test_get_scalar_constraint()
         """
         model = MOI.Utilities.Model{Float64}()
         MOI.Utilities.loadfromstring!(model, s)
-        MOI.Utilities.test_models_equal(mock, model, ["y"], ["cy", "c"])
+        MOI.Test.test_models_equal(mock, model, ["y"], ["cy", "c"])
     end
     @testset "Bridged model" begin
         MOI.set(bridged_mock, MOI.VariableName(), x, "x")
@@ -73,7 +73,7 @@ function test_get_scalar_constraint()
         """
         model = MOI.Utilities.Model{Float64}()
         MOI.Utilities.loadfromstring!(model, s)
-        MOI.Utilities.test_models_equal(
+        MOI.Test.test_models_equal(
             bridged_mock,
             model,
             ["x"],
@@ -203,7 +203,7 @@ function test_exp3_with_add_constrained_variable_y()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(mock, model, ["x", "z"], ["zc", "xc", "ec"])
+    MOI.Test.test_models_equal(mock, model, ["x", "z"], ["zc", "xc", "ec"])
 
     MOI.set(bridged_mock, MOI.VariableName(), y, "y")
     s = """
@@ -214,7 +214,7 @@ function test_exp3_with_add_constrained_variable_y()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         ["x", "y"],

--- a/test/Bridges/Variable/zeros.jl
+++ b/test/Bridges/Variable/zeros.jl
@@ -46,7 +46,7 @@ function test_zeros()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         bridged_mock,
         model,
         ["x", "y", "z"],
@@ -165,7 +165,7 @@ function test_zeros()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
-    MOI.Utilities.test_models_equal(
+    MOI.Test.test_models_equal(
         mock,
         model,
         ["x"],

--- a/test/FileFormats/CBF/CBF.jl
+++ b/test/FileFormats/CBF/CBF.jl
@@ -72,7 +72,7 @@ function _test_write_then_read(model_string::String)
     MOI.read_from_file(model2, CBF_TEST_FILE)
     _set_var_and_con_names(model2)
 
-    return MOIU.test_models_equal(model1, model2, args...)
+    return MOI.Test.test_models_equal(model1, model2, args...)
 end
 
 function _test_read(filename::String, model_string::String)
@@ -84,7 +84,7 @@ function _test_read(filename::String, model_string::String)
     MOI.read_from_file(model2, filename)
     _set_var_and_con_names(model2)
 
-    return MOIU.test_models_equal(model1, model2, args...)
+    return MOI.Test.test_models_equal(model1, model2, args...)
 end
 
 function test_show()

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -41,7 +41,7 @@ function _test_model_equality(model_string, variables, constraints; suffix = "")
     MOI.write_to_file(model, TEST_MOF_FILE * suffix)
     model_2 = MOF.Model()
     MOI.read_from_file(model_2, TEST_MOF_FILE * suffix)
-    MOIU.test_models_equal(model, model_2, variables, constraints)
+    MOI.Test.test_models_equal(model, model_2, variables, constraints)
     return _validate(TEST_MOF_FILE * suffix)
 end
 
@@ -319,7 +319,7 @@ function test_empty_model()
     MOI.write_to_file(model, TEST_MOF_FILE)
     model_2 = MOF.Model()
     MOI.read_from_file(model_2, TEST_MOF_FILE)
-    return MOIU.test_models_equal(model, model_2, String[], String[])
+    return MOI.Test.test_models_equal(model, model_2, String[], String[])
 end
 
 function test_FEASIBILITY_SENSE()
@@ -330,7 +330,7 @@ function test_FEASIBILITY_SENSE()
     MOI.write_to_file(model, TEST_MOF_FILE)
     model_2 = MOF.Model()
     MOI.read_from_file(model_2, TEST_MOF_FILE)
-    return MOIU.test_models_equal(model, model_2, ["x"], String[])
+    return MOI.Test.test_models_equal(model, model_2, ["x"], String[])
 end
 
 function test_empty_function_term()
@@ -346,7 +346,7 @@ function test_empty_function_term()
     MOI.write_to_file(model, TEST_MOF_FILE)
     model_2 = MOF.Model()
     MOI.read_from_file(model_2, TEST_MOF_FILE)
-    return MOIU.test_models_equal(model, model_2, ["x"], ["c"])
+    return MOI.Test.test_models_equal(model, model_2, ["x"], ["c"])
 end
 
 function test_min_objective()

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -14,7 +14,7 @@ function _test_model_equality(model_string, variables, constraints)
     MOI.write_to_file(model, MPS_TEST_FILE)
     model_2 = MPS.Model()
     MOI.read_from_file(model_2, MPS_TEST_FILE)
-    return MOIU.test_models_equal(model, model_2, variables, constraints)
+    return MOI.Test.test_models_equal(model, model_2, variables, constraints)
 end
 
 function test_show()
@@ -136,7 +136,7 @@ z in ZeroOne()
 """,
     )
     MOI.set(model_2, MOI.Name(), "stacked_data")
-    return MOIU.test_models_equal(
+    return MOI.Test.test_models_equal(
         model,
         model_2,
         ["x", "y", "z"],
@@ -162,7 +162,7 @@ con1: 1.0 * x >= 1.0
 x in Integer()
 """,
     )
-    return MOIU.test_models_equal(
+    return MOI.Test.test_models_equal(
         model,
         model_2,
         ["x"],
@@ -316,7 +316,7 @@ x >= 1.0
     MOI.write_to_file(model, MPS_TEST_FILE)
     model_2 = MPS.Model()
     MOI.read_from_file(model_2, MPS_TEST_FILE)
-    return MOIU.test_models_equal(
+    return MOI.Test.test_models_equal(
         model,
         model_2,
         ["x", "y", "z"],
@@ -343,7 +343,7 @@ y <= 0.0
     MOI.write_to_file(model, MPS_TEST_FILE)
     model_2 = MPS.Model()
     MOI.read_from_file(model_2, MPS_TEST_FILE)
-    return MOIU.test_models_equal(
+    return MOI.Test.test_models_equal(
         model,
         model_2,
         ["x", "y", "z"],
@@ -371,7 +371,7 @@ w in Interval(4.0, 5.0)
     MOI.write_to_file(model, MPS_TEST_FILE)
     model_2 = MPS.Model()
     MOI.read_from_file(model_2, MPS_TEST_FILE)
-    return MOIU.test_models_equal(
+    return MOI.Test.test_models_equal(
         model,
         model_2,
         ["w", "x", "y", "z"],

--- a/test/FileFormats/SDPA/SDPA.jl
+++ b/test/FileFormats/SDPA/SDPA.jl
@@ -69,7 +69,7 @@ function _test_write_then_read(model_string::String)
         MOI.set(model2, attr, MOIU.operate(-, Float64, obj))
     end
 
-    return MOIU.test_models_equal(model1, model2, args...)
+    return MOI.Test.test_models_equal(model1, model2, args...)
 end
 
 function _test_read(filename::String, model_string::String)
@@ -79,7 +79,7 @@ function _test_read(filename::String, model_string::String)
     model2 = SDPA.Model()
     MOI.read_from_file(model2, filename)
     _set_var_and_con_names(model2)
-    return MOIU.test_models_equal(model1, model2, args...)
+    return MOI.Test.test_models_equal(model1, model2, args...)
 end
 
 function test_show()

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -106,7 +106,7 @@ function test_one_variable()
 
     model2 = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model2, s)
-    MOIU.test_models_equal(
+    MOI.Test.test_models_equal(
         model,
         model2,
         ["x"],
@@ -158,7 +158,7 @@ function test_linear_constraints()
 
     model2 = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model2, s)
-    MOIU.test_models_equal(
+    MOI.Test.test_models_equal(
         model,
         model2,
         ["x", "y"],
@@ -189,7 +189,7 @@ function test_minimization_linear_objective()
 
     model2 = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model2, s)
-    MOIU.test_models_equal(model, model2, ["x", "y"], String[])
+    MOI.Test.test_models_equal(model, model2, ["x", "y"], String[])
     return
 end
 
@@ -215,7 +215,7 @@ function test_maximization_linear_objective()
 
     model2 = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model2, s)
-    MOIU.test_models_equal(model, model2, ["x", "y"], String[])
+    MOI.Test.test_models_equal(model, model2, ["x", "y"], String[])
     return
 end
 
@@ -263,7 +263,7 @@ function test_SecondOrderCone_constraints()
 
     model2 = MOIU.Model{Float64}()
     MOIU.loadfromstring!(model2, s)
-    MOIU.test_models_equal(
+    MOI.Test.test_models_equal(
         model,
         model2,
         ["x", "y", "z"],

--- a/test/deprecate.jl
+++ b/test/deprecate.jl
@@ -84,6 +84,16 @@ function test_copy_to_copy_names()
     return
 end
 
+function test_test_models_equal()
+    dest = MOI.Utilities.Model{Float64}()
+    src = MOI.Utilities.Model{Float64}()
+    @test_logs(
+        (:warn,),
+        MOI.Utilities.test_models_equal(dest, src, String[], String[]),
+    )
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if startswith("$name", "test_")


### PR DESCRIPTION
It was a bit weird having `test_models_equal` as part of `Utilities` instead of `Test`. This also clarifies that it is not a function that works in all cases. It's intended for small models with everything named.