### PR TITLE
[Utilities] use ConstraintPrimal fallback in CachingOptimizer

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -853,6 +853,7 @@ function MOI.get(
         return MOI.get(model.model_cache, attr, index)
     end
 end
+
 function MOI.get(
     model::CachingOptimizer,
     attr::Union{MOI.AbstractVariableAttribute,MOI.AbstractConstraintAttribute},
@@ -875,6 +876,39 @@ function MOI.get(
         )
     else
         return MOI.get(model.model_cache, attr, indices)
+    end
+end
+
+###
+### MOI.ConstraintPrimal
+###
+
+# ConstraintPrimal is slightly unique for CachingOptimizer because if the solver
+# doesn't support the attribute directly, we can use the fallback to query the
+# function from the cache and the variable value from the optimizer.
+
+_mapped_indices(map, index::MOI.ConstraintIndex) = map[index]
+_mapped_indices(map, indices::Vector) = _mapped_indices(Ref(map), indices)
+
+function MOI.get(
+    model::CachingOptimizer,
+    attr::MOI.ConstraintPrimal,
+    index::Union{Vector{<:MOI.ConstraintIndex},MOI.ConstraintIndex},
+)
+    if state(model) == NO_OPTIMIZER
+        error(
+            "Cannot query $(attr) from caching optimizer because no " *
+            "optimizer is attached.",
+        )
+    end
+    try
+        return MOI.get(
+            model.optimizer,
+            attr,
+            _mapped_indices(model.model_to_optimizer_map, index),
+        )
+    catch
+        return get_fallback(model, attr, index)
     end
 end
 

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -912,7 +912,7 @@ end
 function MOI.get(
     model::CachingOptimizer,
     attr::MOI.ConstraintPrimal,
-    indices::Vector{<:MOI.ConstraintIndex}
+    indices::Vector{<:MOI.ConstraintIndex},
 )
     if state(model) == NO_OPTIMIZER
         error(

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -841,6 +841,14 @@ function test_ConstraintPrimal_fallback()
     )
     x = MOI.add_variable(model)
     c = MOI.add_constraint(model, x, MOI.GreaterThan(1.0))
+    @test_throws(
+        ErrorException,
+        MOI.get(model, MOI.ConstraintPrimal(), c),
+    )
+    @test_throws(
+        ErrorException,
+        MOI.get(model, MOI.ConstraintPrimal(), [c]),
+    )
     MOI.optimize!(model)
     @test MOI.get(model, MOI.ConstraintPrimal(), c) == 1.2
     @test MOI.get(model, MOI.ConstraintPrimal(), [c]) == [1.2]

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -841,17 +841,22 @@ function test_ConstraintPrimal_fallback()
     )
     x = MOI.add_variable(model)
     c = MOI.add_constraint(model, x, MOI.GreaterThan(1.0))
-    @test_throws(
-        ErrorException,
-        MOI.get(model, MOI.ConstraintPrimal(), c),
-    )
-    @test_throws(
-        ErrorException,
-        MOI.get(model, MOI.ConstraintPrimal(), [c]),
-    )
     MOI.optimize!(model)
     @test MOI.get(model, MOI.ConstraintPrimal(), c) == 1.2
     @test MOI.get(model, MOI.ConstraintPrimal(), [c]) == [1.2]
+    return
+end
+
+function test_ConstraintPrimal_fallback_error()
+    model = MOI.Utilities.CachingOptimizer(
+        MOI.Utilities.Model{Float64}(),
+        MOI.Utilities.AUTOMATIC,
+    )
+    x = MOI.add_variable(model)
+    c = MOI.add_constraint(model, x, MOI.GreaterThan(1.0))
+    @test_throws(ErrorException, MOI.get(model, MOI.ConstraintPrimal(), c))
+    @test_throws(ErrorException, MOI.get(model, MOI.ConstraintPrimal(), [c]))
+    return
 end
 
 end  # module


### PR DESCRIPTION
Closes #1310.

I think this is fine for the short-term. It's a continual pain-point for solvers (e.g., @chriscoey bumped into it when updating Pavito).