### PR TITLE
[Utilities] clean dispatch in MA.promote_operation

### DIFF
--- a/src/Utilities/mutable_arithmetics.jl
+++ b/src/Utilities/mutable_arithmetics.jl
@@ -65,15 +65,33 @@ function MA.promote_operation(
     return F
 end
 
-# To avoid type piracy, we add at least one `ScalarLike` outside of the `...`.
+
 const PROMOTE_IMPLEMENTED_OP = Union{typeof(+),typeof(-),typeof(*),typeof(/)}
+
 function MA.promote_operation(
     op::PROMOTE_IMPLEMENTED_OP,
-    F::Type{<:ScalarLike{T}},
-    G::Type{<:ScalarLike{T}},
+    F::Type{<:TypedScalarLike{T}},
+    G::Type{MOI.VariableIndex},
 ) where {T}
     return promote_operation(op, T, F, G)
 end
+
+function MA.promote_operation(
+    op::PROMOTE_IMPLEMENTED_OP,
+    F::Type{MOI.VariableIndex},
+    G::Type{<:TypedScalarLike{T}},
+) where {T}
+    return promote_operation(op, T, F, G)
+end
+
+function MA.promote_operation(
+    op::PROMOTE_IMPLEMENTED_OP,
+    F::Type{<:TypedScalarLike{T}},
+    G::Type{<:TypedScalarLike{T}},
+) where {T}
+    return promote_operation(op, T, F, G)
+end
+
 function MA.promote_operation(
     op::PROMOTE_IMPLEMENTED_OP,
     F::Type{T},

--- a/src/Utilities/mutable_arithmetics.jl
+++ b/src/Utilities/mutable_arithmetics.jl
@@ -65,7 +65,6 @@ function MA.promote_operation(
     return F
 end
 
-
 const PROMOTE_IMPLEMENTED_OP = Union{typeof(+),typeof(-),typeof(*),typeof(/)}
 
 function MA.promote_operation(


### PR DESCRIPTION
ScalarLike{T} includes VariableIndex, which does not have a type
parameter. So passing two variables to promote_operation would have
resulting in a 'T not defined error'.

_We_ know that this would have been caught by another method, but it
seems good coding practice to explicitly enumerate these methods.

Part of #1732 