### PR TITLE
Use tolerance to compare value of blank objective in test

### DIFF
--- a/src/Test/test_objective.jl
+++ b/src/Test/test_objective.jl
@@ -192,7 +192,7 @@ function test_objective_ObjectiveFunction_blank(
     MOI.set(model, obj_attr, f)
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
-    @test MOI.get(model, MOI.ObjectiveValue()) == T(0)
+    @test isapprox(MOI.get(model, MOI.ObjectiveValue()), T(0), config)
     return
 end
 


### PR DESCRIPTION
With SDPA:
```julia
test_objective_ObjectiveFunction_blank: Test Failed at /home/runner/.julia/packages/MathOptInterface/FHFUH/src/Test/test_objective.jl:195
  Expression: MOI.get(model, MOI.ObjectiveValue()) == T(0)
   Evaluated: 1.3932339049530345e-8 == 0.0
```
See https://github.com/jump-dev/SDPA.jl/runs/5383637798?check_suite_focus=true#step:6:616