### PR TITLE
[Test] Minor fixes in nonlinear tests

### DIFF
--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -464,7 +464,7 @@ function test_nonlinear_hs071_NLPBlockDual(model::MOI.ModelLike, config::Config)
     MOI.set(model, MOI.NLPBlock(), block_data)
 
     for sense in [MOI.MIN_SENSE, MOI.MAX_SENSE]
-        MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+        MOI.set(model, MOI.ObjectiveSense(), sense)
         MOI.optimize!(model)
         # Get primal solution
         x = MOI.get(model, MOI.VariablePrimal(), v)

--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -481,8 +481,9 @@ function test_nonlinear_hs071_NLPBlockDual(model::MOI.ModelLike, config::Config)
         MOI.eval_constraint_jacobian_transpose_product(evaluator, jtv, x, con_dual)
 
         # Test that (x, μ, νl, νᵤ) satisfies stationarity condition
-        # ∇f(x) - ∑ μᵢ * ∇cᵢ(x) - νₗ - νᵤ = 0
-        @test isapprox(g, jtv .+ var_dual_ub .+ var_dual_lb, config)
+        # σ ∇f(x) - ∑ μᵢ * ∇cᵢ(x) - νₗ - νᵤ = 0
+        σ = (sense == MOI.MAX_SENSE) ? -1.0 : 1.0
+        @test isapprox(σ .* g, jtv .- var_dual_ub .+ var_dual_lb, config)
     end
     return
 end

--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -478,7 +478,12 @@ function test_nonlinear_hs071_NLPBlockDual(model::MOI.ModelLike, config::Config)
         MOI.eval_objective_gradient(evaluator, g, x)
         # Evaluate ∑ μᵢ * ∇cᵢ(x)
         jtv = zeros(n_variables)
-        MOI.eval_constraint_jacobian_transpose_product(evaluator, jtv, x, con_dual)
+        MOI.eval_constraint_jacobian_transpose_product(
+            evaluator,
+            jtv,
+            x,
+            con_dual,
+        )
 
         # Test that (x, μ, νl, νᵤ) satisfies stationarity condition
         # σ ∇f(x) - ∑ μᵢ * ∇cᵢ(x) - νₗ - νᵤ = 0
@@ -500,12 +505,7 @@ function setup_test(
             MOI.Utilities.mock_optimize!(
                 mock,
                 config.optimal_status,
-                [
-                    1.1,
-                    1.5735520521364397,
-                    2.6746837915674373,
-                    5.4,
-                ],
+                [1.1, 1.5735520521364397, 2.6746837915674373, 5.4],
                 (MOI.VariableIndex, MOI.GreaterThan{Float64}) =>
                     [28.590703804861093, 0.0, 0.0, 0.0],
                 (MOI.VariableIndex, MOI.LessThan{Float64}) =>

--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -483,7 +483,7 @@ function test_nonlinear_hs071_NLPBlockDual(model::MOI.ModelLike, config::Config)
         # Test that (x, μ, νl, νᵤ) satisfies stationarity condition
         # σ ∇f(x) - ∑ μᵢ * ∇cᵢ(x) - νₗ - νᵤ = 0
         σ = (sense == MOI.MAX_SENSE) ? -1.0 : 1.0
-        @test isapprox(σ .* g, jtv .- var_dual_ub .+ var_dual_lb, config)
+        @test isapprox(σ .* g, jtv .+ var_dual_ub .+ var_dual_lb, config)
     end
     return
 end
@@ -500,7 +500,16 @@ function setup_test(
             MOI.Utilities.mock_optimize!(
                 mock,
                 config.optimal_status,
-                [1.1, 1.57355205213644, 2.6746837915674373, 5.4],
+                [
+                    1.1,
+                    1.5735520521364397,
+                    2.6746837915674373,
+                    5.4,
+                ],
+                (MOI.VariableIndex, MOI.GreaterThan{Float64}) =>
+                    [28.590703804861093, 0.0, 0.0, 0.0],
+                (MOI.VariableIndex, MOI.LessThan{Float64}) =>
+                    [0.0, 0.0, 0.0, -5.582550550234756],
             )
             MOI.set(mock, MOI.NLPBlockDual(), [0.178761800, 0.985000823])
         end,
@@ -514,11 +523,16 @@ function setup_test(
                     1.7612041983937636,
                     3.6434497419346723,
                 ],
+                (MOI.VariableIndex, MOI.GreaterThan{Float64}) =>
+                    [0.0, 0.0, 0.0, 0.0],
+                (MOI.VariableIndex, MOI.LessThan{Float64}) =>
+                    [0.0, 0.0, 0.0, 0.0],
             )
             MOI.set(mock, MOI.NLPBlockDual(), [0.0, -5.008488315])
         end,
     )
-    return
+    model.eval_variable_constraint_dual = false
+    return () -> model.eval_variable_constraint_dual = true
 end
 
 """


### PR DESCRIPTION
Minor fixes to make the nonlinear tests pass both with Knitro and MadNLP.

1. `NLPBlockDual`: Check correctness of dual variables directly with KKT stationary condition

As the problem HS071 is nonconvex, solvers can return a different values than the one previously specified in `test_nonlinear_hs071_NLPBlockDual`: 
```julia
@test isapprox(dual, [0.178761800, 0.985000823], config)
```
For instance, both Knitro and MadNLP return `[0.0, 0.4058829] ` there. Using directly the KKT stationary condition avoids this problem.

2. Fix issue in definition of `FeasibilitySenseEvaluator`
When using the `FeasibilitySenseEvaluator`, we test that the primal variable returned is equal to 1: 
```julia
    xv = MOI.get(model, MOI.VariablePrimal(), x)
    @test isapprox(abs(xv), 1.0, config)
```
However, this is inconsistent with the definition of the upper and lower bounds: 
```julia
    lb = [1.0]
    ub = [2.0]
```
Indeed, the constraint specified inside the `FeasibilitySenseEvaluator` is then `1 <= x^2 <= 2`, and `x` can be any value between `1.0` and `sqrt(2)` (or `-sqrt(2)` and `-1.0`). To avoid this, we change the upper bound to `1.0` so the constraint now specified is `x^2 == 1.0`, consistent with the `FeasibilitySenseEvaluator`'s docstring: 
```
Test for FEASIBILITY_SENSE.
Find x satisfying x^2 == 1.
```
