### PR TITLE
Fix performance of MutableArithmetics

### DIFF
--- a/src/Utilities/mutable_arithmetics.jl
+++ b/src/Utilities/mutable_arithmetics.jl
@@ -71,14 +71,14 @@ function MA.promote_operation(
     op::PROMOTE_IMPLEMENTED_OP,
     F::Type{<:ScalarLike{T}},
     G::Type{<:ScalarLike{T}},
-) where {T,N}
+) where {T}
     return promote_operation(op, T, F, G)
 end
 function MA.promote_operation(
     op::PROMOTE_IMPLEMENTED_OP,
     F::Type{T},
     G::Type{<:TypedLike{T}},
-) where {T,N}
+) where {T}
     return promote_operation(op, T, F, G)
 end
 function MA.promote_operation(


### PR DESCRIPTION
To be used in conjunction with https://github.com/jump-dev/MutableArithmetics.jl/pull/147

This is my new favorite performance bug of all time. For some reason,
the extra N type parameter was preventing Julia from being clever, but
it's soooooo hard to notice.