### PR TITLE
[Utilities] Fix getter in UniversalFallback

### DIFF
--- a/src/FileFormats/MOF/nonlinear.jl
+++ b/src/FileFormats/MOF/nonlinear.jl
@@ -62,12 +62,9 @@ function write_nlpblock(
     model::Model,
     name_map::Dict{MOI.VariableIndex,String},
 ) where {T<:Object}
-    # TODO(odow): is there a better way of checking if the NLPBlock is set?
-    nlp_block = try
-        MOI.get(model, MOI.NLPBlock())
-    catch ex
-        @assert isa(ex, KeyError)
-        return  # No NLPBlock set.
+    nlp_block = MOI.get(model, MOI.NLPBlock())
+    if nlp_block === nothing
+        return
     end
     MOI.initialize(nlp_block.evaluator, [:ExprGraph])
     variables = MOI.get(model, MOI.ListOfVariableIndices())

--- a/src/FileFormats/NL/NL.jl
+++ b/src/FileFormats/NL/NL.jl
@@ -243,10 +243,10 @@ MOI.initialize(::_LinearNLPEvaluator, ::Vector{Symbol}) = nothing
 function MOI.copy_to(dest::Model, model::MOI.ModelLike)
     mapping = MOI.Utilities.IndexMap()
     # Initialize the NLP block.
-    nlp_block = try
-        MOI.get(model, MOI.NLPBlock())
-    catch
-        MOI.NLPBlockData(MOI.NLPBoundsPair[], _LinearNLPEvaluator(), false)
+    nlp_block = MOI.get(model, MOI.NLPBlock())
+    if nlp_block === nothing
+        nlp_block =
+            MOI.NLPBlockData(MOI.NLPBoundsPair[], _LinearNLPEvaluator(), false)
     end
     if !(:ExprGraph in MOI.features_available(nlp_block.evaluator))
         error(

--- a/src/FileFormats/NL/NL.jl
+++ b/src/FileFormats/NL/NL.jl
@@ -243,10 +243,11 @@ MOI.initialize(::_LinearNLPEvaluator, ::Vector{Symbol}) = nothing
 function MOI.copy_to(dest::Model, model::MOI.ModelLike)
     mapping = MOI.Utilities.IndexMap()
     # Initialize the NLP block.
-    nlp_block = MOI.get(model, MOI.NLPBlock())
-    if nlp_block === nothing
-        nlp_block =
-            MOI.NLPBlockData(MOI.NLPBoundsPair[], _LinearNLPEvaluator(), false)
+    has_nlp = MOI.NLPBlock() in MOI.get(model, MOI.ListOfModelAttributesSet())
+    nlp_block = if has_nlp
+        MOI.get(model, MOI.NLPBlock())
+    else
+        MOI.NLPBlockData(MOI.NLPBoundsPair[], _LinearNLPEvaluator(), false)
     end
     if !(:ExprGraph in MOI.features_available(nlp_block.evaluator))
         error(

--- a/src/Utilities/print.jl
+++ b/src/Utilities/print.jl
@@ -483,6 +483,9 @@ end
 function _nlp_block(model::MOI.ModelLike)
     try
         block = MOI.get(model, MOI.NLPBlock())
+        if block === nothing
+            return
+        end
         if :ExprGraph in MOI.features_available(block.evaluator)
             MOI.initialize(block.evaluator, [:ExprGraph])
         end

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -258,10 +258,12 @@ end
 
 # Attributes
 function _get(uf::UniversalFallback, attr::MOI.AbstractOptimizerAttribute)
-    return uf.optattr[attr]
+    return get(uf.optattr, attr, nothing)
 end
 
-_get(uf::UniversalFallback, attr::MOI.AbstractModelAttribute) = uf.modattr[attr]
+function _get(uf::UniversalFallback, attr::MOI.AbstractModelAttribute)
+    return get(uf.modattr, attr, nothing)
+end
 
 function _get(
     uf::UniversalFallback,

--- a/test/Utilities/universalfallback.jl
+++ b/test/Utilities/universalfallback.jl
@@ -373,6 +373,13 @@ function test_show()
     return
 end
 
+function test_missing_attribute()
+    model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    @test MOI.get(model, MOI.Test.UnknownModelAttribute()) === nothing
+    @test MOI.get(model, MOI.TimeLimitSec()) === nothing
+    return
+end
+
 end  # module
 
 TestUniversalFallback.runtests()


### PR DESCRIPTION
While thinking about https://github.com/jump-dev/JuMP.jl/issues/2770. The current behavior is:
```Julia
julia> using JuMP, Gurobi

julia> model = Model(Gurobi.Optimizer)
Academic license - for non-commercial use only - expires 2021-11-06
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: Gurobi

julia> MOI.get(model, Gurobi.ModelAttribute("IsMIP"))
ERROR: KeyError: key Gurobi.ModelAttribute("IsMIP") not found
Stacktrace:
 [1] getindex
   @ ./dict.jl:482 [inlined]
 [2] _get
   @ ~/.julia/packages/MathOptInterface/D0LUL/src/Utilities/universalfallback.jl:264 [inlined]
 [3] get
   @ ~/.julia/packages/MathOptInterface/D0LUL/src/Utilities/universalfallback.jl:309 [inlined]
 [4] get(model::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.Bridges.LazyBridgeOptimizer{Gurobi.Optimizer}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}, attr::Gurobi.ModelAttribute)
   @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/D0LUL/src/Utilities/cachingoptimizer.jl:808
 [5] get(model::Model, attr::Gurobi.ModelAttribute)
   @ JuMP ~/.julia/dev/JuMP/src/JuMP.jl:1217
 [6] top-level scope
   @ REPL[3]:1
```

This. is clearly unhelpful.

We return `nothing` variables and constraints, so it seems sensible to do the same with other attributes:
https://github.com/jump-dev/MathOptInterface.jl/blob/f5cc48179a7b41908000259566fe1d5a1f59b45a/src/Utilities/universalfallback.jl#L260-L292

But that'd mean that `MOI.get(model, Gurobi.ModelAttribute("IsMIP"))` returned `nothing`, which is also unhelpful. We should instead return a meaningful error message.

Thoughts?