### PR TITLE
Fix to test_model_UpperBoundAlreadySet

### DIFF
--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -816,6 +816,7 @@ function test_model_UpperBoundAlreadySet(
     model::MOI.ModelLike,
     ::Config{T},
 ) where {T}
+    @requires _supports(config, MOI.delete)
     x = MOI.add_variable(model)
     ub = T(0)
     @requires MOI.supports_constraint(model, MOI.VariableIndex, MOI.LessThan{T})

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -816,11 +816,7 @@ function test_model_UpperBoundAlreadySet(
     model::MOI.ModelLike,
     config::Config{T},
 ) where {T}
-    @requires MOI.supports_constraint(
-        model,
-        MOI.VariableIndex,
-        MOI.LessThan{T},
-    )
+    @requires MOI.supports_constraint(model, MOI.VariableIndex, MOI.LessThan{T})
     @requires _supports(config, MOI.delete)
     x = MOI.add_variable(model)
     ub = T(0)

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -810,16 +810,20 @@ end
         ::Config{T},
     ) where {T}
 
-Test that setting a lower-bound twice throws `UpperBoundAlreadySet`.
+Test that setting an upper-bound twice throws `UpperBoundAlreadySet`.
 """
 function test_model_UpperBoundAlreadySet(
     model::MOI.ModelLike,
-    ::Config{T},
+    config::Config{T},
 ) where {T}
+    @requires MOI.supports_constraint(
+        model,
+        MOI.VariableIndex,
+        MOI.LessThan{T},
+    )
     @requires _supports(config, MOI.delete)
     x = MOI.add_variable(model)
     ub = T(0)
-    @requires MOI.supports_constraint(model, MOI.VariableIndex, MOI.LessThan{T})
     sets = [MOI.EqualTo(ub), MOI.Interval(ub, ub)]
     set2 = MOI.LessThan(ub)
     for set1 in sets


### PR DESCRIPTION
Modifies `test_model_UpperBoundAlreadySet` to match the implementation of `test_model_LowerBoundAlreadySet`.   In particular, fixes potential errors for solvers that do not support `MOI.delete` 
 by mirroring the requirement ```@requires _supports(config, MOI.delete)``` as in the lower bound test.