### PR TITLE
Replace filter_constraints with ModelFilter

### DIFF
--- a/docs/src/submodules/Utilities/overview.md
+++ b/docs/src/submodules/Utilities/overview.md
@@ -347,10 +347,7 @@ The [`copy_to`](@ref) operation can now be implemented as follows (assuming that
 the `Model` definition above is in the `Clp` module so that it can be referred
 to as `Model`, to be distinguished with [`Utilities.Model`](@ref)):
 ```julia
-function _copy_to(
-    dest::Optimizer,
-    src::Model
-)
+function _copy_to(dest::Optimizer, src::Model)
     @assert MOI.is_empty(dest)
     A = src.constraints.coefficients
     row_bounds = src.constraints.constants
@@ -394,6 +391,21 @@ function MOI.copy_to(
     _copy_to(dest, model)
     return index_map
 end
+```
+
+## ModelFilter
+
+Utilities provides [`Utilities.ModelFilter`](@ref) as a useful tool to copy a
+subset of a model. For example, given an infeasible model, we can copy the
+irreducible infeasible subsystem (for models implementing
+[`ConstraintConflictStatus`](@ref)) as follows:
+```julia
+my_filter(::Any, ::Any) = true
+function my_filter(::MOI.ListOfConstraintIndices, ci::MOI.ConstraintIndex)
+    status = MOI.get(dest, MOI.ConstraintConflictStatus(), ci)
+    return status != MOI.NOT_IN_CONFLICT
+end
+MOI.copy_to(dest, filtered_src)
 ```
 
 ## Fallbacks

--- a/docs/src/submodules/Utilities/overview.md
+++ b/docs/src/submodules/Utilities/overview.md
@@ -400,13 +400,13 @@ subset of a model. For example, given an infeasible model, we can copy the
 irreducible infeasible subsystem (for models implementing
 [`ConstraintConflictStatus`](@ref)) as follows:
 ```julia
-my_filter(::Any, ::Any) = true
-function my_filter(::MOI.ListOfConstraintIndices, ci::MOI.ConstraintIndex)
+my_filter(::Any) = true
+function my_filter(ci::MOI.ConstraintIndex)
     status = MOI.get(dest, MOI.ConstraintConflictStatus(), ci)
     return status != MOI.NOT_IN_CONFLICT
 end
 filtered_src = MOI.Utilities.ModelFilter(my_filter, src)
-MOI.copy_to(dest, filtered_src)
+index_map = MOI.copy_to(dest, filtered_src)
 ```
 
 ## Fallbacks

--- a/docs/src/submodules/Utilities/overview.md
+++ b/docs/src/submodules/Utilities/overview.md
@@ -405,6 +405,7 @@ function my_filter(::MOI.ListOfConstraintIndices, ci::MOI.ConstraintIndex)
     status = MOI.get(dest, MOI.ConstraintConflictStatus(), ci)
     return status != MOI.NOT_IN_CONFLICT
 end
+filtered_src = MOI.Utilities.ModelFilter(my_filter, src)
 MOI.copy_to(dest, filtered_src)
 ```
 

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -67,6 +67,7 @@ Utilities.latex_formulation
 Utilities.default_copy_to
 Utilities.IndexMap
 Utilities.identity_index_map
+Utilities.ModelFilter
 ```
 
 ## MatrixOfConstraints

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -382,7 +382,7 @@ function MOIU.pass_nonvariable_constraints(
     dest::AbstractBridgeOptimizer,
     src::MOI.ModelLike,
     idxmap::MOIU.IndexMap,
-    constraint_types;
+    constraint_types,
 )
     if Variable.has_bridges(Variable.bridges(dest))
         # The functions may contained bridged variables which needs to be
@@ -409,12 +409,7 @@ function MOIU.pass_nonvariable_constraints(
         idxmap,
         not_bridged_types,
     )
-    MOIU.pass_nonvariable_constraints_fallback(
-        dest,
-        src,
-        idxmap,
-        bridged_types,
-    )
+    MOIU.pass_nonvariable_constraints_fallback(dest, src, idxmap, bridged_types)
     return
 end
 

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -383,7 +383,6 @@ function MOIU.pass_nonvariable_constraints(
     src::MOI.ModelLike,
     idxmap::MOIU.IndexMap,
     constraint_types;
-    filter_constraints::Union{Nothing,Function} = nothing,
 )
     if Variable.has_bridges(Variable.bridges(dest))
         # The functions may contained bridged variables which needs to be
@@ -392,8 +391,7 @@ function MOIU.pass_nonvariable_constraints(
             dest,
             src,
             idxmap,
-            constraint_types;
-            filter_constraints = filter_constraints,
+            constraint_types,
         )
     end
     not_bridged_types = eltype(constraint_types)[]
@@ -409,15 +407,13 @@ function MOIU.pass_nonvariable_constraints(
         dest.model,
         src,
         idxmap,
-        not_bridged_types;
-        filter_constraints = filter_constraints,
+        not_bridged_types,
     )
     MOIU.pass_nonvariable_constraints_fallback(
         dest,
         src,
         idxmap,
-        bridged_types;
-        filter_constraints = filter_constraints,
+        bridged_types,
     )
     return
 end

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -1060,10 +1060,7 @@ function test_model_ModelFilter_AbstractModelAttribute(
     MOI.set(src, MOI.Name(), "src")
     dest = MOI.Utilities.Model{T}()
     MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
-        if item isa MOI.AbstractModelAttribute
-            return item != MOI.Name()
-        end
-        return true
+        return item != MOI.Name()
     end)
     @test MOI.get(dest, MOI.Name()) == ""
     return
@@ -1088,10 +1085,7 @@ function test_model_ModelFilter_AbstractVariableAttribute(
     MOI.set(src, MOI.VariablePrimalStart(), x, 1.0)
     dest = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}())
     index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
-        if item isa MOI.AbstractVariableAttribute
-            return item != MOI.VariableName()
-        end
-        return true
+        return item != MOI.VariableName()
     end)
     @test MOI.get(dest, MOI.VariableName(), index_map[x]) == ""
     @test MOI.get(dest, MOI.VariablePrimalStart(), index_map[x]) == 1.0

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -1144,33 +1144,6 @@ function test_model_ModelFilter_AbstractConstraintAttribute(
 end
 
 """
-    test_model_ModelFilter_ListOfVariableIndices(
-        src::MOI.ModelLike,
-        ::Config{T},
-    ) where {T}
-
-Tests `Utilties.ModelFilter` of `ListOfVariableIndices`.
-"""
-function test_model_ModelFilter_ListOfVariableIndices(
-    src::MOI.ModelLike,
-    ::Config{T},
-) where {T}
-    x = MOI.add_variables(src, 4)
-    dest = MOI.Utilities.Model{T}()
-    index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
-        if item isa MOI.VariableIndex
-            return isodd(item.value)
-        end
-        return true
-    end)
-    @test MOI.get(dest, MOI.NumberOfVariables()) == 2
-    for xi in x
-        @test haskey(index_map, xi) == isodd(xi.value)
-    end
-    return
-end
-
-"""
     test_model_ModelFilter_ListOfConstraintIndices(
         src::MOI.ModelLike,
         ::Config{T},

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -1043,3 +1043,210 @@ function test_model_ListOfConstraintAttributesSet(
     ) == []
     return
 end
+
+"""
+    test_model_ModelFilter_AbstractModelAttribute(
+        src::MOI.ModelLike,
+        ::Config{T},
+    ) where {T}
+
+Tests `Utilties.ModelFilter` of `AbstractModelAttribute`.
+"""
+function test_model_ModelFilter_AbstractModelAttribute(
+    src::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    @requires MOI.supports(src, MOI.Name())
+    MOI.set(src, MOI.Name(), "src")
+    dest = MOI.Utilities.Model{T}()
+    MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
+        if item isa MOI.AbstractModelAttribute
+            return item != MOI.Name()
+        end
+        return true
+    end)
+    @test MOI.get(dest, MOI.Name()) == ""
+    return
+end
+
+"""
+    test_model_ModelFilter_AbstractVariableAttribute(
+        src::MOI.ModelLike,
+        ::Config{T},
+    ) where {T}
+
+Tests `Utilties.ModelFilter` of `AbstractVariableAttribute`.
+"""
+function test_model_ModelFilter_AbstractVariableAttribute(
+    src::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    @requires MOI.supports(src, MOI.VariableName(), MOI.VariableIndex)
+    @requires MOI.supports(src, MOI.VariablePrimalStart(), MOI.VariableIndex)
+    x = MOI.add_variable(src)
+    MOI.set(src, MOI.VariableName(), x, "x")
+    MOI.set(src, MOI.VariablePrimalStart(), x, 1.0)
+    dest = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}())
+    index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
+        if item isa MOI.AbstractVariableAttribute
+            return item != MOI.VariableName()
+        end
+        return true
+    end)
+    @test MOI.get(dest, MOI.VariableName(), index_map[x]) == ""
+    @test MOI.get(dest, MOI.VariablePrimalStart(), index_map[x]) == 1.0
+    return
+end
+
+"""
+    test_model_ModelFilter_AbstractConstraintAttribute(
+        src::MOI.ModelLike,
+        ::Config{T},
+    ) where {T}
+
+Tests `Utilties.ModelFilter` of `AbstractConstraintAttribute`.
+"""
+function test_model_ModelFilter_AbstractConstraintAttribute(
+    src::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    @requires(
+        MOI.supports(
+            src,
+            MOI.ConstraintName(),
+            MOI.ConstraintIndex{MOI.VectorOfVariables,MOI.Nonnegatives},
+        ),
+    )
+    @requires(
+        MOI.supports(
+            src,
+            MOI.ConstraintDualStart(),
+            MOI.ConstraintIndex{MOI.VectorOfVariables,MOI.Nonnegatives},
+        ),
+    )
+    @requires(
+        MOI.supports_constraint(src, MOI.VectorOfVariables, MOI.Nonnegatives),
+    )
+    x = MOI.add_variable(src)
+    c = MOI.add_constraint(src, MOI.VectorOfVariables([x]), MOI.Nonnegatives(1))
+    MOI.set(src, MOI.ConstraintName(), c, "c")
+    MOI.set(src, MOI.ConstraintDualStart(), c, [1.0])
+    dest = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}())
+    index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
+        if item isa MOI.AbstractConstraintAttribute
+            return item != MOI.ConstraintName()
+        end
+        return true
+    end)
+    @test MOI.get(dest, MOI.ConstraintName(), index_map[c]) == ""
+    @test MOI.get(dest, MOI.ConstraintDualStart(), index_map[c]) == [1.0]
+    return
+end
+
+"""
+    test_model_ModelFilter_ListOfVariableIndices(
+        src::MOI.ModelLike,
+        ::Config{T},
+    ) where {T}
+
+Tests `Utilties.ModelFilter` of `ListOfVariableIndices`.
+"""
+function test_model_ModelFilter_ListOfVariableIndices(
+    src::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    x = MOI.add_variables(src, 4)
+    dest = MOI.Utilities.Model{T}()
+    index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
+        if item isa MOI.VariableIndex
+            return isodd(item.value)
+        end
+        return true
+    end)
+    @test MOI.get(dest, MOI.NumberOfVariables()) == 2
+    for xi in x
+        @test haskey(index_map, xi) == isodd(xi.value)
+    end
+    return
+end
+
+"""
+    test_model_ModelFilter_ListOfConstraintIndices(
+        src::MOI.ModelLike,
+        ::Config{T},
+    ) where {T}
+
+Tests `Utilties.ModelFilter` of `ListOfConstraintIndices`.
+"""
+function test_model_ModelFilter_ListOfConstraintIndices(
+    src::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    @requires(
+        MOI.supports_constraint(src, MOI.SingleVariable, MOI.GreaterThan{T}),
+    )
+    x = MOI.add_variables(src, 4)
+    MOI.add_constraint.(src, MOI.SingleVariable.(x), MOI.GreaterThan(zero(T)))
+    dest = MOI.Utilities.Model{T}()
+    index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
+        if item isa MOI.ConstraintIndex
+            return isodd(item.value)
+        end
+        return true
+    end)
+    @test MOI.get(dest, MOI.NumberOfVariables()) == 4
+    @test MOI.get(
+        dest,
+        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}(),
+    ) == 2
+    for xi in x
+        @test haskey(index_map, xi)
+        ci =
+            MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{T}}(xi.value)
+        @test haskey(index_map, ci) == isodd(xi.value)
+    end
+    return
+end
+
+"""
+    test_model_ModelFilter_ListOfConstraintTypesPresent(
+        src::MOI.ModelLike,
+        ::Config{T},
+    ) where {T}
+
+Tests `Utilties.ModelFilter` of `ListOfConstraintTypesPresent`.
+"""
+function test_model_ModelFilter_ListOfConstraintTypesPresent(
+    src::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    @requires(
+        MOI.supports_constraint(src, MOI.SingleVariable, MOI.GreaterThan{T}),
+    )
+    @requires(
+        MOI.supports_constraint(src, MOI.SingleVariable, MOI.LessThan{T}),
+    )
+    x = MOI.add_variables(src, 4)
+    MOI.add_constraint.(src, MOI.SingleVariable.(x), MOI.GreaterThan(zero(T)))
+    MOI.add_constraint.(src, MOI.SingleVariable.(x), MOI.LessThan(one(T)))
+    dest = MOI.Utilities.Model{T}()
+    index_map = MOI.copy_to(
+        dest,
+        MOI.Utilities.ModelFilter(src) do item
+            if item isa Tuple{Type,Type}
+                return item == (MOI.SingleVariable, MOI.LessThan{T})
+            end
+            return true
+        end,
+    )
+    @test MOI.get(dest, MOI.NumberOfVariables()) == 4
+    @test MOI.get(
+        dest,
+        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}(),
+    ) == 0
+    @test MOI.get(
+        dest,
+        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{T}}(),
+    ) == 4
+    return
+end

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -1150,10 +1150,10 @@ function test_model_ModelFilter_ListOfConstraintIndices(
     ::Config{T},
 ) where {T}
     @requires(
-        MOI.supports_constraint(src, MOI.SingleVariable, MOI.GreaterThan{T}),
+        MOI.supports_constraint(src, MOI.VariableIndex, MOI.GreaterThan{T}),
     )
     x = MOI.add_variables(src, 4)
-    MOI.add_constraint.(src, MOI.SingleVariable.(x), MOI.GreaterThan(zero(T)))
+    MOI.add_constraint.(src, x, MOI.GreaterThan(zero(T)))
     dest = MOI.Utilities.Model{T}()
     index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
         if item isa MOI.ConstraintIndex
@@ -1164,12 +1164,12 @@ function test_model_ModelFilter_ListOfConstraintIndices(
     @test MOI.get(dest, MOI.NumberOfVariables()) == 4
     @test MOI.get(
         dest,
-        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}(),
+        MOI.NumberOfConstraints{MOI.VariableIndex,MOI.GreaterThan{T}}(),
     ) == 2
     for xi in x
         @test haskey(index_map, xi)
         ci =
-            MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{T}}(xi.value)
+            MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{T}}(xi.value)
         @test haskey(index_map, ci) == isodd(xi.value)
     end
     return
@@ -1188,20 +1188,20 @@ function test_model_ModelFilter_ListOfConstraintTypesPresent(
     ::Config{T},
 ) where {T}
     @requires(
-        MOI.supports_constraint(src, MOI.SingleVariable, MOI.GreaterThan{T}),
+        MOI.supports_constraint(src, MOI.VariableIndex, MOI.GreaterThan{T}),
     )
     @requires(
-        MOI.supports_constraint(src, MOI.SingleVariable, MOI.LessThan{T}),
+        MOI.supports_constraint(src, MOI.VariableIndex, MOI.LessThan{T}),
     )
     x = MOI.add_variables(src, 4)
-    MOI.add_constraint.(src, MOI.SingleVariable.(x), MOI.GreaterThan(zero(T)))
-    MOI.add_constraint.(src, MOI.SingleVariable.(x), MOI.LessThan(one(T)))
+    MOI.add_constraint.(src, x, MOI.GreaterThan(zero(T)))
+    MOI.add_constraint.(src, x, MOI.LessThan(one(T)))
     dest = MOI.Utilities.Model{T}()
     index_map = MOI.copy_to(
         dest,
         MOI.Utilities.ModelFilter(src) do item
             if item isa Tuple{Type,Type}
-                return item == (MOI.SingleVariable, MOI.LessThan{T})
+                return item == (MOI.VariableIndex, MOI.LessThan{T})
             end
             return true
         end,
@@ -1209,11 +1209,11 @@ function test_model_ModelFilter_ListOfConstraintTypesPresent(
     @test MOI.get(dest, MOI.NumberOfVariables()) == 4
     @test MOI.get(
         dest,
-        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{T}}(),
+        MOI.NumberOfConstraints{MOI.VariableIndex,MOI.GreaterThan{T}}(),
     ) == 0
     @test MOI.get(
         dest,
-        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.LessThan{T}}(),
+        MOI.NumberOfConstraints{MOI.VariableIndex,MOI.LessThan{T}}(),
     ) == 4
     return
 end

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -1168,8 +1168,7 @@ function test_model_ModelFilter_ListOfConstraintIndices(
     ) == 2
     for xi in x
         @test haskey(index_map, xi)
-        ci =
-            MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{T}}(xi.value)
+        ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{T}}(xi.value)
         @test haskey(index_map, ci) == isodd(xi.value)
     end
     return
@@ -1190,9 +1189,7 @@ function test_model_ModelFilter_ListOfConstraintTypesPresent(
     @requires(
         MOI.supports_constraint(src, MOI.VariableIndex, MOI.GreaterThan{T}),
     )
-    @requires(
-        MOI.supports_constraint(src, MOI.VariableIndex, MOI.LessThan{T}),
-    )
+    @requires(MOI.supports_constraint(src, MOI.VariableIndex, MOI.LessThan{T}))
     x = MOI.add_variables(src, 4)
     MOI.add_constraint.(src, x, MOI.GreaterThan(zero(T)))
     MOI.add_constraint.(src, x, MOI.LessThan(one(T)))

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -249,16 +249,14 @@ function pass_nonvariable_constraints(
     dest::CachingOptimizer,
     src::MOI.ModelLike,
     idxmap::IndexMap,
-    constraint_types;
-    filter_constraints::Union{Nothing,Function} = nothing,
+    constraint_types,
 )
     dest.state == ATTACHED_OPTIMIZER && reset_optimizer(dest)
     return pass_nonvariable_constraints(
         dest.model_cache,
         src,
         idxmap,
-        constraint_types;
-        filter_constraints = filter_constraints,
+        constraint_types,
     )
 end
 function final_touch(m::CachingOptimizer, index_map)

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -467,10 +467,7 @@ Use the `do` syntax to provide a single function.
 
 ```julia
 filtered_src = MOI.Utilities.ModelFilter(src) do item
-    if item isa Tuple{Type,Type}
-        return item != (MOI.SingleVariable, MOI.Integer)
-    end
-    return attr != MOI.ListOfConstraintIndices{MOI.SingleVariable,MOI.Integer}()
+    return item != (MOI.VariableIndex, MOI.Integer)
 end
 MOI.copy_to(dest, filtered_src)
 ```

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -556,7 +556,7 @@ end
 function MOI.is_empty(model::ModelFilter)
     if MOI.is_empty(model.inner)
         return true
-    elseif MOI.get(model, MOI.NumberOfVariables()) > 0
+    elseif MOI.get(model.inner, MOI.NumberOfVariables()) > 0
         return false
     elseif length(MOI.get(model, MOI.ListOfModelAttributesSet())) > 0
         return false

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -558,11 +558,6 @@ function MOI.is_empty(model::ModelFilter)
     elseif length(MOI.get(model, MOI.ListOfModelAttributesSet())) > 0
         return false
     end
-    for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
-        if MOI.get(model, MOI.NumberOfConstraints{F,S}()) > 0
-            return false
-        end
-    end
     return true
 end
 

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -438,16 +438,23 @@ two arguments: an attribute (see below) and an element from the list returned by
 that attribute. It returns `true` if the element should be included in `dest`,
 and `false` otherwise.
 
-The attributes that are filtered are:
+The components that are filtered are:
 
- * `MOI.ListOfConstraintAttributesSet`
- * `MOI.ListOfConstraintIndices`
- * `MOI.ListOfConstraintTypesPresent`
- * `MOI.ListOfModelAttributesSet`
- * `MOI.ListOfVariableAttributesSet`
- * `MOI.ListOfVariableIndices`
+ * Entire constraint types via:
+   * `MOI.ListOfConstraintTypesPresent`
+ * Individual constraints via:
+   * `MOI.ListOfConstraintIndices{F,S}`
+ * Specific attributes via:
+   * `MOI.ListOfModelAttributesSet`
+   * `MOI.ListOfConstraintAttributesSet`
+   * `MOI.ListOfVariableAttributesSet`
 
-See the examples for examples of how this works.
+!!! warning
+    The list of attributes filtered may change in a future release. You should
+    write functions that are generic and not limited to the five types listed
+    above.
+
+See below for examples of how this works.
 
 !!! note
     This layer has a limited scope. It is intended by be used in conjunction
@@ -507,7 +514,6 @@ function MOI.get(
         MOI.ListOfConstraintTypesPresent,
         MOI.ListOfModelAttributesSet,
         MOI.ListOfVariableAttributesSet,
-        MOI.ListOfVariableIndices,
     },
 )
     return filter(model.filter, MOI.get(model.inner, attr))

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -444,9 +444,9 @@ The attributes that are filtered are:
 
  * `MOI.ListOfModelAttributesSet`
  * `MOI.ListOfVariableAttributesSet`
+ * `MOI.ListOfVariableIndices`
  * `MOI.ListOfConstraintAttributesSet`
  * `MOI.ListOfConstraintIndices`
- * `MOI.ListOfVariableIndices`
 
 See the examples for examples of how this works.
 

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -433,10 +433,11 @@ end
 """
     ModelFilter(filter::Function, model::MOI.ModelLike)
 
-A layer to filter out various components of `model`. The filter function takes
-two arguments: an attribute (see below) and an element from the list returned by
-that attribute. It returns `true` if the element should be included in `dest`,
-and `false` otherwise.
+A layer to filter out various components of `model`.
+
+The filter function takes a single argument, which is eacy element from the list
+returned by the attributes below. It returns `true` if the element should be
+visible in the filtered model and `false` otherwise.
 
 The components that are filtered are:
 
@@ -452,7 +453,7 @@ The components that are filtered are:
 !!! warning
     The list of attributes filtered may change in a future release. You should
     write functions that are generic and not limited to the five types listed
-    above.
+    above. Thus, you should probably define a fallback `filter(::Any) = true`.
 
 See below for examples of how this works.
 
@@ -479,9 +480,9 @@ MOI.copy_to(dest, filtered_src)
 Use type dispatch to simplify the implementation:
 
 ```julia
-my_filter(::Any, ::Any) = true
-my_filter(::MOI.ListOfModelAttributesSet, ::MOI.VariableName) = false
-my_filter(::MOI.ListOfConstraintAttributesSet, ::MOI.ConstraintName) = false
+my_filter(::Any) = true  # Note the generic fallback!
+my_filter(::MOI.VariableName) = false
+my_filter(::MOI.ConstraintName) = false
 filtered_src = MOI.Utilities.ModelFilter(my_filter, src)
 MOI.copy_to(dest, filtered_src)
 ```
@@ -489,8 +490,8 @@ MOI.copy_to(dest, filtered_src)
 ## Example: copy irreducible infeasible subsystem
 
 ```julia
-my_filter(::Any, ::Any) = true
-function my_filter(::MOI.ListOfConstraintIndices, ci::MOI.ConstraintIndex)
+my_filter(::Any) = true  # Note the generic fallback!
+function my_filter(ci::MOI.ConstraintIndex)
     status = MOI.get(dest, MOI.ConstraintConflictStatus(), ci)
     return status != MOI.NOT_IN_CONFLICT
 end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -524,12 +524,8 @@ function MOI.get(model::ModelFilter, attr::MOI.AbstractModelAttribute)
 end
 
 # !!! warning
-#     Slow implementations, but we need to report the number of variables and
-#     constraints in the filtered model, not in the `.inner`.
-
-function MOI.get(model::ModelFilter, ::MOI.NumberOfVariables)
-    return length(MOI.get(model, MOI.ListOfVariableIndices()))
-end
+#     Slow implementations, but we need to report the number of constraints in
+#     the filtered model, not in the `.inner`.
 
 function MOI.get(model::ModelFilter, ::MOI.NumberOfConstraints{F,S}) where {F,S}
     return length(MOI.get(model, MOI.ListOfConstraintIndices{F,S}()))

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -430,8 +430,6 @@ function default_copy_to(dest::MOI.ModelLike, src::MOI.ModelLike)
     return index_map
 end
 
-_always_true(::Any) = true
-
 """
     ModelFilter(filter::Function, model::MOI.ModelLike)
 

--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -388,7 +388,6 @@ function _allocate_constraints(
     index_map,
     ::Type{F},
     ::Type{S},
-    filter_constraints::Union{Nothing,Function},
 ) where {T,F,S}
     i = set_index(model.sets, S)
     if i === nothing || F != _affine_function_type(T, S)
@@ -398,9 +397,6 @@ function _allocate_constraints(
         src,
         MOI.ListOfConstraintIndices{_affine_function_type(T, S),S}(),
     )
-    if filter_constraints !== nothing
-        filter!(filter_constraints, cis_src)
-    end
     for ci_src in cis_src
         func = MOI.get(src, MOI.CanonicalConstraintFunction(), ci_src)
         set = MOI.get(src, MOI.ConstraintSet(), ci_src)
@@ -459,11 +455,10 @@ function pass_nonvariable_constraints(
     dest::MatrixOfConstraints,
     src::MOI.ModelLike,
     index_map::IndexMap,
-    constraint_types;
-    filter_constraints::Union{Nothing,Function} = nothing,
+    constraint_types,
 )
     for (F, S) in constraint_types
-        _allocate_constraints(dest, src, index_map, F, S, filter_constraints)
+        _allocate_constraints(dest, src, index_map, F, S)
     end
     return
 end

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -530,15 +530,13 @@ function pass_nonvariable_constraints(
     dest::AbstractModel,
     src::MOI.ModelLike,
     idxmap::IndexMap,
-    constraint_types;
-    filter_constraints::Union{Nothing,Function} = nothing,
+    constraint_types,
 )
     return pass_nonvariable_constraints(
         dest.constraints,
         src,
         idxmap,
-        constraint_types;
-        filter_constraints = filter_constraints,
+        constraint_types,
     )
 end
 

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -108,12 +108,7 @@ function pass_nonvariable_constraints(
             push!(unsupported_types, (F, S))
         end
     end
-    pass_nonvariable_constraints(
-        dest.model,
-        src,
-        idxmap,
-        supported_types,
-    )
+    pass_nonvariable_constraints(dest.model, src, idxmap, supported_types)
     return pass_nonvariable_constraints_fallback(
         dest,
         src,

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -97,8 +97,7 @@ function pass_nonvariable_constraints(
     dest::UniversalFallback,
     src::MOI.ModelLike,
     idxmap::IndexMap,
-    constraint_types;
-    filter_constraints::Union{Nothing,Function} = nothing,
+    constraint_types,
 )
     supported_types = eltype(constraint_types)[]
     unsupported_types = eltype(constraint_types)[]
@@ -113,15 +112,13 @@ function pass_nonvariable_constraints(
         dest.model,
         src,
         idxmap,
-        supported_types;
-        filter_constraints = filter_constraints,
+        supported_types,
     )
     return pass_nonvariable_constraints_fallback(
         dest,
         src,
         idxmap,
-        unsupported_types;
-        filter_constraints = filter_constraints,
+        unsupported_types,
     )
 end
 

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -614,12 +614,12 @@ end
 
 function test_filtering_copy_empty()
     src = MOI.Utilities.Model{Float64}()
-    x = MOI.add_variable(src)
+    MOI.set(src, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     model = MOI.Utilities.ModelFilter(src) do item
-        return !(item isa MOI.VariableIndex)
+        return item !== MOI.ObjectiveSense()
     end
     @test MOI.is_empty(model)
-    MOI.set(src, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.add_variable(src)
     @test !MOI.is_empty(model)
     MOI.empty!(model)
     @test MOI.is_empty(model)
@@ -678,23 +678,6 @@ function test_filtering_copy_AbstractConstraintAttribute()
     index_map = MOI.copy_to(dest, filtered_src)
     @test MOI.get(dest, MOI.ConstraintName(), index_map[c]) == ""
     @test MOI.get(dest, MOI.ConstraintDualStart(), index_map[c]) == [1.0]
-    return
-end
-
-function test_filtering_copy_ListOfVariableIndices()
-    src = MOI.Utilities.Model{Float64}()
-    x = MOI.add_variables(src, 4)
-    dest = MOI.Utilities.Model{Float64}()
-    index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
-        if item isa MOI.VariableIndex
-            return isodd(item.value)
-        end
-        return true
-    end)
-    @test MOI.get(dest, MOI.NumberOfVariables()) == 2
-    for xi in x
-        @test haskey(index_map, xi) == isodd(xi.value)
-    end
     return
 end
 

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -703,12 +703,14 @@ function test_filtering_copy_ListOfConstraintIndices()
     x = MOI.add_variables(src, 4)
     MOI.add_constraint.(src, MOI.SingleVariable.(x), MOI.GreaterThan(0.0))
     dest = MOI.Utilities.Model{Float64}()
-    index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do item
+    filtered_src = MOI.Utilities.ModelFilter(src) do item
         if item isa MOI.ConstraintIndex
             return isodd(item.value)
         end
         return true
-    end)
+    end
+    @test !MOI.is_empty(filtered_src)
+    index_map = MOI.copy_to(dest, filtered_src)
     @test MOI.get(dest, MOI.NumberOfVariables()) == 4
     @test MOI.get(
         dest,

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -623,6 +623,8 @@ function test_filtering_copy_empty()
     @test !MOI.is_empty(model)
     MOI.empty!(model)
     @test MOI.is_empty(model)
+    MOI.set(src, MOI.Name(), "Model")
+    @test !MOI.is_empty(model)
     return
 end
 

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -627,10 +627,11 @@ function test_filtering_copy_AbstractModelAttribute()
 end
 
 function test_filtering_copy_AbstractVariableAttribute()
-    src = MOI.Utilities.Model{Float64}()
+    src = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     x = MOI.add_variable(src)
     MOI.set(src, MOI.VariableName(), x, "x")
-    dest = MOI.Utilities.Model{Float64}()
+    MOI.set(src, MOI.VariablePrimalStart(), x, 1.0)
+    dest = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do attr, item
         if attr != MOI.ListOfVariableAttributesSet()
             return true
@@ -638,22 +639,25 @@ function test_filtering_copy_AbstractVariableAttribute()
         return item != MOI.VariableName()
     end)
     @test MOI.get(dest, MOI.VariableName(), index_map[x]) == ""
+    @test MOI.get(dest, MOI.VariablePrimalStart(), index_map[x]) == 1.0
     return
 end
 
 function test_filtering_copy_AbstractConstraintAttribute()
-    src = MOI.Utilities.Model{Float64}()
+    src = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     x = MOI.add_variable(src)
     c = MOI.add_constraint(src, MOI.VectorOfVariables([x]), MOI.Nonnegatives(1))
     MOI.set(src, MOI.ConstraintName(), c, "c")
-    dest = MOI.Utilities.Model{Float64}()
+    MOI.set(src, MOI.ConstraintDualStart(), c, [1.0])
+    dest = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     index_map = MOI.copy_to(dest, MOI.Utilities.ModelFilter(src) do attr, item
         if !(attr isa MOI.ListOfConstraintAttributesSet)
             return true
         end
         return item != MOI.ConstraintName()
     end)
-    @test MOI.get(dest, MOI.VariableName(), index_map[x]) == ""
+    @test MOI.get(dest, MOI.ConstraintName(), index_map[c]) == ""
+    @test MOI.get(dest, MOI.ConstraintDualStart(), index_map[c]) == [1.0]
     return
 end
 

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -699,6 +699,10 @@ function test_filtering_copy_ListOfConstraintIndices()
         dest,
         MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}(),
     ) == 2
+    @test MOI.get(
+        filtered_src,
+        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}(),
+    ) == 2
     for xi in x
         @test haskey(index_map, xi)
         ci = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -686,7 +686,7 @@ end
 function test_filtering_copy_ListOfConstraintIndices()
     src = MOI.Utilities.Model{Float64}()
     x = MOI.add_variables(src, 4)
-    MOI.add_constraint.(src, MOI.SingleVariable.(x), MOI.GreaterThan(0.0))
+    MOI.add_constraint.(src, x, MOI.GreaterThan(0.0))
     dest = MOI.Utilities.Model{Float64}()
     filtered_src = MOI.Utilities.ModelFilter(src) do item
         if item isa MOI.ConstraintIndex
@@ -699,15 +699,15 @@ function test_filtering_copy_ListOfConstraintIndices()
     @test MOI.get(dest, MOI.NumberOfVariables()) == 4
     @test MOI.get(
         dest,
-        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}(),
+        MOI.NumberOfConstraints{MOI.VariableIndex,MOI.GreaterThan{Float64}}(),
     ) == 2
     @test MOI.get(
         filtered_src,
-        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}(),
+        MOI.NumberOfConstraints{MOI.VariableIndex,MOI.GreaterThan{Float64}}(),
     ) == 2
     for xi in x
         @test haskey(index_map, xi)
-        ci = MOI.ConstraintIndex{MOI.SingleVariable,MOI.GreaterThan{Float64}}(
+        ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.GreaterThan{Float64}}(
             xi.value,
         )
         @test haskey(index_map, ci) == isodd(xi.value)
@@ -718,14 +718,14 @@ end
 function test_filtering_copy_ListOfConstraintTypesPresent()
     src = MOI.Utilities.Model{Float64}()
     x = MOI.add_variables(src, 4)
-    MOI.add_constraint.(src, MOI.SingleVariable.(x), MOI.GreaterThan(0.0))
-    MOI.add_constraint.(src, MOI.SingleVariable.(x), MOI.ZeroOne())
+    MOI.add_constraint.(src, x, MOI.GreaterThan(0.0))
+    MOI.add_constraint.(src, x, MOI.ZeroOne())
     dest = MOI.Utilities.Model{Float64}()
     index_map = MOI.copy_to(
         dest,
         MOI.Utilities.ModelFilter(src) do item
             if item isa Tuple{Type,Type}
-                return item == (MOI.SingleVariable, MOI.ZeroOne)
+                return item == (MOI.VariableIndex, MOI.ZeroOne)
             end
             return true
         end,
@@ -733,11 +733,11 @@ function test_filtering_copy_ListOfConstraintTypesPresent()
     @test MOI.get(dest, MOI.NumberOfVariables()) == 4
     @test MOI.get(
         dest,
-        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.GreaterThan{Float64}}(),
+        MOI.NumberOfConstraints{MOI.VariableIndex,MOI.GreaterThan{Float64}}(),
     ) == 0
     @test MOI.get(
         dest,
-        MOI.NumberOfConstraints{MOI.SingleVariable,MOI.ZeroOne}(),
+        MOI.NumberOfConstraints{MOI.VariableIndex,MOI.ZeroOne}(),
     ) == 4
     return
 end

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -605,7 +605,7 @@ function test_filtering_copy()
 
     # Perform the copy.
     dst = OrderConstrainedVariablesModel()
-    index_map = MOI.copy_to(dst, MOI.Utilities.FilterModel(f, src))
+    index_map = MOI.copy_to(dst, MOI.Utilities.ModelFilter(f, src))
 
     @test typeof(c1) == typeof(dst.constraintIndices[1])
     @test length(dst.constraintIndices) == 1
@@ -677,7 +677,7 @@ function test_BoundModel_filtering_copy()
 
     # Perform the filtered copy. This should not throw an error.
     dst = BoundModel()
-    MOI.copy_to(dst, MOI.Utilities.FilterModel(f, src))
+    MOI.copy_to(dst, MOI.Utilities.ModelFilter(f, src))
     @test MOI.get(
         dst,
         MOI.NumberOfConstraints{MOI.VariableIndex,MOI.LessThan{Float64}}(),


### PR DESCRIPTION
The `filter_constraints` argument was always a bit weird. This goes to a model-wrapper approach that @blegat created instead.

Closes #1554