### PR TITLE
VariablePrimal: document undefined behaviour 

### DIFF
--- a/docs/src/reference/errors.md
+++ b/docs/src/reference/errors.md
@@ -71,7 +71,7 @@ UnsupportedSubmittable
 SubmitNotAllowed
 ```
 
-Note that setting the [`ConstraintFunction`](@ref) of a [`VariableIndex`]
+Note that setting the [`ConstraintFunction`](@ref) of a [`VariableIndex`](@ref)
 constraint is not allowed:
 ```@docs
 SettingVariableIndexNotAllowed

--- a/docs/src/reference/errors.md
+++ b/docs/src/reference/errors.md
@@ -26,6 +26,7 @@ When an invalid result index is used to retrieve an attribute, a
 [`ResultIndexBoundsError`](@ref) should be thrown: 
 ```@docs
 ResultIndexBoundsError
+check_result_index_bounds
 ```
 
 As discussed in [JuMP mapping](@ref), for scalar constraint with a nonzero

--- a/docs/src/reference/errors.md
+++ b/docs/src/reference/errors.md
@@ -22,6 +22,12 @@ be thrown:
 InvalidIndex
 ```
 
+When an invalid result index is used to retrieve an attribute, a 
+[`ResultIndexBoundsError`](@ref) should be thrown: 
+```@docs
+ResultIndexBoundsError
+```
+
 As discussed in [JuMP mapping](@ref), for scalar constraint with a nonzero
 function constant, a [`ScalarFunctionConstantNotZero`](@ref) exception may be
 thrown:

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1023,10 +1023,13 @@ attribute_value_type(::ObjectiveFunctionType) = Type{<:AbstractFunction}
 
 A model attribute for the objective value of the primal solution `result_index`.
 
-If the solver does not have a primal value for the objective (for instance, 
-because of an infeasibility or because there is no solution with the 
-requested `result_index`), the result is undefined. Users should first check
-[`PrimalStatus`](@ref) before accessing the `ObjectiveValue` attribute.
+If the solver does not have a primal value for the objective because the 
+`result_index` is beyond the available solutions (whose number is indicated by
+the [`ResultCount`](@ref) attribute), getting this attribute must throw a 
+[`ResultIndexBoundsError`](@ref). Otherwise, if the result is unavailable for 
+another reason (for instance, only a dual solution is available), the result is
+undefined. Users should first check [`PrimalStatus`](@ref) before accessing the
+`ObjectiveValue` attribute.
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -158,7 +158,7 @@ end
     check_result_index_bounds(model::ModelLike, attr)
 
 This function checks whether enough results are available in the `model` for 
-the requested `attr`, using its `result_index` member variable. If the model 
+the requested `attr`, using its `result_index` field. If the model 
 does not have sufficient results to answer the query, it throws a 
 [`ResultIndexBoundsError`](@ref).
 """

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1190,6 +1190,10 @@ struct VariablePrimalStart <: AbstractVariableAttribute end
 
 A variable attribute for the assignment to some primal variable's value in
 result `result_index`. If `result_index` is omitted, it is 1 by default.
+        
+If the solver does not have a primal value for the variable (for instance, 
+because of an infeasibility or because there is no solution with the 
+requested `result_index`), the result is undefined.
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1257,6 +1257,11 @@ Possible values are:
 
 A variable attribute for the `BasisStatusCode` of a variable in result
 `result_index`, with respect to an available optimal solution basis.
+
+If the solver does not have a basis status for the variable (for instance, 
+because of an infeasibility or because there is no solution with the 
+requested `result_index`), the result is undefined. Users should first check
+[`PrimalStatus`](@ref) before accessing the `ConstraintPrimal` attribute.
 """
 struct VariableBasisStatus <: AbstractVariableAttribute
     result_index::Int

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -138,6 +138,17 @@ SubmitNotAllowed(sub::AbstractSubmittable) = SubmitNotAllowed(sub, "")
 operation_name(err::SubmitNotAllowed) = "Submitting $(err.sub)"
 message(err::SubmitNotAllowed) = err.message
 
+"""
+    struct ResultIndexBoundsError{AttrType} <: Exception
+        attr::AttrType
+        result_count::Int
+    end
+
+An error indicating that the requested attribute `attr` could not be retrieved,
+because the solver returned too few results compared to what was requested. 
+For instance, the user tries to retrieve `VariablePrimal(2)` when only one 
+solution is available, or when the model is infeasible and has no solution. 
+"""
 struct ResultIndexBoundsError{AttrType} <: Exception
     attr::AttrType
     result_count::Int

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1406,10 +1406,13 @@ These solvers may return the value of `s` for `ConstraintPrimal`, rather than
 `b - Ax`. (Although these are constrained by an equality constraint, due to
 numerical tolerances they may not be identical.)
 
-If the solver does not have a primal value for the constraint (for instance, 
-because of an infeasibility or because there is no solution with the 
-requested `result_index`), the result is undefined. Users should first check
-[`PrimalStatus`](@ref) before accessing the `ConstraintPrimal` attribute.
+If the solver does not have a primal value for the constraint because the 
+`result_index` is beyond the available solutions (whose number is indicated by
+the [`ResultCount`](@ref) attribute), getting this attribute must throw a 
+[`ResultIndexBoundsError`](@ref). Otherwise, if the result is unavailable for 
+another reason (for instance, only a dual solution is available), the result is
+undefined. Users should first check [`PrimalStatus`](@ref) before accessing the
+`ConstraintPrimal` attribute.
 
 If `result_index` is omitted, it is 1 by default. See [`ResultCount`](@ref) for
 information on how the results are ordered.

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1004,6 +1004,11 @@ attribute_value_type(::ObjectiveFunctionType) = Type{<:AbstractFunction}
 
 A model attribute for the objective value of the primal solution `result_index`.
 
+If the solver does not have a primal value for the objective (for instance, 
+because of an infeasibility or because there is no solution with the 
+requested `result_index`), the result is undefined. Users should first check
+[`PrimalStatus`](@ref) before accessing the `ObjectiveValue` attribute.
+
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """
 struct ObjectiveValue <: AbstractModelAttribute

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -154,6 +154,14 @@ struct ResultIndexBoundsError{AttrType} <: Exception
     result_count::Int
 end
 
+"""
+    check_result_index_bounds(model::ModelLike, attr)
+
+This function checks whether enough results are available in the `model` for 
+the requested `attr`, using its `result_index` member variable. If the model 
+does not have sufficient results to answer the query, it throws a 
+[`ResultIndexBoundsError`](@ref).
+"""
 function check_result_index_bounds(model::ModelLike, attr)
     result_count = get(model, ResultCount())
     if !(1 <= attr.result_index <= result_count)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1190,7 +1190,7 @@ struct VariablePrimalStart <: AbstractVariableAttribute end
 
 A variable attribute for the assignment to some primal variable's value in
 result `result_index`. If `result_index` is omitted, it is 1 by default.
-        
+
 If the solver does not have a primal value for the variable (for instance, 
 because of an infeasibility or because there is no solution with the 
 requested `result_index`), the result is undefined. Users should first check
@@ -1357,6 +1357,11 @@ However, some conic solvers reformulate `b - Ax in S` to `s = b - Ax, s in S`.
 These solvers may return the value of `s` for `ConstraintPrimal`, rather than
 `b - Ax`. (Although these are constrained by an equality constraint, due to
 numerical tolerances they may not be identical.)
+
+If the solver does not have a primal value for the constraint (for instance, 
+because of an infeasibility or because there is no solution with the 
+requested `result_index`), the result is undefined. Users should first check
+[`PrimalStatus`](@ref) before accessing the `ConstraintPrimal` attribute.
 
 If `result_index` is omitted, it is 1 by default. See [`ResultCount`](@ref) for
 information on how the results are ordered.

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1044,10 +1044,13 @@ end
 A model attribute for the value of the objective function of the dual problem
 for the `result_index`th dual result.
 
-If the solver does not have a dual value for the objective (for instance, 
-because of an infeasibility or because there is no solution with the 
-requested `result_index`), the result is undefined. Users should first check
-[`DualStatus`](@ref) before accessing the `DualObjectiveValue` attribute.
+If the solver does not have a dual value for the objective because the 
+`result_index` is beyond the available solutions (whose number is indicated by
+the [`ResultCount`](@ref) attribute), getting this attribute must throw a 
+[`ResultIndexBoundsError`](@ref). Otherwise, if the result is unavailable for 
+another reason (for instance, only a primal solution is available), the result is
+undefined. Users should first check [`DualStatus`](@ref) before accessing the
+`DualObjectiveValue` attribute.
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """
@@ -1223,10 +1226,13 @@ struct VariablePrimalStart <: AbstractVariableAttribute end
 A variable attribute for the assignment to some primal variable's value in
 result `result_index`. If `result_index` is omitted, it is 1 by default.
 
-If the solver does not have a primal value for the variable (for instance, 
-because of an infeasibility or because there is no solution with the 
-requested `result_index`), the result is undefined. Users should first check
-[`PrimalStatus`](@ref) before accessing the `VariablePrimal` attribute.
+If the solver does not have a primal value for the variable because the 
+`result_index` is beyond the available solutions (whose number is indicated by
+the [`ResultCount`](@ref) attribute), getting this attribute must throw a 
+[`ResultIndexBoundsError`](@ref). Otherwise, if the result is unavailable for 
+another reason (for instance, only a dual solution is available), the result is
+undefined. Users should first check [`PrimalStatus`](@ref) before accessing the
+`VariablePrimal` attribute.
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """
@@ -1290,10 +1296,13 @@ Possible values are:
 A variable attribute for the `BasisStatusCode` of a variable in result
 `result_index`, with respect to an available optimal solution basis.
 
-If the solver does not have a basis status for the variable (for instance, 
-because of an infeasibility or because there is no solution with the 
-requested `result_index`), the result is undefined. Users should first check
-[`PrimalStatus`](@ref) before accessing the `VariableBasisStatus` attribute.
+If the solver does not have a basis statue for the variable because the 
+`result_index` is beyond the available solutions (whose number is indicated by
+the [`ResultCount`](@ref) attribute), getting this attribute must throw a 
+[`ResultIndexBoundsError`](@ref). Otherwise, if the result is unavailable for 
+another reason (for instance, only a dual solution is available), the result is
+undefined. Users should first check [`PrimalStatus`](@ref) before accessing the
+`VariableBasisStatus` attribute.
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """
@@ -1416,10 +1425,13 @@ end
 A constraint attribute for the assignment to some constraint's dual value(s) in
 result `result_index`. If `result_index` is omitted, it is 1 by default.
 
-If the solver does not have a dual value for the constraint (for instance, 
-because of an infeasibility or because there is no solution with the 
-requested `result_index`), the result is undefined. Users should first check
-[`DualStatus`](@ref) before accessing the `ConstraintDual` attribute.
+If the solver does not have a dual value for the variable because the 
+`result_index` is beyond the available solutions (whose number is indicated by
+the [`ResultCount`](@ref) attribute), getting this attribute must throw a 
+[`ResultIndexBoundsError`](@ref). Otherwise, if the result is unavailable for 
+another reason (for instance, only a primal solution is available), the result is
+undefined. Users should first check [`DualStatus`](@ref) before accessing the
+`ConstraintDual` attribute.
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """
@@ -1435,12 +1447,15 @@ A constraint attribute for the `BasisStatusCode` of some constraint in result
 `result_index`, with respect to an available optimal solution basis. If
 `result_index` is omitted, it is 1 by default.
 
-See [`ResultCount`](@ref) for information on how the results are ordered.
+If the solver does not have a basis statue for the constraint because the 
+`result_index` is beyond the available solutions (whose number is indicated by
+the [`ResultCount`](@ref) attribute), getting this attribute must throw a 
+[`ResultIndexBoundsError`](@ref). Otherwise, if the result is unavailable for 
+another reason (for instance, only a dual solution is available), the result is
+undefined. Users should first check [`PrimalStatus`](@ref) before accessing the
+`ConstraintBasisStatus` attribute.
 
-If the solver does not have a basis status for the constraint (for instance, 
-because of an infeasibility or because there is no solution with the 
-requested `result_index`), the result is undefined. Users should first check
-[`PrimalStatus`](@ref) before accessing the `ConstraintBasisStatus` attribute.
+See [`ResultCount`](@ref) for information on how the results are ordered.
 
 ## Notes
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1017,6 +1017,11 @@ end
 A model attribute for the value of the objective function of the dual problem
 for the `result_index`th dual result.
 
+If the solver does not have a dual value for the objective (for instance, 
+because of an infeasibility or because there is no solution with the 
+requested `result_index`), the result is undefined. Users should first check
+[`DualStatus`](@ref) before accessing the `DualObjectiveValue` attribute.
+
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """
 struct DualObjectiveValue <: AbstractModelAttribute

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1271,7 +1271,7 @@ A variable attribute for the `BasisStatusCode` of a variable in result
 If the solver does not have a basis status for the variable (for instance, 
 because of an infeasibility or because there is no solution with the 
 requested `result_index`), the result is undefined. Users should first check
-[`PrimalStatus`](@ref) before accessing the `ConstraintPrimal` attribute.
+[`PrimalStatus`](@ref) before accessing the `VariableBasisStatus` attribute.
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -148,6 +148,8 @@ An error indicating that the requested attribute `attr` could not be retrieved,
 because the solver returned too few results compared to what was requested. 
 For instance, the user tries to retrieve `VariablePrimal(2)` when only one 
 solution is available, or when the model is infeasible and has no solution. 
+
+See also: [`check_result_index_bounds`](@ref).
 """
 struct ResultIndexBoundsError{AttrType} <: Exception
     attr::AttrType

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1410,6 +1410,11 @@ A constraint attribute for the `BasisStatusCode` of some constraint in result
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 
+If the solver does not have a basis status for the constraint (for instance, 
+because of an infeasibility or because there is no solution with the 
+requested `result_index`), the result is undefined. Users should first check
+[`PrimalStatus`](@ref) before accessing the `ConstraintBasisStatus` attribute.
+
 ## Notes
 
 For the basis status of a variable, query [`VariableBasisStatus`](@ref).

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1262,6 +1262,8 @@ If the solver does not have a basis status for the variable (for instance,
 because of an infeasibility or because there is no solution with the 
 requested `result_index`), the result is undefined. Users should first check
 [`PrimalStatus`](@ref) before accessing the `ConstraintPrimal` attribute.
+
+See [`ResultCount`](@ref) for information on how the results are ordered.
 """
 struct VariableBasisStatus <: AbstractVariableAttribute
     result_index::Int

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1394,6 +1394,11 @@ end
 A constraint attribute for the assignment to some constraint's dual value(s) in
 result `result_index`. If `result_index` is omitted, it is 1 by default.
 
+If the solver does not have a dual value for the constraint (for instance, 
+because of an infeasibility or because there is no solution with the 
+requested `result_index`), the result is undefined. Users should first check
+[`DualStatus`](@ref) before accessing the `ConstraintDual` attribute.
+
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """
 struct ConstraintDual <: AbstractConstraintAttribute

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1193,7 +1193,8 @@ result `result_index`. If `result_index` is omitted, it is 1 by default.
         
 If the solver does not have a primal value for the variable (for instance, 
 because of an infeasibility or because there is no solution with the 
-requested `result_index`), the result is undefined.
+requested `result_index`), the result is undefined. Users should first check
+[`PrimalStatus`](@ref) before accessing the `VariablePrimal` attribute.
 
 See [`ResultCount`](@ref) for information on how the results are ordered.
 """


### PR DESCRIPTION
Fixes #1600. 

If you are OK with the wording, the same patch could be applied to `ConstraintDual`, `ConstraintBasisStatus`, `ObjectiveValue`, `DualObjectiveValue`, `VariableBasisStatus`, `ConstraintPrimal`. 