### PR TITLE
[Test] relax inferred in attribute_value_type

### DIFF
--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -404,11 +404,7 @@ function _test_attribute_value_type(
     attribute::Union{MOI.AbstractModelAttribute,MOI.AbstractOptimizerAttribute},
 )
     T = MOI.attribute_value_type(attribute)
-    @static if VERSION < v"1.5"
-        @test MOI.get(model, attribute) isa T
-    else
-        @test @inferred(T, MOI.get(model, attribute)) isa T
-    end
+    @test MOI.get(model, attribute) isa T
     return
 end
 


### PR DESCRIPTION
This came up in CPLEX. For `ObjectiveFunctionType`, it will infer as `Type`, but a concrete type will be returned. Since inference is also Julia-version specific, we should probably just drop this requirement.