### PR TITLE
Replace copy_to_and_optimize! with optimize_model!

### DIFF
--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -60,7 +60,7 @@ AbstractOptimizer
 OptimizerWithAttributes
 optimize!
 instantiate
-copy_to_and_optimize!
+optimize_model!
 ```
 
 ## Optimizer attributes

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -60,7 +60,6 @@ AbstractOptimizer
 OptimizerWithAttributes
 optimize!
 instantiate
-optimize_model!
 ```
 
 ## Optimizer attributes

--- a/docs/src/tutorials/implementing.md
+++ b/docs/src/tutorials/implementing.md
@@ -271,7 +271,7 @@ All `Optimizer`s must implement the following methods:
 
  * [`empty!`](@ref)
  * [`is_empty`](@ref)
- * [`optimize!`](@ref) (or [`optimize_model!`](@ref))
+ * [`optimize!`](@ref)
 
 Other methods, detailed below, are optional or depend on how you implement the
 interface.

--- a/docs/src/tutorials/implementing.md
+++ b/docs/src/tutorials/implementing.md
@@ -271,7 +271,7 @@ All `Optimizer`s must implement the following methods:
 
  * [`empty!`](@ref)
  * [`is_empty`](@ref)
- * [`optimize!`](@ref) (or [`copy_to_and_optimize!`](@ref))
+ * [`optimize!`](@ref) (or [`optimize_model!`](@ref))
 
 Other methods, detailed below, are optional or depend on how you implement the
 interface.

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -171,7 +171,7 @@ end
 
 A single call similar to calling [`copy_to`](@ref) followed by
 [`optimize!`](@ref). Return an [`IndexMap`](@ref) and a `Bool` `copied`.
-If `copied` is `true`, `src` was copied to `dest` so [`optimize!](@ref)
+If `copied` is `true`, `src` was copied to `dest` so [`optimize!`](@ref)
 can be called again on `dest`, e.g., after changing the starting values
 or optimizer attributes. On the other hand, if `copied` is `false`, the
 model was not copied to `dest` so calling [`optimize!`](@ref) is not allowed.

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -202,7 +202,7 @@ An optimizer can decide to implement this function instead of implementing
 [`copy_to`](@ref) and [`optimize!`](@ref) individually.
 
 !!! warning
-    This is an experimental new feature of MOI v0.10 that may break in MOI v1.0.
+    This function will be removed in MOI v1.0, use `optimize_model!` instead.
 """
 function copy_to_and_optimize!(dest, src) # TODO remove in favor of `optimize_model!`
     # The arguments above are untyped to avoid ambiguities.

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -164,6 +164,32 @@ function copy_to(dest, src; kwargs...)
 end
 
 """
+    optimize_model!(
+        dest::AbstractOptimizer,
+        src::ModelLike,
+    )::IndexMap
+
+A single call similar to calling [`copy_to`](@ref) followed by
+[`optimize!`](@ref). Return an [`IndexMap`](@ref) and a `Bool` `copied`.
+If `copied` is `true`, `src` was copied to `dest` so [`optimize!](@ref)
+can be called again on `dest`, e.g., after changing the starting values
+or optimizer attributes. On the other hand, if `copied` is `false`, the
+model was not copied to `dest` so calling [`optimize!`](@ref) is not allowed.
+However, attributes for which [`is_set_by_optimize`](@ref) is true can be
+queried from `dest`.
+
+An optimizer can decide to implement this function instead of implementing
+[`copy_to`](@ref) and [`optimize!`](@ref) individually.
+
+!!! warning
+    This is an experimental new feature of MOI v0.10.1 that may break in MOI v1.0.
+"""
+function optimize_model!(dest, src)
+    # The arguments above are untyped to avoid ambiguities.
+    return copy_to_and_optimize!(dest, src), true
+end
+
+"""
     copy_to_and_optimize!(
         dest::AbstractOptimizer,
         src::ModelLike,
@@ -172,15 +198,13 @@ end
 A single call equivalent to calling [`copy_to`](@ref) followed by
 [`optimize!`](@ref).  Like [`copy_to`](@ref), it returns an [`IndexMap`].
 
-Keyword arguments are passed to [`copy_to`](@ref).
-
 An optimizer can decide to implement this function instead of implementing
 [`copy_to`](@ref) and [`optimize!`](@ref) individually.
 
 !!! warning
     This is an experimental new feature of MOI v0.10 that may break in MOI v1.0.
 """
-function copy_to_and_optimize!(dest, src)
+function copy_to_and_optimize!(dest, src) # TODO remove in favor of `optimize_model!`
     # The arguments above are untyped to avoid ambiguities.
     index_map = copy_to(dest, src)
     optimize!(dest)

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -186,29 +186,9 @@ An optimizer can decide to implement this function instead of implementing
 """
 function optimize_model!(dest, src)
     # The arguments above are untyped to avoid ambiguities.
-    return copy_to_and_optimize!(dest, src), true
-end
-
-"""
-    copy_to_and_optimize!(
-        dest::AbstractOptimizer,
-        src::ModelLike,
-    )::IndexMap
-
-A single call equivalent to calling [`copy_to`](@ref) followed by
-[`optimize!`](@ref).  Like [`copy_to`](@ref), it returns an [`IndexMap`].
-
-An optimizer can decide to implement this function instead of implementing
-[`copy_to`](@ref) and [`optimize!`](@ref) individually.
-
-!!! warning
-    This function will be removed in MOI v1.0, use `optimize_model!` instead.
-"""
-function copy_to_and_optimize!(dest, src) # TODO remove in favor of `optimize_model!`
-    # The arguments above are untyped to avoid ambiguities.
     index_map = copy_to(dest, src)
     optimize!(dest)
-    return index_map
+    return index_map, true
 end
 
 include("error.jl")

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -181,6 +181,9 @@ queried from `dest`.
 An optimizer can decide to implement this function instead of implementing
 [`copy_to`](@ref) and [`optimize!`](@ref) individually.
 
+!!! note
+    The main purpose of this function is for use in [`Utilities.CachingOptimizer`](@ref).
+
 !!! warning
     This is an experimental new feature of MOI v0.10.1 that may break in MOI v1.0.
 """

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -34,7 +34,7 @@ Start the solution procedure.
     optimize!(
         dest::AbstractOptimizer,
         src::ModelLike,
-    )::IndexMap
+    )::Tuple{IndexMap,Bool}
 
 A single call similar to calling [`copy_to(dest, src)`](@ref `copy_to`) followed
 by `optimize!(dest)`. Return an [`IndexMap`](@ref) and a `Bool` `copied`.

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -200,7 +200,7 @@ end
 
 function __attach_optimizer(
     model::CachingOptimizer,
-    ::typeof(MOI.optimizer_model!),
+    ::typeof(MOI.optimize_model!),
 ) where {F<:Function}
     indexmap, copied = MOI.optimize_model!(model.optimizer, model.model_cache)
     if copied
@@ -306,7 +306,7 @@ MOI.is_empty(m::CachingOptimizer) = MOI.is_empty(m.model_cache)
 
 function MOI.optimize!(m::CachingOptimizer)
     if m.mode == AUTOMATIC && m.state == EMPTY_OPTIMIZER
-        _attach_optimizer(m, MOI.copy_to_and_optimize!)
+        _attach_optimizer(m, MOI.optimize_model!)
     else
         # TODO: better error message if no optimizer is set
         @assert m.state == ATTACHED_OPTIMIZER

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -191,16 +191,16 @@ end
 
 function __attach_optimizer(
     model::CachingOptimizer,
-    copy_to::typeof(MOI.copy_to!),
+    ::typeof(MOI.copy_to),
 ) where {F<:Function}
-    indexmap = MOI.copy_to!(model.optimizer, model.model_cache)::IndexMap
+    indexmap = MOI.copy_to(model.optimizer, model.model_cache)::IndexMap
     model.state = ATTACHED_OPTIMIZER
     return indexmap
 end
 
 function __attach_optimizer(
     model::CachingOptimizer,
-    copy_to::typeof(MOI.optimizer_model!),
+    ::typeof(MOI.optimizer_model!),
 ) where {F<:Function}
     indexmap, copied = MOI.optimize_model!(model.optimizer, model.model_cache)
     if copied

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -765,8 +765,8 @@ end
 
 struct CopyToAndOptimizer <: MOI.AbstractOptimizer end
 MOI.is_empty(::CopyToAndOptimizer) = true
-function MOI.copy_to_and_optimize!(::CopyToAndOptimizer, src; kws...)
-    return MOI.Utilities.IndexMap()
+function MOI.optimize_model!(::CopyToAndOptimizer, src; kws...)
+    return MOI.Utilities.IndexMap(), false
 end
 
 function test_copy_to_and_optimize!()
@@ -776,7 +776,7 @@ function test_copy_to_and_optimize!()
         optimizer,
     )
     MOI.optimize!(model)
-    @test MOI.Utilities.state(model) == MOI.Utilities.ATTACHED_OPTIMIZER
+    @test MOI.Utilities.state(model) == MOI.Utilities.EMPTY_OPTIMIZER
     return
 end
 

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -765,7 +765,7 @@ end
 
 struct CopyToAndOptimizer <: MOI.AbstractOptimizer end
 MOI.is_empty(::CopyToAndOptimizer) = true
-function MOI.optimize_model!(::CopyToAndOptimizer, src; kws...)
+function MOI.optimize!(::CopyToAndOptimizer, src::MOI.ModelLike)
     return MOI.Utilities.IndexMap(), false
 end
 


### PR DESCRIPTION
There is an issue with `copy_to_and_optimize!`. What if the user changes the optimizer attributes and then want to optimize again ?
The solver supports setting optimizer attributes so the state in the `CachingOptimizer` will remain `ATTACHED_OPTIMIZER`.
So it will call `optimize!` but the solver can't optimize since it did not cache the model data.
For solvers relying on `copy_to_and_optimize!`, `CachingOptimizer` should keep the state `EMPTY_OPTIMIZER`.
This PR allows to do that with a new `MOI.optimize_model!`.
I have kept `copy_to_and_optimize!` so that it's not breaking but we can get rid of it in MOI v1.0.

Closes https://github.com/jump-dev/MathOptInterface.jl/issues/1604