### PR TITLE
[Utilties] don't throw UnsupportedAttribute in pass_attributes

### DIFF
--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -25,7 +25,6 @@ function pass_attributes(
             if attr == MOI.Name()
                 continue  # Skipping names is okay.
             end
-            throw(MOI.UnsupportedAttribute(attr))
         end
         _pass_attribute(dest, src, index_map, attr)
     end
@@ -66,7 +65,6 @@ function pass_attributes(
             if attr == MOI.VariableName() || attr == MOI.VariablePrimalStart()
                 continue  # Skipping names and start values is okay.
             end
-            throw(MOI.UnsupportedAttribute(attr))
         end
         _pass_attribute(dest, src, index_map, vis_src, attr)
     end
@@ -115,7 +113,6 @@ function pass_attributes(
             )
                 continue  # Skipping names and start values is okay.
             end
-            throw(MOI.UnsupportedAttribute(attr))
         end
         _pass_attribute(dest, src, index_map, cis_src, attr)
     end


### PR DESCRIPTION
Closes #1614

@blegat's argument being that there should already be some fallbacks for this, and catching it here might obscure other bugs.