### PR TITLE
[Test] fix missing config in _test_det_cone_helper

### DIFF
--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -5942,7 +5942,11 @@ function _test_det_cone_helper(
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         expected_objval = use_logdet ? log(T(5)) : 5^inv(T(3))
         @test ≈(MOI.get(model, MOI.ObjectiveValue()), expected_objval, config)
-        @test ≈(MOI.get(model, MOI.VariablePrimal(), t), expected_objval, config)
+        @test ≈(
+            MOI.get(model, MOI.VariablePrimal(), t),
+            expected_objval,
+            config,
+        )
         det_value = MOI.get(model, MOI.ConstraintPrimal(), det_constraint)
         @test ≈(det_value[1], expected_objval, config)
         if use_logdet

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -5942,7 +5942,7 @@ function _test_det_cone_helper(
         @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
         expected_objval = use_logdet ? log(T(5)) : 5^inv(T(3))
         @test ≈(MOI.get(model, MOI.ObjectiveValue()), expected_objval, config)
-        @test ≈(MOI.get(model, MOI.VariablePrimal(), t), expected_objval)
+        @test ≈(MOI.get(model, MOI.VariablePrimal(), t), expected_objval, config)
         det_value = MOI.get(model, MOI.ConstraintPrimal(), det_constraint)
         @test ≈(det_value[1], expected_objval, config)
         if use_logdet


### PR DESCRIPTION
Seems like I missed this one.  Caught by the solver test for SCS: https://github.com/jump-dev/SolverTests/runs/4328930300?check_suite_focus=true