### PR TITLE
[Utilities] allow callbacks through CachingOptimizer

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -277,7 +277,7 @@ function MOI.optimize!(m::CachingOptimizer)
         # to check if we have an `AbstractCallback` set and attach the optimizer
         # before recalling `MOI.optimize!`.
         for attr in MOI.get(m, MOI.ListOfModelAttributesSet())
-            if typeof(attr) <: MOI.AbstractCallback
+            if attr isa MOI.AbstractCallback
                 attach_optimizer(m)
                 return MOI.optimize!(m)
             end


### PR DESCRIPTION
I hit another snag: callbacks through a CachingOptimizer require `optimizer_to_model_map` to be set before `optimize!` so that they are accessible for things like `CallbackVariablePrimal`. But, the two-argument version means that this isn't set until afterwards. 

As a work-around, we call `attach` if a callback is set. I don't think there will be any optimizers that require the two-argument version and support callbacks. There aren't any at the moment, at least.