### PR TITLE
Fix logic in cost_of_bridging

### DIFF
--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -397,8 +397,8 @@ of bridges that will need to be used.
 
 In fact, if the order does matter (in the sense that changing the order of the
 vector returned by this function leads to a different formulation), it means the
-variable _is_ in at least in one other variable constraint. Thus, in a sense we
-could do `x - y + sign(x)`` but `!iszero(x), x - y` is fine
+variable is in at least one other variable constraint. Thus, in a sense we
+could do `x - y + sign(x)`` but `!iszero(x), x - y` is fine.
 
 ## Example
 

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -374,11 +374,10 @@ The sorting happens in the `_cost_of_bridging` function and has three main
 considerations:
 
 1. First add sets for which the `VariableBridgingCost` is `0`. This ensures that
-   we minimize the number of variable bridges that get added. (Variable bridges
-   are bad because they produce an expression that needs substituting into the
-   remainder of the model.)
+   we minimize the number of variable bridges that get added.
 2. Then add sets for which the VariableBridgingCost is smaller than the
-   `ConstraintBridgingCost` (again avoiding variable bridges).
+   `ConstraintBridgingCost` so they can get added with
+   `add_constrained_variable(s)`.
 3. Finally, break any remaining ties in favor of `AbstractVectorSet`s. This
    ensures we attempt to add large blocks of variables (e.g., such as PSD
    matrices) before we add things like variable bounds.

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -367,8 +367,7 @@ end
 Return a `Vector{Type}` of the set types corresponding to `VariableIndex` and
 `VectorOfVariables` constraints in the order in which they should be added.
 
-The order is important because some solvers require variables to be added in
-particular order, and the order can also impact the bridging decisions.
+## How the order is computed
 
 The sorting happens in the `_cost_of_bridging` function and has three main
 considerations:
@@ -381,6 +380,54 @@ considerations:
 3. Finally, break any remaining ties in favor of `AbstractVectorSet`s. This
    ensures we attempt to add large blocks of variables (e.g., such as PSD
    matrices) before we add things like variable bounds.
+
+## Why the order is important
+
+The order is important because some solvers require variables to be added in
+particular order, and the order can also impact the bridging decisions.
+
+We favor adding first variables that won't use variables bridges because then
+the variable constraints on the same variable can still be added as
+`VariableIndex` or `VectorOfVariables` constraints.
+
+If a variable does need variable bridges and is part of another variable
+constraint, then the other variable constraint will be force-bridged into affine
+constraints, so there is a hidden cost in terms of number of additional number
+of bridges that will need to be used.
+
+In fact, if the order does matter (in the sense that changing the order of the
+vector returned by this function leads to a different formulation), it means the
+variable _is_ in at least in one other variable constraint. Thus, in a sense we
+could do `x - y + sign(x)`` but `!iszero(x), x - y` is fine
+
+## Example
+
+A key example is Pajarito. It supports `VariableIndex`-in-`Integer` and
+`VectorAffine`-in-`Nonnegatives`. If the user writes:
+```julia
+@variable(model, x >= 1, Int)
+```
+then we need to add two variable-related constraints:
+ * `VariableIndex`-in-`Integer`
+ * `VariableIndex`-in-`GreaterThan`
+The first is natively supported and the variable and constraint bridging cost is
+0. The second must be bridged to  `VectorAffineFunction`-in-`Nonnegatives` via
+`x - 1 in Nonnegatives(1)`, and the variable and constraint bridging cost is
+`1` in both cases.
+
+If the order is `[Integer, GreaterThan]`, then we add `x ∈ Integer` and
+`x - 1 in Nonnegatives`. Both are natively supported and it only requires a
+single constraint bridge.
+
+If the order is `[GreaterThan, Integer]`, then we add a new variable constrained
+to `y ∈ Nonnegatives` and end up with an expression from the variable bridge of
+`x = y + 1`. Then when we add the Integer constraint, we get `y + 1 in Integer`,
+which is not natively supported. Therefore, we need to add `y + 1 - z ∈ Zeros`
+and `z ∈ Integer`. Oops! This cost an extra variable, a variable bridge of
+`x = y + 1`and a `Zeros` constraint.
+
+Unfortunately, we don't have a good way of computing the updated costs for other
+constraints if a variable bridge is chosen.
 """
 function sorted_variable_sets_by_cost(dest::MOI.ModelLike, src::MOI.ModelLike)
     constraint_types = MOI.get(src, MOI.ListOfConstraintTypesPresent())

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -347,24 +347,20 @@ function _cost_of_bridging(
     dest::MOI.ModelLike,
     ::Type{S},
 ) where {S<:MOI.AbstractScalarSet}
-    return (
-        MOI.get(dest, MOI.VariableBridgingCost{S}()) +
-        MOI.get(dest, MOI.ConstraintBridgingCost{MOI.VariableIndex,S}()),
-        # In case of ties, we give priority to vector sets. See issue #987.
-        false,
-    )
+    x = MOI.get(dest, MOI.VariableBridgingCost{S}())
+    y = MOI.get(dest, MOI.ConstraintBridgingCost{MOI.VariableIndex,S}())
+    # In case of ties, we give priority to vector sets. See issue #987.
+    return (x - y, false, x + y)
 end
 
 function _cost_of_bridging(
     dest::MOI.ModelLike,
     ::Type{S},
 ) where {S<:MOI.AbstractVectorSet}
-    return (
-        MOI.get(dest, MOI.VariableBridgingCost{S}()) +
-        MOI.get(dest, MOI.ConstraintBridgingCost{MOI.VectorOfVariables,S}()),
-        # In case of ties, we give priority to vector sets. See issue #987
-        true,
-    )
+    x = MOI.get(dest, MOI.VariableBridgingCost{S}())
+    y = MOI.get(dest, MOI.ConstraintBridgingCost{MOI.VectorOfVariables,S}())
+    # In case of ties, we give priority to vector sets. See issue #987
+    return (x - y, true, x + y)
 end
 
 """

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -348,7 +348,7 @@ function _cost_of_bridging(
     ::Type{S},
 ) where {S<:MOI.AbstractScalarSet}
     return (
-        MOI.get(dest, MOI.VariableBridgingCost{S}()) -
+        MOI.get(dest, MOI.VariableBridgingCost{S}()) +
         MOI.get(dest, MOI.ConstraintBridgingCost{MOI.VariableIndex,S}()),
         # In case of ties, we give priority to vector sets. See issue #987.
         false,
@@ -360,7 +360,7 @@ function _cost_of_bridging(
     ::Type{S},
 ) where {S<:MOI.AbstractVectorSet}
     return (
-        MOI.get(dest, MOI.VariableBridgingCost{S}()) -
+        MOI.get(dest, MOI.VariableBridgingCost{S}()) +
         MOI.get(dest, MOI.ConstraintBridgingCost{MOI.VectorOfVariables,S}()),
         # In case of ties, we give priority to vector sets. See issue #987
         true,

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -449,7 +449,7 @@ function test_create_variables_using_supports_add_constrained_variable()
     dest = OrderConstrainedVariablesModel()
     bridged_dest = MOI.Bridges.full_bridge_optimizer(dest, Float64)
     @test MOIU.sorted_variable_sets_by_cost(bridged_dest, src) ==
-          Type[MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives]
+          Type[MOI.Nonnegatives, MOI.Zeros, MOI.Nonpositives]
     @test MOI.supports_add_constrained_variables(bridged_dest, MOI.Nonnegatives)
     @test MOI.get(bridged_dest, MOI.VariableBridgingCost{MOI.Nonnegatives}()) ==
           0.0
@@ -486,12 +486,12 @@ function test_create_variables_using_supports_add_constrained_variable()
         MOI.ConstraintBridgingCost{MOI.VectorOfVariables,MOI.Zeros}(),
     ) == 2.0
     index_map = MOI.copy_to(bridged_dest, src)
-    @test length(dest.constraintIndices) == 4
+    @test length(dest.constraintIndices) == 6
 
     dest = ReverseOrderConstrainedVariablesModel()
     bridged_dest = MOI.Bridges.full_bridge_optimizer(dest, Float64)
     @test MOIU.sorted_variable_sets_by_cost(bridged_dest, src) ==
-          Type[MOI.Zeros, MOI.Nonpositives, MOI.Nonnegatives]
+          Type[MOI.Nonpositives, MOI.Zeros, MOI.Nonnegatives]
     @test MOI.supports_add_constrained_variables(bridged_dest, MOI.Nonnegatives)
     @test MOI.get(bridged_dest, MOI.VariableBridgingCost{MOI.Nonnegatives}()) ==
           2.0
@@ -528,7 +528,7 @@ function test_create_variables_using_supports_add_constrained_variable()
         MOI.ConstraintBridgingCost{MOI.VectorOfVariables,MOI.Zeros}(),
     ) == 3.0
     index_map = MOI.copy_to(bridged_dest, src)
-    @test length(dest.constraintIndices) == 4
+    @test length(dest.constraintIndices) == 6
 
     # With single variables
     src = MOIU.Model{Float64}()
@@ -923,7 +923,7 @@ function test_sorted_variable_sets_by_cost_1()
     MOI.add_constraint(src, y, MOI.SecondOrderCone(2))
     dest = MOI.Bridges.full_bridge_optimizer(Optimizer1698_1(), Float64)
     @test MOI.Utilities.sorted_variable_sets_by_cost(dest, src) ==
-          [MOI.Integer, MOI.GreaterThan{Float64}, MOI.SecondOrderCone]
+          [MOI.SecondOrderCone, MOI.Integer, MOI.GreaterThan{Float64}]
     return
 end
 


### PR DESCRIPTION
@blegat should this be a + or a -? Part of #1698 

With the `-`:
```Julia
julia> solver = MOI.instantiate(
           MOI.OptimizerWithAttributes(
               MOIPajarito.Optimizer,
               "oa_solver" => MOI.OptimizerWithAttributes(GLPK.Optimizer),
               "conic_solver" => MOI.OptimizerWithAttributes(ECOS.Optimizer),
           );
           with_bridge_type = Float64
       );

julia> MOI.Utilities._cost_of_bridging(solver, MOI.GreaterThan{Float64})
(0.0, false)

julia> MOI.Utilities._cost_of_bridging(solver, MOI.Integer)
(0.0, false)
```
The cost for GreaterThan is `1 - 1` but the cost for `Integer` is `0 - 0`. Or perhaps we need to return a triplet of `(x - y, x + y, false)`.
