### PR TITLE
Update release notes for v0.10.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,5 +1,13 @@
 # Release notes
 
+## v0.10.3 (September 18, 2021)
+
+For a detailed list of the closed issues and pull requests from this release,
+see the [tag notes](https://github.com/jump-dev/MathOptInterface.jl/releases/tag/v0.10.3).
+
+- Fix bug which prevented callbacks from working through a CachingOptimizer
+- Fix bug in `Test` submodule
+
 ## v0.10.2 (September 16, 2021)
 
 For a detailed list of the closed issues and pull requests from this release,


### PR DESCRIPTION
If we merge #1619 and then this, we should have GLPK, Ipopt, and SCS all updated and working with the new MOI. Then we can tag their releases and start working on breaking changes for JuMP.