### PR TITLE
Add FreeVariables

### DIFF
--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -45,6 +45,7 @@ Utilities.ObjectiveContainer
 
 ```@docs
 Utilities.VariablesContainer
+Utilities.FreeVariables
 ```
 
 ### `.constraints`

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -61,6 +61,7 @@ include("variables.jl")
 
 include("objective_container.jl")
 include("variables_container.jl")
+include("free_variables.jl")
 include("vector_of_constraints.jl")
 include("struct_of_constraints.jl")
 include("model.jl")

--- a/src/Utilities/free_variables.jl
+++ b/src/Utilities/free_variables.jl
@@ -1,0 +1,39 @@
+"""
+    mutable struct FreeVariables <: MOI.ModelLike
+        n::Int64
+        FreeVariables() = new(0)
+    end
+
+A struct for storing free variables that can be used as the `variables` field
+of [`GenericModel`](@ref) or [`GenericModel`](@ref).
+"""
+mutable struct FreeVariables <: MOI.ModelLike
+    n::Int64
+    FreeVariables() = new(0)
+end
+
+function MOI.empty!(model::FreeVariables)
+    model.n = 0
+    return
+end
+
+MOI.is_empty(model::FreeVariables) = iszero(model.n)
+
+function MOI.add_variable(model::FreeVariables)
+    model.n += 1
+    return MOI.VariableIndex(model.n)
+end
+
+function MOI.get(model::FreeVariables, ::MOI.ListOfVariableIndices)
+    return MOI.VariableIndex[MOI.VariableIndex(i) for i in 1:model.n]
+end
+
+function MOI.is_valid(model::FreeVariables, vi::MOI.VariableIndex)
+    return 1 <= vi.value <= model.n
+end
+
+MOI.get(model::FreeVariables, ::MOI.NumberOfVariables) = model.n
+
+function MOI.get(model::FreeVariables, ::MOI.ListOfConstraintTypesPresent)
+    return Tuple{Type,Type}[]
+end

--- a/src/Utilities/free_variables.jl
+++ b/src/Utilities/free_variables.jl
@@ -5,7 +5,61 @@
     end
 
 A struct for storing free variables that can be used as the `variables` field
-of [`GenericModel`](@ref) or [`GenericModel`](@ref).
+of [`GenericModel`](@ref) or [`GenericModel`](@ref). It represents a model
+that does not support any constraint nor objective function.
+
+## Example
+
+The following model type represents a conic model in geometric form. As opposed
+to [`VariablesContainer`](@ref), `FreeVariables` does not support constraint
+bounds so they are bridged into an affine constraint in the
+[`MathOptInterface.Nonnegatives`](@ref) cone as expected for the geometric
+conic form.
+```jldocstest
+julia> MOI.Utilities.@product_of_sets(
+    Cones,
+    MOI.Zeros,
+    MOI.Nonnegatives,
+    MOI.SecondOrderCone,
+    MOI.PositiveSemidefiniteConeTriangle,
+);
+
+julia> const ConicModel{T} = MOI.Utilities.GenericOptimizer{
+    T,
+    MOI.Utilities.ObjectiveContainer{T},
+    MOI.Utilities.FreeVariables,
+    MOI.Utilities.MatrixOfConstraints{
+        T,
+        MOI.Utilities.MutableSparseMatrixCSC{
+            T,
+            Int,
+            MOI.Utilities.OneBasedIndexing,
+        },
+        Vector{T},
+        Cones{T},
+    },
+};
+
+julia> model = MOI.instantiate(ConicModel{Float64}, with_bridge_type=Float64);
+
+julia> x = MOI.add_variable(model)
+MathOptInterface.VariableIndex(1)
+
+julia> c = MOI.add_constraint(model, x, MOI.GreaterThan(1.0))
+MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.GreaterThan{Float64}}(1)
+
+julia> MOI.Bridges.is_bridged(model, c)
+true
+
+julia> bridge = MOI.Bridges.bridge(model, c)
+MathOptInterface.Bridges.Constraint.VectorizeBridge{Float64, MathOptInterface.VectorAffineFunction{Float64}, MathOptInterface.Nonnegatives, MathOptInterface.VariableIndex}(MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64}, MathOptInterface.Nonnegatives}(1), 1.0)
+
+julia> bridge.vector_constraint
+MathOptInterface.ConstraintIndex{MathOptInterface.VectorAffineFunction{Float64}, MathOptInterface.Nonnegatives}(1)
+
+julia> MOI.Bridges.is_bridged(model, bridge.vector_constraint)
+false
+```
 """
 mutable struct FreeVariables <: MOI.ModelLike
     n::Int64

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -343,11 +343,11 @@ end
 # Constraints
 
 function MOI.supports_constraint(
-    ::AbstractModel{T},
+    model::AbstractModel,
     ::Type{MOI.VariableIndex},
-    ::Type{<:SUPPORTED_VARIABLE_SCALAR_SETS{T}},
-) where {T}
-    return true
+    ::Type{S},
+) where {S<:MOI.AbstractScalarSet}
+    return MOI.supports_constraint(model.variables, MOI.VariableIndex, S)
 end
 function MOI.supports_constraint(
     model::AbstractModel,
@@ -358,10 +358,10 @@ function MOI.supports_constraint(
 end
 
 function MOI.add_constraint(
-    model::AbstractModel{T},
+    model::AbstractModel,
     f::MOI.VariableIndex,
-    s::SUPPORTED_VARIABLE_SCALAR_SETS{T},
-) where {T}
+    s::MOI.AbstractScalarSet,
+)
     return MOI.add_constraint(model.variables, f, s)
 end
 

--- a/src/Utilities/variables_container.jl
+++ b/src/Utilities/variables_container.jl
@@ -237,6 +237,14 @@ function MOI.get(b::VariablesContainer, ::MOI.NumberOfVariables)::Int64
     return sum(x != _DELETED_VARIABLE for x in b.set_mask)
 end
 
+function MOI.supports_constraint(
+    ::VariablesContainer{T},
+    ::Type{MOI.VariableIndex},
+    ::Type{<:SUPPORTED_VARIABLE_SCALAR_SETS{T}},
+) where {T}
+    return true
+end
+
 function MOI.add_constraint(
     b::VariablesContainer{T},
     f::MOI.VariableIndex,

--- a/src/Utilities/variables_container.jl
+++ b/src/Utilities/variables_container.jl
@@ -179,12 +179,6 @@ function VariablesContainer{T}() where {T}
     return VariablesContainer{T}(UInt16[], T[], T[])
 end
 
-function MOI.throw_if_not_valid(b::VariablesContainer, index)
-    if !MOI.is_valid(b, index)
-        throw(MOI.InvalidIndex(index))
-    end
-end
-
 function Base.:(==)(a::VariablesContainer, b::VariablesContainer)
     return a.set_mask == b.set_mask && a.lower == b.lower && a.upper == b.upper
 end
@@ -249,7 +243,7 @@ function MOI.add_constraint(
     b::VariablesContainer{T},
     f::MOI.VariableIndex,
     set::S,
-) where {T,S}
+) where {T,S<:SUPPORTED_VARIABLE_SCALAR_SETS}
     flag = _single_variable_flag(S)
     mask = b.set_mask[f.value]
     _throw_if_lower_bound_set(f, S, mask, T)
@@ -314,15 +308,6 @@ function MOI.set(
     return throw(MOI.SettingVariableIndexNotAllowed())
 end
 
-function MOI.set(
-    ::VariablesContainer,
-    ::MOI.ConstraintFunction,
-    ci::MOI.ConstraintIndex,
-    func,
-)
-    return throw(MOI.FunctionTypeMismatch{MOI.func_type(ci),typeof(func)}())
-end
-
 function MOI.get(
     model::VariablesContainer,
     ::MOI.ConstraintSet,
@@ -347,15 +332,6 @@ function MOI.set(
         model.upper[ci.value] = _upper_bound(set)
     end
     return
-end
-
-function MOI.set(
-    ::VariablesContainer,
-    ::MOI.ConstraintSet,
-    ci::MOI.ConstraintIndex{MOI.VariableIndex},
-    set,
-)
-    return throw(MOI.SetTypeMismatch{MOI.set_type(ci),typeof(set)}())
 end
 
 function MOI.get(
@@ -406,6 +382,49 @@ function MOI.get(
         end
     end
     return list
+end
+
+# These `MOI.ModelLike` fallbacks have to be redefined here as
+# `VariablesContainer` is not a subtype of `MOI.ModelLike`
+
+function MOI.throw_if_not_valid(b::VariablesContainer, index)
+    if !MOI.is_valid(b, index)
+        throw(MOI.InvalidIndex(index))
+    end
+end
+
+function MOI.set(
+    ::VariablesContainer,
+    ::MOI.ConstraintFunction,
+    ci::MOI.ConstraintIndex,
+    func,
+)
+    return throw(MOI.FunctionTypeMismatch{MOI.func_type(ci),typeof(func)}())
+end
+
+function MOI.set(
+    ::VariablesContainer,
+    ::MOI.ConstraintSet,
+    ci::MOI.ConstraintIndex{MOI.VariableIndex},
+    set,
+)
+    return throw(MOI.SetTypeMismatch{MOI.set_type(ci),typeof(set)}())
+end
+
+function MOI.supports_constraint(
+    ::VariablesContainer,
+    ::Type{<:MOI.AbstractFunction},
+    ::Type{<:MOI.AbstractSet},
+)
+    return false
+end
+
+function MOI.add_constraint(
+    ::VariablesContainer,
+    func::MOI.AbstractFunction,
+    set::MOI.AbstractSet,
+)
+    throw(MOI.UnsupportedConstraint{typeof(func),typeof(set)}())
 end
 
 ###

--- a/src/Utilities/variables_container.jl
+++ b/src/Utilities/variables_container.jl
@@ -424,7 +424,7 @@ function MOI.add_constraint(
     func::MOI.AbstractFunction,
     set::MOI.AbstractSet,
 )
-    throw(MOI.UnsupportedConstraint{typeof(func),typeof(set)}())
+    return throw(MOI.UnsupportedConstraint{typeof(func),typeof(set)}())
 end
 
 ###

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -55,7 +55,7 @@ function _new_VectorSets()
     return MOI.Utilities.GenericOptimizer{
         Int,
         MOI.Utilities.ObjectiveContainer{Int},
-        MOI.Utilities.VariablesContainer{Int},
+        MOI.Utilities.FreeVariables,
         MOI.Utilities.MatrixOfConstraints{
             Int,
             MOI.Utilities.MutableSparseMatrixCSC{
@@ -114,7 +114,9 @@ function test_VectorSets_basic()
         @test MOI.is_valid(src, k)
         @test MOI.is_valid(model, v)
     end
-    @test length(MOI.get(src, MOI.ListOfConstraintTypesPresent())) == 1
+    @test length(MOI.get(model, MOI.ListOfConstraintTypesPresent())) == 1
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+    @test MOI.get(model, MOI.ListOfVariableIndices()) == MOI.VariableIndex.(1:2)
     MOI.empty!(model)
     @test MOI.is_empty(model)
     return


### PR DESCRIPTION
Needed by https://github.com/jump-dev/DiffOpt.jl/pull/187/ and by most conic solvers.

The problem when using `VariablesContainer` is that model that use this as inner representation will need to redefine `supports_constraint` and `supports_add_constrained_variable` to avoid variables bounds to go through. This is quite tedious and if you don't do it correctly, you will silently ignore constraints that went through hidden in this VariablesContainer while they should have been bridged. This is the problem with DiffOpt.
For conic solvers, when they use `VariablesContainer` in their `OptimizerCache`, they need to verify that no variable bounds have been set during `copy_to`. Also, you cannot just copy_to to the `OptimizerCache` as otherwise, that won't bridge the variable bounds, you are forced to use it as cache of a `CachingOptimizer` as the `CachingOptimizer` will check that this is supported as well for the solver.