### PR TITLE
Fix space issue in BibTeX entry

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,5 +1,4 @@
-@article{
-    legat2021mathoptinterface,
+@article{legat2021mathoptinterface,
     title={{MathOptInterface}: a data structure for mathematical optimization problems},
     author={Legat, Beno{\^\i}t and Dowson, Oscar and Garcia, Joaquim Dias and Lubin, Miles},
     journal={INFORMS Journal on Computing},

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,9 +46,8 @@ is available on [arXiv](https://arxiv.org).
 
 If you find MathOptInterface useful in your work, we kindly request that you
 cite the following paper:
-```
-@article{
-    legat2021mathoptinterface,
+```bibtex
+@article{legat2021mathoptinterface,
     title={{MathOptInterface}: a data structure for mathematical optimization problems},
     author={Legat, Beno{\^\i}t and Dowson, Oscar and Garcia, Joaquim Dias and Lubin, Miles},
     journal={INFORMS Journal on Computing},


### PR DESCRIPTION
JabRef complains with "Found corrupted citation key ... (contains whitespace)."