### PR TITLE
[Test] add version_added to better control MOI.Test.runtests

### DIFF
--- a/docs/src/submodules/Test/overview.md
+++ b/docs/src/submodules/Test/overview.md
@@ -83,7 +83,12 @@ function test_runtests()
         exclude = [
             "test_attribute_NumberOfThreads",
             "test_quadratic_",
-        ]
+        ],
+        # This argument is useful to prevent tests from failing on future
+        # releases of MOI that add new tests. Don't let this number get too far
+        # behind the current MOI release though! You should periodically check
+        # for new tests in order to fix bugs and implement new features.
+        exclude_tests_after = v"0.10.5",
     )
     return
 end
@@ -272,6 +277,12 @@ function setup_test(
     )
     return
 end
+```
+
+Finally, you also need to implement [`version_added`](@ref). If we added this
+test when the latest released version of MOI was `v0.10.5`, define:
+```julia
+version_added(::typeof(test_unit_optimize!_twice)) = v"0.10.6"
 ```
 
 **Step 6**

--- a/docs/src/submodules/Test/reference.md
+++ b/docs/src/submodules/Test/reference.md
@@ -16,6 +16,7 @@ Functions to help test implementations of MOI. See
 Test.Config
 Test.runtests
 Test.setup_test
+Test.version_added
 Test.@requires
 Test.RequirementUnmet
 ```

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -6810,6 +6810,12 @@ function test_conic_SecondOrderCone_negative_post_bound_2(
     return
 end
 
+function version_added(
+    ::typeof(test_conic_SecondOrderCone_negative_post_bound_2),
+)
+    return v"0.10.6"
+end
+
 function setup_test(
     ::typeof(test_conic_SecondOrderCone_negative_post_bound_2),
     model::MOIU.MockOptimizer,
@@ -6869,6 +6875,12 @@ function test_conic_SecondOrderCone_negative_post_bound_3(
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE
     return
+end
+
+function version_added(
+    ::typeof(test_conic_SecondOrderCone_negative_post_bound_3),
+)
+    return v"0.10.6"
 end
 
 function setup_test(

--- a/src/Test/test_solve.jl
+++ b/src/Test/test_solve.jl
@@ -1436,6 +1436,8 @@ function test_solve_conflict_zeroone_2(
     return
 end
 
+version_added(::typeof(test_solve_conflict_zeroone_2)) = v"0.10.6"
+
 function setup_test(
     ::typeof(test_solve_conflict_zeroone_2),
     model::MOIU.MockOptimizer,

--- a/test/Test/Test.jl
+++ b/test/Test/Test.jl
@@ -37,3 +37,14 @@ MOI.Test.runtests(
         "test_model_supports_constraint_VectorOfVariables_Nonnegatives",
     ],
 )
+
+# Test exclude_tests_after. This should work despite no methods being added for IncompleteOptimizer
+# because every test should get skipped.
+
+struct IncompleteOptimizer <: MOI.AbstractOptimizer end
+
+MOI.Test.runtests(
+    IncompleteOptimizer(),
+    MOI.Test.Config();
+    exclude_tests_after = v"0.0.1",
+)


### PR DESCRIPTION
Closes #1661

Not sold on the `exclude_tests_after` name; open to bike shed.

I think with this design it lets us be much more liberal with adding new (potentially breaking) tests, and we won't have this constant fight about updating solvers. Then, solver authors can periodically increment this bound and deal with the fallout. In a post-1.0 world of MOI, nothing of their existing code should break, so this is really just a catch on adding new features.