### PR TITLE
Call final_touch in optimize in CachingOptimizer

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -298,6 +298,7 @@ MOI.is_empty(m::CachingOptimizer) = MOI.is_empty(m.model_cache)
 
 function MOI.optimize!(m::CachingOptimizer)
     if m.mode == AUTOMATIC && m.state == EMPTY_OPTIMIZER
+        final_touch(m.model_cache, nothing)
         # Here is a special case for callbacks: we can't use the two-argument
         # call to optimize! because we need the `optimizer_to_model_map` to be
         # set _prior_ to starting the optimization process. Therefore, we need

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -925,6 +925,9 @@ end
 function MOI.copy_to(::MOI.Utilities.MockOptimizer, ::FinalTouchDetector)
     return MOI.Utilities.IndexMap()
 end
+function MOI.get(::FinalTouchDetector, ::MOI.ListOfOptimizerAttributesSet)
+    return MOI.AbstractOptimizerAttribute[]
+end
 function MOI.get(::FinalTouchDetector, ::MOI.ListOfModelAttributesSet)
     return MOI.AbstractModelAttribute[]
 end


### PR DESCRIPTION
This allows to use a `CachingOptimizer` with a `MatrixOfConstraint` cache with the workflow: `add_variable`, `add_constraint`, `optimize`.

- [x] Test