### PR TITLE
Remove source of common test failure in LowerBoundAlreadySet

### DIFF
--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -801,10 +801,7 @@ function test_model_LowerBoundAlreadySet(
     @requires _supports(config, MOI.delete)
     x = MOI.add_variable(model)
     lb = zero(T)
-    sets = [
-        MOI.EqualTo(lb),
-        MOI.Interval(lb, lb),
-    ]
+    sets = [MOI.EqualTo(lb), MOI.Interval(lb, lb)]
     set2 = MOI.GreaterThan(lb)
     for set1 in sets
         if !MOI.supports_constraint(model, MOI.VariableIndex, typeof(set1))
@@ -837,10 +834,7 @@ function test_model_UpperBoundAlreadySet(
     x = MOI.add_variable(model)
     ub = zero(T)
     @requires MOI.supports_constraint(model, MOI.VariableIndex, MOI.LessThan{T})
-    sets = [
-        MOI.EqualTo(ub),
-        MOI.Interval(ub, ub),
-    ]
+    sets = [MOI.EqualTo(ub), MOI.Interval(ub, ub)]
     set2 = MOI.LessThan(ub)
     for set1 in sets
         if !MOI.supports_constraint(model, MOI.VariableIndex, typeof(set1))

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -804,8 +804,6 @@ function test_model_LowerBoundAlreadySet(
     sets = [
         MOI.EqualTo(lb),
         MOI.Interval(lb, lb),
-        MOI.Semicontinuous(lb, lb),
-        MOI.Semiinteger(lb, lb),
     ]
     set2 = MOI.GreaterThan(lb)
     for set1 in sets
@@ -842,8 +840,6 @@ function test_model_UpperBoundAlreadySet(
     sets = [
         MOI.EqualTo(ub),
         MOI.Interval(ub, ub),
-        MOI.Semicontinuous(ub, ub),
-        MOI.Semiinteger(ub, ub),
     ]
     set2 = MOI.LessThan(ub)
     for set1 in sets

--- a/test/Bridges/Constraint/semi_to_binary.jl
+++ b/test/Bridges/Constraint/semi_to_binary.jl
@@ -235,6 +235,29 @@ function test_SemiToBinary()
     return
 end
 
+"""
+    test_lower_bound_already_set()
+
+The second call to `add_constraint` is broken because it should throw:
+```julia
+MOI.LowerBoundAlreadySet{
+    MOI.Semicontinuous{Float64},
+    MOI.GreaterThan{Float64},
+}
+```
+See MathOptInterface issue #1431.
+"""
+function test_lower_bound_already_set()
+    model = MOI.Utilities.Model{Float64}()
+    bridged = MOI.Bridges.Constraint.SemiToBinary{Float64}(model)
+    x = MOI.add_variable(bridged)
+    MOI.add_constraint(bridged, x, MOI.Semicontinuous(1.0, 2.0))
+    @test_broken(
+        MOI.add_constraint(bridged, x, MOI.GreaterThan(0.0)) === nothing,
+    )
+    return
+end
+
 end  # module
 
 TestConstraintSemiToBinary.runtests()


### PR DESCRIPTION
I considered a few ways of fixing #1431 (e.g., adding an Interval constraint so the variable would have a bound), but couldn't find anything satisfactory. The bridges need something like #1097, but that's a much greater fix.

This stops people running into the common source of failure, and it includes a broken test for us to fix in the future.

Closes #1431. I've opened #1665 to track the broader issue.