### PR TITLE
[perf] Precompile for instantiate

### DIFF
--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -249,6 +249,10 @@ include("instantiate.jl")
 include("deprecate.jl")
 include("DeprecatedTest/DeprecatedTest.jl")
 
+if VERSION > v"1.4.2"
+    _precompile_()
+end
+
 """
     IndexMap()
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -84,3 +84,7 @@ function precompile_model(model, constraints)
     end
     return Base.precompile(Tuple{typeof(add_constrained_variables),model,Reals})
 end
+
+function _precompile_()
+    Base.precompile(Tuple{Core.kwftype(typeof(instantiate)),NamedTuple{(:with_bridge_type,), Tuple{DataType}},typeof(instantiate),Type})   # time: 0.481656
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -86,5 +86,12 @@ function precompile_model(model, constraints)
 end
 
 function _precompile_()
-    Base.precompile(Tuple{Core.kwftype(typeof(instantiate)),NamedTuple{(:with_bridge_type,), Tuple{DataType}},typeof(instantiate),Type})   # time: 0.481656
+    return Base.precompile(
+        Tuple{
+            Core.kwftype(typeof(instantiate)),
+            NamedTuple{(:with_bridge_type,),Tuple{DataType}},
+            typeof(instantiate),
+            Type,
+        },
+    )   # time: 0.481656
 end


### PR DESCRIPTION
A small but easy win

Before
```
(base) oscar@Oscars-MBP time_to_first_solve % ~/julia --project=. script.jl clp
Running: clp 
 10.806358 seconds (26.74 M allocations: 1.644 GiB, 7.28% gc time, 21.54% compilation time)
  0.001693 seconds (3.54 k allocations: 305.125 KiB)
(base) oscar@Oscars-MBP time_to_first_solve % 
(base) oscar@Oscars-MBP time_to_first_solve % ~/julia --project=. script.jl clp --no-bridge
Running: clp --no-bridge
  5.038987 seconds (10.89 M allocations: 675.651 MiB, 5.38% gc time, 40.86% compilation time)
  0.001256 seconds (2.55 k allocations: 242.703 KiB)
(base) oscar@Oscars-MBP time_to_first_solve % ~/julia --project=. script.jl glpk           
Running: glpk 
  6.586336 seconds (17.67 M allocations: 1.037 GiB, 6.42% gc time, 35.91% compilation time)
  0.000462 seconds (1.22 k allocations: 84.453 KiB)
(base) oscar@Oscars-MBP time_to_first_solve % ~/julia --project=. script.jl glpk --no-bridge
Running: glpk --no-bridge
  4.445656 seconds (6.81 M allocations: 399.100 MiB, 5.10% gc time, 99.96% compilation time)
  0.000261 seconds (659 allocations: 65.656 KiB)
```

After
```
(base) oscar@Oscars-MBP time_to_first_solve % ~/julia --project=. script.jl clp
Running: clp 
 10.459239 seconds (26.24 M allocations: 1.615 GiB, 6.40% gc time, 20.68% compilation time)
  0.001283 seconds (3.54 k allocations: 305.125 KiB)
(base) oscar@Oscars-MBP time_to_first_solve % ~/julia --project=. script.jl clp --no-bridge
Running: clp --no-bridge
  4.933136 seconds (9.90 M allocations: 616.622 MiB, 5.80% gc time, 38.88% compilation time)
  0.001164 seconds (2.55 k allocations: 242.703 KiB)
(base) oscar@Oscars-MBP time_to_first_solve % ~/julia --project=. script.jl glpk           
Running: glpk 
  6.546280 seconds (17.18 M allocations: 1.008 GiB, 6.63% gc time, 35.29% compilation time)
  0.000453 seconds (1.22 k allocations: 84.453 KiB)
(base) oscar@Oscars-MBP time_to_first_solve % ~/julia --project=. script.jl glpk --no-bridge
Running: glpk --no-bridge
  3.855736 seconds (5.82 M allocations: 340.533 MiB, 5.64% gc time, 99.95% compilation time)
  0.000261 seconds (659 allocations: 65.656 KiB)
```