### PR TITLE
Relax AbstractOptimizer requirement in instantiate

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -92,7 +92,7 @@ mutable struct CachingOptimizer{O,M<:MOI.ModelLike} <: MOI.AbstractOptimizer
 
     function CachingOptimizer(
         cache::MOI.ModelLike,
-        optimizer::MOI.AbstractOptimizer,
+        optimizer::MOI.ModelLike,
     )
         @assert MOI.is_empty(optimizer)
         model = new{typeof(optimizer),typeof(cache)}(

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -90,10 +90,7 @@ mutable struct CachingOptimizer{O,M<:MOI.ModelLike} <: MOI.AbstractOptimizer
         )
     end
 
-    function CachingOptimizer(
-        cache::MOI.ModelLike,
-        optimizer::MOI.ModelLike,
-    )
+    function CachingOptimizer(cache::MOI.ModelLike, optimizer::MOI.ModelLike)
         @assert MOI.is_empty(optimizer)
         model = new{typeof(optimizer),typeof(cache)}(
             optimizer,

--- a/src/instantiate.jl
+++ b/src/instantiate.jl
@@ -55,18 +55,18 @@ const _INSTANTIATE_NOT_CALLABLE_MESSAGE =
     _instantiate_and_check(optimizer_constructor)
 
 Create an instance of optimizer by calling `optimizer_constructor`.
-Then check that the type returned is an empty [`AbstractOptimizer`](@ref).
+Then check that the type returned is an empty [`ModelLike`](@ref).
 """
 function _instantiate_and_check(optimizer_constructor)
     if !applicable(optimizer_constructor)
         error(_INSTANTIATE_NOT_CALLABLE_MESSAGE)
     end
     optimizer = optimizer_constructor()
-    if !isa(optimizer, AbstractOptimizer)
+    if !isa(optimizer, ModelLike)
         error(
             "The provided `optimizer_constructor` returned an object of type " *
             "$(typeof(optimizer)). Expected a " *
-            "MathOptInterface.AbstractOptimizer.",
+            "MathOptInterface.ModelLike.",
         )
     end
     if !is_empty(optimizer)

--- a/test/FileFormats/FileFormats.jl
+++ b/test/FileFormats/FileFormats.jl
@@ -49,6 +49,23 @@ function test_copying()
     end
 end
 
+function test_instantiate()
+    models = [
+        MOI.FileFormats.CBF.Model,
+        MOI.FileFormats.LP.Model,
+        MOI.FileFormats.MOF.Model,
+        MOI.FileFormats.MPS.Model,
+        MOI.FileFormats.SDPA.Model,
+    ]
+    for src in models
+        model = MOI.instantiate(src)
+        @test model isa src
+        bridged = MOI.instantiate(src; with_bridge_type = Float64)
+        @test bridged isa MOI.Bridges.LazyBridgeOptimizer
+    end
+    return
+end
+
 function test_compressed_open()
     for cs in [MOI.FileFormats.Bzip2(), MOI.FileFormats.Gzip()]
         for open_type in ["a", "r+", "w+", "a+"]

--- a/test/instantiate.jl
+++ b/test/instantiate.jl
@@ -67,7 +67,7 @@ function _test_instantiate(T)
 
     err = ErrorException(
         "The provided `optimizer_constructor` returned an object of type " *
-        "$Int. Expected a MathOptInterface.AbstractOptimizer.",
+        "$Int. Expected a MathOptInterface.ModelLike.",
     )
     h() = 1
     @test_throws err MOI.instantiate(h)


### PR DESCRIPTION
Alternative to #1780

This will need JuMP to lower-bound it's dependence on MOI, but that's okay. This is really a bug-fix, so I plan to tag as 1.1.1.
```julia
julia> using MathOptInterface; const MOI = MathOptInterface
MathOptInterface

julia> MOI.instantiate(MOI.FileFormats.NL.Model)
An AMPL (.nl) model

julia> MOI.instantiate(MOI.FileFormats.NL.Model; with_bridge_type = Float64)
MOIB.LazyBridgeOptimizer{MOIU.CachingOptimizer{MOI.FileFormats.NL.Model, MOIU.UniversalFallback{MOIU.Model{Float64}}}}
with 0 variable bridges
with 0 constraint bridges
with 0 objective bridges
with inner model MOIU.CachingOptimizer{MOI.FileFormats.NL.Model, MOIU.UniversalFallback{MOIU.Model{Float64}}}
  in state EMPTY_OPTIMIZER
  in mode AUTOMATIC
  with model cache MOIU.UniversalFallback{MOIU.Model{Float64}}
    fallback for MOIU.Model{Float64}
  with optimizer An AMPL (.nl) model

julia> MOI.instantiate(MOI.FileFormats.MPS.Model; with_bridge_type = Float64)
MOIB.LazyBridgeOptimizer{MOIU.GenericModel{Float64, MOIU.ObjectiveContainer{Float64}, MOIU.VariablesContainer{Float64}, MOI.FileFormats.MPS.ModelFunctionConstraints{Float64}}}
with 0 variable bridges
with 0 constraint bridges
with 0 objective bridges
with inner model A Mathematical Programming System (MPS) model
```