### PR TITLE
Add operator fallbacks for pure SingleVariable operations

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1922,21 +1922,35 @@ function Base.:-(α::Number, f::MOI.SingleVariable)
     return operate(-, typeof(α), α, f)
 end
 
-# SingleVariable defaults to Float64
-function Base.:+(arg::MOI.SingleVariable, args::MOI.SingleVariable...)
-    return operate(+, Float64, arg, args...)
+function Base.:+(::MOI.SingleVariable, ::MOI.SingleVariable...)
+    return error(
+        "Unable to add SingleVariables together because no coefficient type " *
+        "is specified. Instead of `x + y`, convert one of the terms to a " *
+        "`ScalarAffineFunction` first by left-multiplying by `one(T)` where " *
+        "`T` is the coefficient type For example: `1.0 * x + y`.",
+    )
 end
 
-function Base.:-(arg::MOI.SingleVariable, args::MOI.SingleVariable...)
-    return operate(-, Float64, arg, args...)
+function Base.:-(::MOI.SingleVariable, ::MOI.SingleVariable...)
+    return error(
+        "Unable to subtract SingleVariables together because no coefficient " *
+        "type is specified. Instead of `x - y`, convert one of the terms to a " *
+        "`ScalarAffineFunction` first by left-multiplying by `one(T)` where " *
+        "`T` is the coefficient type For example: `1.0 * x - y`.",
+    )
 end
 
 function Base.:*(
-    arg::MOI.SingleVariable,
-    arg2::MOI.SingleVariable,
-    args::MOI.SingleVariable...,
+    ::MOI.SingleVariable,
+    ::MOI.SingleVariable,
+    ::MOI.SingleVariable...,
 )
-    return operate(*, Float64, arg, arg2, args...)
+    return error(
+        "Unable to multiply SingleVariables together because no coefficient " *
+        "type is specified. Instead of `x * y`, convert one of the terms to a " *
+        "`ScalarAffineFunction` first by left-multiplying by `one(T)` where " *
+        "`T` is the coefficient type For example: `1.0 * x * y`.",
+    )
 end
 
 # Vector +/-

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -1788,9 +1788,9 @@ Test the three Base.:(op) fallbacks for pure SingleVariable operations.
 """
 function test_SingleVariable_operators()
     x = MOI.SingleVariable(MOI.VariableIndex(1))
-    @test x + x ≈ 1.0 * x + 1.0 * x
-    @test x - x ≈ 1.0 * x - 1.0 * x
-    @test x * x ≈ 1.0 * x * 1.0 * x
+    @test_throws ErrorException x + x
+    @test_throws ErrorException x - x
+    @test_throws ErrorException x * x
     return
 end
 


### PR DESCRIPTION
We have a choice: we can either throw an error, or choose a default coefficient type. I went with the default coefficient type of `Float64` since that seems to be what most people would expect to happen.

Closes #1555