### PR TITLE
Revert "[Utilties] don't throw UnsupportedAttribute in pass_attribute…

### DIFF
--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -25,6 +25,7 @@ function pass_attributes(
             if attr == MOI.Name()
                 continue  # Skipping names is okay.
             end
+            throw(MOI.UnsupportedAttribute(attr))
         end
         _pass_attribute(dest, src, index_map, attr)
     end
@@ -65,6 +66,7 @@ function pass_attributes(
             if attr == MOI.VariableName() || attr == MOI.VariablePrimalStart()
                 continue  # Skipping names and start values is okay.
             end
+            throw(MOI.UnsupportedAttribute(attr))
         end
         _pass_attribute(dest, src, index_map, vis_src, attr)
     end
@@ -118,6 +120,7 @@ function pass_attributes(
             )
                 continue  # Skipping names and start values is okay.
             end
+            throw(MOI.UnsupportedAttribute(attr))
         end
         _pass_attribute(dest, src, index_map, cis_src, attr)
     end


### PR DESCRIPTION
This reverts commit 1a3c637dafd17e9ea59e66a774a2778e1f6ba772.

This caused widespread failures in SolverTests for solvers using a caching optimizer.
https://github.com/jump-dev/MathOptInterface.jl/pull/1656#issuecomment-978211649