### PR TITLE
[FileFormats] fix copy_to for NL.Model when used with bridges

### DIFF
--- a/src/FileFormats/NL/NL.jl
+++ b/src/FileFormats/NL/NL.jl
@@ -829,10 +829,7 @@ function MOI.get(model::_CachingModel, attr::MOI.AnyAttribute, args...)
     return MOI.get(model.cache, attr, args...)
 end
 
-function MOI.supports(
-    model::_CachingModel,
-    attr::MOI.AnyAttribute,
-    args...)
+function MOI.supports(model::_CachingModel, attr::MOI.AnyAttribute, args...)
     return MOI.supports(model.inner, attr, args...)
 end
 
@@ -846,7 +843,7 @@ end
 
 function MOI.copy_to(
     dest::MOI.Bridges.LazyBridgeOptimizer{MOI.FileFormats.NL.Model},
-    src::MOI.ModelLike
+    src::MOI.ModelLike,
 )
     model = _CachingModel(dest.model)
     index_map = MOI.Utilities.default_copy_to(model, src)

--- a/src/FileFormats/NL/NL.jl
+++ b/src/FileFormats/NL/NL.jl
@@ -846,7 +846,9 @@ function MOI.copy_to(
     src::MOI.ModelLike,
 )
     model = _CachingModel(dest.model)
-    index_map = MOI.copy_to(model, src)
+    # This needs to be `default_copy_to` so that it uses the incremental
+    # interface.
+    index_map = MOI.Utilities.default_copy_to(model, src)
     MOI.copy_to(model.inner, model.cache)
     return index_map
 end

--- a/src/FileFormats/NL/NL.jl
+++ b/src/FileFormats/NL/NL.jl
@@ -846,7 +846,7 @@ function MOI.copy_to(
     src::MOI.ModelLike,
 )
     model = _CachingModel(dest.model)
-    index_map = MOI.Utilities.default_copy_to(model, src)
+    index_map = MOI.copy_to(model, src)
     MOI.copy_to(model.inner, model.cache)
     return index_map
 end

--- a/src/FileFormats/NL/NL.jl
+++ b/src/FileFormats/NL/NL.jl
@@ -838,7 +838,7 @@ function MOI.supports_constraint(
     f::MOI.AbstractFunction,
     s::MOI.AbstractSet,
 )
-    return MOI.supports(model.inner, f, s)
+    return MOI.supports_constraint(model.inner, f, s)
 end
 
 function MOI.copy_to(


### PR DESCRIPTION
Closes #1779 

This was actually slightly more complicated that expected (there's a long comment in the code explaining why this is necessary). But essentially we were missing a test for the case where we tried to copy to a `Bridges.full_bridge_optimizer(NL.Model(), Float64)`. The other file formats work fine because they use `@model`, but NL is special because I cut out an extra cache and only implemented `copy_to`. (I can't have tried it via JuMP since I removed the cache.)

Other fixes, like JuMP using a CachingOptimizer, won't work because `NL.Model` is not an AbstractOptimizer. This is definitely a hole in the API, but since this is a one-off case we can keep it like this for now. If we encounter other places where this is useful, we could consider adding a `CachingModel` to `MOI.Utilities`.

```Julia
julia> using JuMP

julia> model = Model()
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.

julia> @variable(model, x >= 0)
x

julia> @objective(model, Min, 2x + 1)
2 x + 1

julia> write_to_file(model, "test.nl")

shell> cat test.nl
g3 1 1 0
 1 0 1 0 0 0
 0 1
 0 0
 0 0 0
 0 0 0 1
 0 0 0 0 0
 0 1
 0 0
 0 0 0 0 0
O0 0
n1
x1
0 0
b
2 0
G0 1
0 2

(copt) pkg> st
      Status `/private/tmp/copt/Project.toml`
  [4076af6c] JuMP v0.23.2
  [b8f27783] MathOptInterface v1.1.0 `~/.julia/dev/MathOptInterface`
```