### PR TITLE
[Utilities] fix fallback of map_indices

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -143,7 +143,7 @@ function reset_optimizer(m::CachingOptimizer, optimizer::MOI.AbstractOptimizer)
             continue
         end
         value = MOI.get(m.model_cache, attr)
-        optimizer_value = map_indices(m.model_to_optimizer_map, value)
+        optimizer_value = map_indices(m.model_to_optimizer_map, attr, value)
         MOI.set(m.optimizer, attr, optimizer_value)
     end
     return
@@ -727,7 +727,7 @@ end
 
 function MOI.set(m::CachingOptimizer, attr::MOI.AbstractModelAttribute, value)
     if m.state == ATTACHED_OPTIMIZER
-        optimizer_value = map_indices(m.model_to_optimizer_map, value)
+        optimizer_value = map_indices(m.model_to_optimizer_map, attr, value)
         if m.mode == AUTOMATIC
             try
                 MOI.set(m.optimizer, attr, optimizer_value)
@@ -754,7 +754,7 @@ function MOI.set(
 )
     if m.state == ATTACHED_OPTIMIZER
         optimizer_index = m.model_to_optimizer_map[index]
-        optimizer_value = map_indices(m.model_to_optimizer_map, value)
+        optimizer_value = map_indices(m.model_to_optimizer_map, attr, value)
         if m.mode == AUTOMATIC
             try
                 MOI.set(m.optimizer, attr, optimizer_index, optimizer_value)
@@ -802,6 +802,7 @@ function MOI.get(model::CachingOptimizer, attr::MOI.AbstractModelAttribute)
         end
         return map_indices(
             model.optimizer_to_model_map,
+            attr,
             MOI.get(model.optimizer, attr)::MOI.attribute_value_type(attr),
         )
     else
@@ -843,6 +844,7 @@ function MOI.get(
         end
         return map_indices(
             model.optimizer_to_model_map,
+            attr,
             MOI.get(
                 model.optimizer,
                 attr,
@@ -868,6 +870,7 @@ function MOI.get(
         end
         return map_indices(
             model.optimizer_to_model_map,
+            attr,
             MOI.get(
                 model.optimizer,
                 attr,
@@ -969,7 +972,7 @@ function MOI.set(
     attr::MOI.AbstractOptimizerAttribute,
     value,
 )
-    optimizer_value = map_indices(model.model_to_optimizer_map, value)
+    optimizer_value = map_indices(model.model_to_optimizer_map, attr, value)
     if model.optimizer !== nothing
         MOI.set(model.optimizer, attr, optimizer_value)
     end
@@ -990,6 +993,7 @@ function MOI.get(model::CachingOptimizer, attr::MOI.AbstractOptimizerAttribute)
     end
     return map_indices(
         model.optimizer_to_model_map,
+        attr,
         MOI.get(model.optimizer, attr)::MOI.attribute_value_type(attr),
     )
 end
@@ -1033,6 +1037,7 @@ function MOI.get(
     @assert m.state == ATTACHED_OPTIMIZER
     return map_indices(
         m.optimizer_to_model_map,
+        attr.attr,
         MOI.get(m.optimizer, attr.attr)::MOI.attribute_value_type(attr.attr),
     )
 end
@@ -1047,6 +1052,7 @@ function MOI.get(
     @assert m.state == ATTACHED_OPTIMIZER
     return map_indices(
         m.optimizer_to_model_map,
+        attr.attr,
         MOI.get(
             m.optimizer,
             attr.attr,
@@ -1065,6 +1071,7 @@ function MOI.get(
     @assert m.state == ATTACHED_OPTIMIZER
     return map_indices(
         m.optimizer_to_model_map,
+        attr.attr,
         MOI.get(
             m.optimizer,
             attr.attr,
@@ -1100,7 +1107,11 @@ function MOI.set(
     v,
 ) where {T<:MOI.AbstractModelAttribute}
     @assert m.state == ATTACHED_OPTIMIZER
-    MOI.set(m.optimizer, attr.attr, map_indices(m.model_to_optimizer_map, v))
+    MOI.set(
+        m.optimizer,
+        attr.attr,
+        map_indices(m.model_to_optimizer_map, attr.attr, v),
+    )
     return
 end
 
@@ -1127,7 +1138,7 @@ function MOI.set(
         m.optimizer,
         attr.attr,
         map_indices_to_optimizer(m, idx),
-        map_indices(m.model_to_optimizer_map, v),
+        map_indices(m.model_to_optimizer_map, attr.attr, v),
     )
     return
 end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -39,7 +39,7 @@ function _pass_attribute(
 )
     value = MOI.get(src, attr)
     if value !== nothing
-        MOI.set(dest, attr, map_indices(index_map, value))
+        MOI.set(dest, attr, map_indices(index_map, attr, value))
     end
     return
 end
@@ -81,7 +81,12 @@ function _pass_attribute(
     for x in vis_src
         value = MOI.get(src, attr, x)
         if value !== nothing
-            MOI.set(dest, attr, index_map[x], map_indices(index_map, value))
+            MOI.set(
+                dest,
+                attr,
+                index_map[x],
+                map_indices(index_map, attr, value),
+            )
         end
     end
     return
@@ -129,7 +134,12 @@ function _pass_attribute(
     for ci in cis_src
         value = MOI.get(src, attr, ci)
         if value !== nothing
-            MOI.set(dest, attr, index_map[ci], map_indices(index_map, value))
+            MOI.set(
+                dest,
+                attr,
+                index_map[ci],
+                map_indices(index_map, attr, value),
+            )
         end
     end
     return

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -3163,7 +3163,10 @@ function convert_approx(
     i = findfirst(t -> isapprox(t.coefficient, one(T), atol = tol), f.terms)
     if abs(f.constant) > tol ||
        i === nothing ||
-       any(j -> j != i && abs(f.terms[j].coefficient) > tol, eachindex(f.terms))
+       any(
+           j -> j != i && abs(f.terms[j].coefficient) > tol,
+           eachindex(f.terms),
+       )
         throw(InexactError(:convert_approx, MOI.VariableIndex, func))
     end
     return f.terms[i].variable

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -82,12 +82,20 @@ Substitute any [`MOI.VariableIndex`](@ref) (resp. [`MOI.ConstraintIndex`](@ref))
 in `x` by the [`MOI.VariableIndex`](@ref) (resp. [`MOI.ConstraintIndex`](@ref))
 of the same type given by `index_map(x)`.
 
-This function is used by implementations of [`MOI.copy_to`](@ref) on constraint
-functions, attribute values and submittable values hence it needs to be
-implemented for custom types that are meant to be used as attribute or
-submittable value.
+## When to implement this method for new types `X`
+
+This function is used by implementations of [`MOI.copy_to`](@ref) on
+constraint functions, attribute values and submittable values. If you define a
+new attribute whose values `x::X` contain variable or constraint indices, you
+must also implement this function.
+
+A default fallback of
+```julia
+map_indices(::F, x::Any) where {F<:Function} = x
+```
+exists for the case where the attribute value does not need to be changed.
 """
-function map_indices end
+map_indices(::F, x::Any) where {F<:Function} = x
 
 """
     map_indices(

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -449,7 +449,7 @@ function MOI.get(mock::MockOptimizer, attr::MOI.AbstractOptimizerAttribute)
     if MOI.is_set_by_optimize(attr)
         return mock.optimizer_attributes[attr]
     else
-        return xor_indices(MOI.get(mock.inner_model, attr))
+        return MOI.get(mock.inner_model, attr)
     end
 end
 function MOI.get(mock::MockOptimizer, attr::MOI.AbstractModelAttribute)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -323,7 +323,7 @@ function MOI.set(
     if MOI.is_set_by_optimize(attr)
         mock.optimizer_attributes[attr] = value
     else
-        MOI.set(mock.inner_model, attr, xor_indices(value))
+        MOI.set(mock.inner_model, attr, value)
     end
     return
 end

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -859,6 +859,27 @@ function test_ConstraintPrimal_fallback_error()
     return
 end
 
+struct _OptimizerAttributeValue1670 end
+
+function test_map_indices_issue_1670()
+    optimizer = MOI.Utilities.MockOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+    )
+    model = MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        optimizer,
+    )
+    MOI.Utilities.attach_optimizer(model)
+    MOI.set(
+        model,
+        MOI.RawOptimizerAttribute("1670"),
+        _OptimizerAttributeValue1670(),
+    )
+    @test MOI.get(optimizer, MOI.RawOptimizerAttribute("1670")) ==
+          _OptimizerAttributeValue1670()
+    return
+end
+
 end  # module
 
 TestCachingOptimizer.runtests()


### PR DESCRIPTION
Closes #1670.

I think the original argument was that we shouldn't have a fallback to force everyone to implement it. However, most people implementing this method just implement the fallback:
 - https://github.com/atoptima/BlockDecomposition.jl/blob/v1.4.0/src/axis.jl#L16
 - https://github.com/atoptima/BlockDecomposition.jl/blob/v1.4.0/src/tree.jl#L20

If people are writing new attributes and not accounting for this, that's on them for not testing correctly.