### PR TITLE
[Utilities] simplify MutableSparseMatrix to remove final_touch

### DIFF
--- a/src/Utilities/sparse_matrix.jl
+++ b/src/Utilities/sparse_matrix.jl
@@ -43,12 +43,15 @@ _shift(x::Array{<:Integer}, ::ZeroBasedIndexing, ::OneBasedIndexing) = x .+ 1
         colptr::Vector{Ti}
         rowval::Vector{Ti}
         nzval::Vector{Tv}
+        nz_added::Vector{Ti}
     end
 
 Matrix type loading sparse matrices in the Compressed Sparse Column format.
 The indexing used is `indexing`, see [`AbstractIndexing`](@ref). The other
 fields have the same meaning than for `SparseArrays.SparseMatrixCSC` except
-that the indexing is different unless `indexing` is `OneBasedIndexing`.
+that the indexing is different unless `indexing` is `OneBasedIndexing`. In
+addition, `nz_added` is used to cache the number of non-zero terms that have
+been added to each column due to the incremental nature of `load_terms`.
 
 The matrix is loaded in 5 steps:
 1) `MOI.empty!` is called.

--- a/test/Utilities/sparse_matrix.jl
+++ b/test/Utilities/sparse_matrix.jl
@@ -79,6 +79,11 @@ function test_VectorAffine_ZeroBased()
     @test A.rowval == [0, 0, 1, 0, 1]
     @test A.nzval == [1.0, 1.0, 2.0, 1.0, 3.0]
     @test A.colptr == [0, 1, 3, 5]
+    MOI.empty!(A)
+    MOI.Utilities.add_column(A)
+    C = convert(SparseArrays.SparseMatrixCSC{Float64,Int}, A)
+    @test size(C) == (0, 1)
+    return
 end
 
 function test_extract_function()
@@ -145,6 +150,11 @@ function test_VectorAffine_OneBased()
     @test A.rowval == [1, 1, 2, 1, 2]
     @test A.nzval == [1.0, 1.0, 2.0, 1.0, 3.0]
     @test A.colptr == [1, 2, 4, 6]
+    MOI.empty!(A)
+    MOI.Utilities.add_column(A)
+    C = convert(SparseArrays.SparseMatrixCSC{Float64,Int}, A)
+    @test size(C) == (0, 1)
+    return
 end
 
 function test_ScalarAffine_ZeroBased()
@@ -174,6 +184,11 @@ function test_ScalarAffine_ZeroBased()
     @test A.rowval == [0, 0, 1, 0, 1]
     @test A.nzval == [1.0, 1.0, 2.0, 1.0, 3.0]
     @test A.colptr == [0, 1, 3, 5]
+    MOI.empty!(A)
+    MOI.Utilities.add_column(A)
+    C = convert(SparseArrays.SparseMatrixCSC{Float64,Int}, A)
+    @test size(C) == (0, 1)
+    return
 end
 
 function test_ScalarAffine_OneBased()
@@ -203,6 +218,11 @@ function test_ScalarAffine_OneBased()
     @test A.rowval == [1, 1, 2, 1, 2]
     @test A.nzval == [1.0, 1.0, 2.0, 1.0, 3.0]
     @test A.colptr == [1, 2, 4, 6]
+    MOI.empty!(A)
+    MOI.Utilities.add_column(A)
+    C = convert(SparseArrays.SparseMatrixCSC{Float64,Int}, A)
+    @test size(C) == (0, 1)
+    return
 end
 
 end


### PR DESCRIPTION
Closes #1711 

The need for `final_touch` is just a recipe for bugs like this. We should endeavor to make it that we don't need to call `final_touch` for most things (now I think it's only the sets).