### PR TITLE
Fix printing of non-real number types

### DIFF
--- a/src/Utilities/print.jl
+++ b/src/Utilities/print.jl
@@ -111,8 +111,10 @@ function _shorten(options::_PrintOptions, x::Float64)
     return string(x)
 end
 
+_shorten(::_PrintOptions, x) = string("(", x, ")")
+
 """
-    _to_string(options::_PrintOptions, c::Float64, x::String)
+    _to_string(options::_PrintOptions, c::Real, x::String)
 
 Write a coefficient-name pair to string. There are a few cases to handle.
 
@@ -126,12 +128,7 @@ Write a coefficient-name pair to string. There are a few cases to handle.
     +1.0x | "x"      | " + x"
     -1.0x | "-x"     | " - x"
 """
-function _to_string(
-    options::_PrintOptions,
-    c::Float64,
-    x::String;
-    is_first::Bool,
-)
+function _to_string(options::_PrintOptions, c::Real, x::String; is_first::Bool)
     prefix = if is_first
         c < 0 ? "-" : ""
     else
@@ -143,6 +140,15 @@ function _to_string(
     else
         return string(prefix, s, " ", x)
     end
+end
+
+function _to_string(
+    options::_PrintOptions,
+    c::Number,
+    x::String;
+    is_first::Bool,
+)
+    return string(is_first ? "" : " + ", _shorten(options, c), " ", x)
 end
 
 function _to_string(

--- a/test/Utilities/print.jl
+++ b/test/Utilities/print.jl
@@ -58,6 +58,31 @@ function test_numbers()
     @test MOIU._to_string(options, -1.2, "x"; is_first = false) == " - 1.2 x"
 end
 
+function test_complex_numbers()
+    x = 1.0 + 1.0im
+    options =
+        MOIU._PrintOptions(MIME("text/plain"); simplify_coefficients = true)
+    @test MOIU._to_string(options, x, "x"; is_first = true) == "(1.0 + 1.0im) x"
+    @test MOIU._to_string(options, x, "x"; is_first = false) ==
+          " + (1.0 + 1.0im) x"
+    @test MOIU._to_string(options, -x, "x"; is_first = true) ==
+          "(-1.0 - 1.0im) x"
+    @test MOIU._to_string(options, -x, "x"; is_first = false) ==
+          " + (-1.0 - 1.0im) x"
+    return
+end
+
+function test_rational_numbers()
+    x = 1 // 2
+    options =
+        MOIU._PrintOptions(MIME("text/plain"); simplify_coefficients = true)
+    @test MOIU._to_string(options, x, "x"; is_first = true) == "(1//2) x"
+    @test MOIU._to_string(options, x, "x"; is_first = false) == " + (1//2) x"
+    @test MOIU._to_string(options, -x, "x"; is_first = true) == "-(1//2) x"
+    @test MOIU._to_string(options, -x, "x"; is_first = false) == " - (1//2) x"
+    return
+end
+
 function test_variable()
     model = MOIU.Model{Float64}()
     x = MOI.add_variable(model)
@@ -97,6 +122,16 @@ function test_ScalarAffineFunction()
     )
     @test MOIU._to_string(PLAIN, model, f) == "1.4 - 1.2 x + 1.3 x"
     @test MOIU._to_string(LATEX, model, f) == "1.4 - 1.2 x + 1.3 x"
+end
+
+function test_ScalarAffineFunction_complex()
+    model = MOI.Utilities.UniversalFallback(MOIU.Model{Float64}())
+    x = MOI.add_variable(model)
+    MOI.set(model, MOI.VariableName(), x, "x")
+    f = (1.0 + 1.0im)x
+    s = MOI.EqualTo(1.0 + 1.0im)
+    @test MOIU._to_string(PLAIN, model, f) == "(0.0 + 0.0im) + (1.0 + 1.0im) x"
+    @test MOIU._to_string(LATEX, model, f) == "(0.0 + 0.0im) + (1.0 + 1.0im) x"
 end
 
 function test_ScalarQuadraticTerm()


### PR DESCRIPTION
Closes #1693

```Julia
julia> model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
MOIU.UniversalFallback{MOIU.Model{Float64}}
fallback for MOIU.Model{Float64}

julia> x = MOI.add_variable(model)
MathOptInterface.VariableIndex(1)

julia> c = MOI.add_constraint(model, (1.0 + 1.0im)x, MOI.EqualTo(1.0 + 1.0im))
MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{ComplexF64}, MathOptInterface.EqualTo{ComplexF64}}(1)

julia> print(model)
Feasibility

Subject to:

ScalarAffineFunction{ComplexF64}-in-EqualTo{ComplexF64}
 (0.0 + 0.0im) + (1.0 + 1.0im) v[1] == (1.0 + 1.0im)
```