### PR TITLE
Automatic promotion with shift_constant

### DIFF
--- a/src/Utilities/sets.jl
+++ b/src/Utilities/sets.jl
@@ -35,15 +35,19 @@ See also [`shift_constant`](@ref).
 """
 supports_shift_constant(::Type{S}) where {S<:MOI.AbstractSet} = false
 
-function shift_constant(
-    set::Union{MOI.LessThan{T},MOI.GreaterThan{T},MOI.EqualTo{T}},
-    offset::T,
-) where {T}
-    return typeof(set)(MOI.constant(set) + offset)
+function shift_constant(set::MOI.LessThan, offset)
+    return MOI.LessThan(MOI.constant(set) + offset)
 end
-
 supports_shift_constant(::Type{<:MOI.LessThan}) = true
+
+function shift_constant(set::MOI.GreaterThan, offset)
+    return MOI.GreaterThan(MOI.constant(set) + offset)
+end
 supports_shift_constant(::Type{<:MOI.GreaterThan}) = true
+
+function shift_constant(set::MOI.EqualTo, offset)
+    return MOI.EqualTo(MOI.constant(set) + offset)
+end
 supports_shift_constant(::Type{<:MOI.EqualTo}) = true
 
 function shift_constant(set::MOI.Interval, offset)

--- a/test/Utilities/sets.jl
+++ b/test/Utilities/sets.jl
@@ -46,10 +46,13 @@ end
 function test_shifts()
     @test MOIU.supports_shift_constant(MOI.EqualTo{Int})
     @test MOIU.shift_constant(MOI.EqualTo(3), 1) == MOI.EqualTo(4)
+    @test MOIU.shift_constant(MOI.EqualTo(3), im) == MOI.EqualTo(3 + im)
     @test MOIU.supports_shift_constant(MOI.GreaterThan{Int})
     @test MOIU.shift_constant(MOI.GreaterThan(6), -1) == MOI.GreaterThan(5)
+    @test MOIU.shift_constant(MOI.GreaterThan(6), -1.0) == MOI.GreaterThan(5.0)
     @test MOIU.supports_shift_constant(MOI.LessThan{Int})
     @test MOIU.shift_constant(MOI.LessThan(2), 2) == MOI.LessThan(4)
+    @test MOIU.shift_constant(MOI.LessThan(2), 2.0) == MOI.LessThan(4.0)
     @test MOIU.supports_shift_constant(MOI.Interval{Int})
     @test MOIU.shift_constant(MOI.Interval(-2, 3), 1) == MOI.Interval(-1, 4)
     @test MOIU.supports_shift_constant(MOI.ZeroOne) == false


### PR DESCRIPTION
This is needed to make this work at the JuMP level:
```julia
julia> @constraint(model, im * x == 1)
ERROR: MethodError: no method matching shift_constant(::MathOptInterface.EqualTo{Float64}, ::ComplexF64)
Closest candidates are:
  shift_constant(::Union{MathOptInterface.EqualTo{T}, MathOptInterface.GreaterThan{T}, MathOptInterface.LessThan{T}}, ::T) where T at ~/.julia/packages/MathOptInterface/IQWV4/src/Utilities/sets.jl:38
  shift_constant(::MathOptInterface.Interval, ::Any) at ~/.julia/packages/MathOptInterface/IQWV4/src/Utilities/sets.jl:49
  shift_constant(::MathOptInterface.Test.UnknownScalarSet, ::Any) at ~/.julia/packages/MathOptInterface/IQWV4/src/Test/test_model.jl:14
Stacktrace:
 [1] build_constraint(_error::Function, expr::GenericAffExpr{ComplexF64, VariableRef}, set::MathOptInterface.EqualTo{Float64})
   @ JuMP ~/.julia/dev/JuMP/src/macros.jl:574
 [2] macro expansion
   @ ~/.julia/dev/JuMP/src/macros.jl:816 [inlined]
 [3] top-level scope
   @ REPL[15]:1
```