### PR TITLE
Prep for v0.10.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "0.10.5"
+version = "0.10.6"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,6 +1,9 @@
 # Release notes
 
-## v0.10.6 (In development)
+## v0.10.6 (November 30, 2021)
+
+For a detailed list of the closed issues and pull requests from this release,
+see the [tag notes](https://github.com/jump-dev/MathOptInterface.jl/releases/tag/v0.10.6).
 
 ### New features
 
@@ -23,6 +26,7 @@
  - Fixed a bug in `FileFormats.NL` when printing large integers
  - Remove a common test failure for `LowerBoundAlreadySet` tests
  - `Utilities.num_rows` is now exported
+ - Remove parts of failing `test_model_copy_to_xxx` tests due to bridges
 
 ## v0.10.5 (November 7, 2021)
 


### PR DESCRIPTION
This release actually contained quite a bit of material.

Most solvers are passing: https://github.com/jump-dev/SolverTests/pull/17

The few that aren't either haven't been updated to 0.10, or are failing the new infeasibility certificate tests. There's a new feature in MOI.Test to avoid these situations in future.