### PR TITLE
Allow skipping NLPBlockDual

### DIFF
--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -469,26 +469,29 @@ function test_nonlinear_hs071_NLPBlockDual(model::MOI.ModelLike, config::Config)
         # Get primal solution
         x = MOI.get(model, MOI.VariablePrimal(), v)
         # Get dual solution
-        con_dual = MOI.get(model, MOI.NLPBlockDual())
-        var_dual_lb = MOI.get(model, MOI.ConstraintDual(), cl)
-        var_dual_ub = MOI.get(model, MOI.ConstraintDual(), cu)
+        if _supports(config, MOI.BLPBlockDual) &&
+            _supports(config, MOI.ConstraintStatus)
+            con_dual = MOI.get(model, MOI.NLPBlockDual())
+            var_dual_lb = MOI.get(model, MOI.ConstraintDual(), cl)
+            var_dual_ub = MOI.get(model, MOI.ConstraintDual(), cu)
 
-        # Evaluate ∇f(x)
-        g = zeros(n_variables)
-        MOI.eval_objective_gradient(evaluator, g, x)
-        # Evaluate ∑ μᵢ * ∇cᵢ(x)
-        jtv = zeros(n_variables)
-        MOI.eval_constraint_jacobian_transpose_product(
-            evaluator,
-            jtv,
-            x,
-            con_dual,
-        )
+            # Evaluate ∇f(x)
+            g = zeros(n_variables)
+            MOI.eval_objective_gradient(evaluator, g, x)
+            # Evaluate ∑ μᵢ * ∇cᵢ(x)
+            jtv = zeros(n_variables)
+            MOI.eval_constraint_jacobian_transpose_product(
+                evaluator,
+                jtv,
+                x,
+                con_dual,
+            )
 
-        # Test that (x, μ, νl, νᵤ) satisfies stationarity condition
-        # σ ∇f(x) - ∑ μᵢ * ∇cᵢ(x) - νₗ - νᵤ = 0
-        σ = (sense == MOI.MAX_SENSE) ? -1.0 : 1.0
-        @test isapprox(σ .* g, jtv .+ var_dual_ub .+ var_dual_lb, config)
+            # Test that (x, μ, νl, νᵤ) satisfies stationarity condition
+            # σ ∇f(x) - ∑ μᵢ * ∇cᵢ(x) - νₗ - νᵤ = 0
+            σ = (sense == MOI.MAX_SENSE) ? -1.0 : 1.0
+            @test isapprox(σ .* g, jtv .+ var_dual_ub .+ var_dual_lb, config)
+        end
     end
     return
 end


### PR DESCRIPTION
Should it be this or `if MOI.get(model, MOI.DualStatus()) != MOI.NO_SOLUTION` ?