### PR TITLE
[Bridges] error in RSOCtoPSD when dimension is 2

### DIFF
--- a/src/Bridges/Constraint/soc_to_psd.jl
+++ b/src/Bridges/Constraint/soc_to_psd.jl
@@ -185,7 +185,7 @@ function MOIB.map_function(::Type{<:RSOCtoPSDBridge{T}}, func) where {T}
     if length(scalars) < 3
         error(
             "Unable to bridge RotatedSecondOrderCone to PSD because the ",
-            "dimension is too small.",
+            "dimension is too small: got $(length(scalars)), expected >= 3.",
         )
     end
     h = MOIU.operate!(*, T, scalars[2], convert(T, 2))

--- a/src/Bridges/Constraint/soc_to_psd.jl
+++ b/src/Bridges/Constraint/soc_to_psd.jl
@@ -120,13 +120,16 @@ function MOIB.inverse_adjoint_map_function(
 end
 
 """
-The `RSOCtoPSDBridge` transforms the second order cone constraint ``\\lVert x \\rVert \\le 2tu`` with ``u \\ge 0`` into the semidefinite cone constraints
+The `RSOCtoPSDBridge` transforms the second order cone constraint
+``\\lVert x \\rVert \\le 2tu`` with ``u \\ge 0`` into the semidefinite cone
+constraints
 ```math
 \\begin{pmatrix}
   t & x^\\top\\\\
   x & 2uI
 \\end{pmatrix} \\succeq 0
 ```
+
 Indeed by the Schur Complement, it is positive definite iff
 ```math
 \\begin{align*}
@@ -179,6 +182,12 @@ end
 
 function MOIB.map_function(::Type{<:RSOCtoPSDBridge{T}}, func) where {T}
     scalars = MOIU.eachscalar(func)
+    if length(scalars) < 3
+        error(
+            "Unable to bridge RotatedSecondOrderCone to PSD because the ",
+            "dimension is too small."
+        )
+    end
     h = MOIU.operate!(*, T, scalars[2], convert(T, 2))
     return _SOCtoPSDaff(T, scalars[[1; 3:length(scalars)]], h)
 end

--- a/src/Bridges/Constraint/soc_to_psd.jl
+++ b/src/Bridges/Constraint/soc_to_psd.jl
@@ -185,7 +185,7 @@ function MOIB.map_function(::Type{<:RSOCtoPSDBridge{T}}, func) where {T}
     if length(scalars) < 3
         error(
             "Unable to bridge RotatedSecondOrderCone to PSD because the ",
-            "dimension is too small."
+            "dimension is too small.",
         )
     end
     h = MOIU.operate!(*, T, scalars[2], convert(T, 2))

--- a/test/Bridges/Constraint/soc_to_psd.jl
+++ b/test/Bridges/Constraint/soc_to_psd.jl
@@ -150,6 +150,22 @@ function test_RSOCtoPSD()
     return
 end
 
+# TODO(odow): we should fix this so it does not error.
+function test_rsoc_to_psd_dimension_2()
+    inner = MOI.Utilities.Model{Float64}()
+    model = MOI.Bridges.Constraint.RSOCtoPSD{Float64}(inner)
+    x = MOI.add_variables(model, 2)
+    @test_throws(
+        ErrorException,
+        MOI.add_constraint(
+            model,
+            MOI.VectorOfVariables(x),
+            MOI.RotatedSecondOrderCone(2),
+        ),
+    )
+    return
+end
+
 end  # module
 
 TestConstraintSOCtoPSD.runtests()


### PR DESCRIPTION
Closes #1761 

The premise of using a RotatedSecondOrderCone in dimension 2 has always seemed a bit iffy to me.