### PR TITLE
Fix bug in which OptimizerAttributes were not copied to a CachingOptimizer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## v1.0.1 (In development)
+
+### Bug fixes
+
+ - Fixed a bug in which OptimizerAttributes were not copied in CachingOptimizer
+
 ## v1.0.0 (February 17, 2022)
 
 Although tagged as a breaking release, v1.0.0 is v0.10.9 with deprecations

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -104,7 +104,7 @@ mutable struct CachingOptimizer{O,M<:MOI.ModelLike} <: MOI.AbstractOptimizer
             IndexMap(),
         )
         # Optimizer attributes should be copied now. Other attributes are copied
-        # later.
+        # later during `copy_to`.
         _copy_optimizer_attributes(model)
         return model
     end

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -95,7 +95,7 @@ mutable struct CachingOptimizer{O,M<:MOI.ModelLike} <: MOI.AbstractOptimizer
         optimizer::MOI.AbstractOptimizer,
     )
         @assert MOI.is_empty(optimizer)
-        return new{typeof(optimizer),typeof(cache)}(
+        model = new{typeof(optimizer),typeof(cache)}(
             optimizer,
             cache,
             EMPTY_OPTIMIZER,
@@ -103,6 +103,10 @@ mutable struct CachingOptimizer{O,M<:MOI.ModelLike} <: MOI.AbstractOptimizer
             IndexMap(),
             IndexMap(),
         )
+        # Optimizer attributes should be copied now. Other attributes are copied
+        # later.
+        _copy_optimizer_attributes(model)
+        return model
     end
 end
 
@@ -115,6 +119,26 @@ function Base.show(io::IO, C::CachingOptimizer)
     show(IOContext(io, :indent => get(io, :indent, 0) + 2), C.model_cache)
     print(io, "\n$(indent)with optimizer ")
     return show(IOContext(io, :indent => get(io, :indent, 0) + 2), C.optimizer)
+end
+
+function _copy_optimizer_attributes(m::CachingOptimizer)
+    @assert m.state == EMPTY_OPTIMIZER
+    for attr in MOI.get(m.model_cache, MOI.ListOfOptimizerAttributesSet())
+        # Skip attributes which don't apply to the new optimizer.
+        if attr isa MOI.RawOptimizerAttribute
+            # Even if the optimizer claims to `supports` `attr`, the value
+            # might have a different meaning (e.g., two solvers with `logLevel`
+            # as a RawOptimizerAttribute). To be on the safe side, just skip all
+            # raw parameters.
+            continue
+        elseif !MOI.is_copyable(attr) || !MOI.supports(m.optimizer, attr)::Bool
+            continue
+        end
+        value = MOI.get(m.model_cache, attr)
+        optimizer_value = map_indices(m.model_to_optimizer_map, attr, value)
+        MOI.set(m.optimizer, attr, optimizer_value)
+    end
+    return
 end
 
 ## Methods for managing the state of CachingOptimizer.
@@ -147,21 +171,7 @@ function reset_optimizer(m::CachingOptimizer, optimizer::MOI.AbstractOptimizer)
     @assert MOI.is_empty(optimizer)
     m.optimizer = optimizer
     m.state = EMPTY_OPTIMIZER
-    for attr in MOI.get(m.model_cache, MOI.ListOfOptimizerAttributesSet())
-        # Skip attributes which don't apply to the new optimizer.
-        if attr isa MOI.RawOptimizerAttribute
-            # Even if the optimizer claims to `supports` `attr`, the value
-            # might have a different meaning (e.g., two solvers with `logLevel`
-            # as a RawOptimizerAttribute). To be on the safe side, just skip all raw
-            # parameters.
-            continue
-        elseif !MOI.is_copyable(attr) || !MOI.supports(m.optimizer, attr)::Bool
-            continue
-        end
-        value = MOI.get(m.model_cache, attr)
-        optimizer_value = map_indices(m.model_to_optimizer_map, attr, value)
-        MOI.set(m.optimizer, attr, optimizer_value)
-    end
+    _copy_optimizer_attributes(m)
     return
 end
 

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -891,6 +891,29 @@ function test_map_indices_issue_1670()
     return
 end
 
+function test_copy_optimizer_attributes_2887()
+    cache() = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    optimizer() = MOI.Utilities.MockOptimizer(cache())
+    # Test without calling Silent
+    model = cache()
+    opt = optimizer()
+    model = MOI.Utilities.CachingOptimizer(model, opt)
+    @test MOI.get(opt, MOI.Silent()) === nothing
+    # Test with Silent => true
+    model = cache()
+    MOI.set(model, MOI.Silent(), true)
+    opt = optimizer()
+    model = MOI.Utilities.CachingOptimizer(model, opt)
+    @test MOI.get(opt, MOI.Silent()) == true
+    # Test with Silent => false
+    model = cache()
+    MOI.set(model, MOI.Silent(), false)
+    opt = optimizer()
+    model = MOI.Utilities.CachingOptimizer(model, opt)
+    @test MOI.get(opt, MOI.Silent()) == false
+    return
+end
+
 end  # module
 
 TestCachingOptimizer.runtests()


### PR DESCRIPTION
Closes jump-dev/MathOptInterface.jl#1750
Closes https://github.com/jump-dev/JuMP.jl/issues/2887