### PR TITLE
non-const model macro generation

### DIFF
--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -490,3 +490,19 @@ end
 end  # module
 
 TestModel.runtests()
+
+@testset "Model macro toplevel" begin
+    MathOptInterface.Utilities.@model(
+        NonconstModel,
+        (MathOptInterface.ZeroOne,),
+        (),
+        (),
+        (),
+        (),
+        (MathOptInterface.ScalarAffineFunction,),
+        (),
+        (),
+        false,
+        false,
+    )
+end


### PR DESCRIPTION
Follow-up solution on https://github.com/jump-dev/MathOptInterface.jl/issues/1631
Adds an optional argument. The original version remains the default to be non-breaking, even though I still wonder if const should be the default