### PR TITLE
[docs] move NEWS to the documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,6 @@
+MathOptInterface (MOI release notes)
+====================================
+
+Release notes for MathOptInterface have been moved to the documentation.
+
+See https://jump.dev/MathOptInterface.jl/latest/release_notes/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-MathOptInterface (MOI release notes)
+MathOptInterface (MOI) release notes
 ====================================
 
 Release notes for MathOptInterface have been moved to the documentation.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -72,6 +72,7 @@ makedocs(
                 "API Reference" => "submodules/Test/reference.md",
             ],
         ],
+        "Release notes" => "release_notes.md",
     ],
 )
 

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -3,7 +3,7 @@
 v0.10.0 (unreleased)
 ---------------------------
 
-**MOI is a significant breaking release. There are a large number of
+**MOI v0.10 is a significant breaking release. There are a large number of
 user-visible breaking changes and code refactors, as well as a substantial
 number of new features.**
 

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,8 +1,7 @@
-MathOptInterface (MOI) release notes
-====================================
+# Release notes
 
-v0.10.0 (In development)
-------------------------
+v0.10.0 (unreleased)
+---------------------------
 
 **MOI is a significant breaking release. There are a large number of
 user-visible breaking changes and code refactors, as well as a substantial


### PR DESCRIPTION
The Python ecosystem do this. I think it works quite well: http://xarray.pydata.org/en/latest/whats-new.html

It's doubly important for this release of MOI because there are such a large number of changes.