### PR TITLE
Fix tests names

### DIFF
--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -6768,7 +6768,7 @@ function setup_test(
 end
 
 """
-    test_conic_SecondOrderCone_negative_post_bound_ii(
+    test_conic_SecondOrderCone_negative_post_bound_2(
         model::MOI.ModelLike,
         config::Config{T},
     ) where {T}
@@ -6776,7 +6776,7 @@ end
 Test a second order cosnstraint with an epigraph variable >= -M and the bound
 constraints added via `add_constraint`.
 """
-function test_conic_SecondOrderCone_negative_post_bound_ii(
+function test_conic_SecondOrderCone_negative_post_bound_2(
     model::MOI.ModelLike,
     config::Config{T},
 ) where {T}
@@ -6811,7 +6811,7 @@ function test_conic_SecondOrderCone_negative_post_bound_ii(
 end
 
 function setup_test(
-    ::typeof(test_conic_SecondOrderCone_negative_post_bound_ii),
+    ::typeof(test_conic_SecondOrderCone_negative_post_bound_2),
     model::MOIU.MockOptimizer,
     ::Config,
 )
@@ -6828,7 +6828,7 @@ function setup_test(
 end
 
 """
-    test_conic_SecondOrderCone_negative_post_bound_iii(
+    test_conic_SecondOrderCone_negative_post_bound_3(
         model::MOI.ModelLike,
         config::Config{T},
     ) where {T}
@@ -6836,7 +6836,7 @@ end
 Test a second order cosnstraint with an epigraph variable >= -M and the bound
 constraints added via `add_constraints`.
 """
-function test_conic_SecondOrderCone_negative_post_bound_iii(
+function test_conic_SecondOrderCone_negative_post_bound_3(
     model::MOI.ModelLike,
     config::Config{T},
 ) where {T}
@@ -6872,7 +6872,7 @@ function test_conic_SecondOrderCone_negative_post_bound_iii(
 end
 
 function setup_test(
-    ::typeof(test_conic_SecondOrderCone_negative_post_bound_iii),
+    ::typeof(test_conic_SecondOrderCone_negative_post_bound_3),
     model::MOIU.MockOptimizer,
     ::Config,
 )

--- a/src/Test/test_solve.jl
+++ b/src/Test/test_solve.jl
@@ -1402,12 +1402,12 @@ function setup_test(
 end
 
 """
-    test_solve_conflict_zeroone_ii(model::MOI.ModelLike, config::Config)
+    test_solve_conflict_zeroone_2(model::MOI.ModelLike, config::Config)
 
 Test the ConflictStatus API when an integrality is in the conflict.
 In this test, integrality is the conflict and no the upper bound == 1.
 """
-function test_solve_conflict_zeroone_ii(
+function test_solve_conflict_zeroone_2(
     model::MOI.ModelLike,
     config::Config{T},
 ) where {T}
@@ -1437,7 +1437,7 @@ function test_solve_conflict_zeroone_ii(
 end
 
 function setup_test(
-    ::typeof(test_solve_conflict_zeroone_ii),
+    ::typeof(test_solve_conflict_zeroone_2),
     model::MOIU.MockOptimizer,
     ::Config,
 )

--- a/test/Utilities/CleverDicts.jl
+++ b/test/Utilities/CleverDicts.jl
@@ -156,7 +156,7 @@ function test_iterate()
     return
 end
 
-function test_iterate_ii()
+function test_iterate_2()
     d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
     key = CleverDicts.add_item(d, "first")
     key2 = CleverDicts.add_item(d, "second")
@@ -184,7 +184,7 @@ function test_iterate_ii()
     return
 end
 
-function test_iterate_iii()
+function test_iterate_3()
     d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
     y = 0
     for (k, v) in d


### PR DESCRIPTION
When tests require a number because of a duplicate name they were using `ii` and `2`. I kept the latter because it is clearer.
We should highlight this in docs?