### PR TITLE
Allow throwing from ZeroOne tests with bounds

### DIFF
--- a/src/Test/test_constraint.jl
+++ b/src/Test/test_constraint.jl
@@ -537,14 +537,20 @@ function test_constraint_ZeroOne_bounds(
     try
         MOI.add_constraint(model, x, MOI.GreaterThan(T(0)))
     catch err
-        @test err isa MOI.LowerBoundAlreadySet
-        return
+        if err isa MOI.LowerBoundAlreadySet
+            return
+        else
+            rethrow(err)
+        end
     end
     try
         MOI.add_constraint(model, x, MOI.LessThan(T(1)))
     catch err
-        @test err isa MOI.UpperBoundAlreadySet
-        return
+        if err isa MOI.UpperBoundAlreadySet
+            return
+        else
+            rethrow(err)
+        end
     end
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     f = T(2) * x
@@ -589,14 +595,20 @@ function test_constraint_ZeroOne_bounds_2(
     try
         MOI.add_constraint(model, x, MOI.GreaterThan(T(0)))
     catch err
-        @test err isa MOI.LowerBoundAlreadySet
-        return
+        if err isa MOI.LowerBoundAlreadySet
+            return
+        else
+            rethrow(err)
+        end
     end
     try
         MOI.add_constraint(model, x, MOI.LessThan(T(1 // 2)))
     catch err
-        @test err isa MOI.UpperBoundAlreadySet
-        return
+        if err isa MOI.UpperBoundAlreadySet
+            return
+        else
+            rethrow(err)
+        end
     end
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     f = T(2) * x
@@ -642,14 +654,20 @@ function test_constraint_ZeroOne_bounds_3(
     try
         MOI.add_constraint(model, x, MOI.GreaterThan(T(1 // 5)))
     catch err
-        @test err isa MOI.LowerBoundAlreadySet
-        return
+        if err isa MOI.LowerBoundAlreadySet
+            return
+        else
+            rethrow(err)
+        end
     end
     try
         MOI.add_constraint(model, x, MOI.LessThan(T(1 // 2)))
     catch err
-        @test err isa MOI.UpperBoundAlreadySet
-        return
+        if err isa MOI.UpperBoundAlreadySet
+            return
+        else
+            rethrow(err)
+        end
     end
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     f = T(2) * x

--- a/src/Test/test_constraint.jl
+++ b/src/Test/test_constraint.jl
@@ -534,8 +534,18 @@ function test_constraint_ZeroOne_bounds(
     @requires MOI.supports_constraint(model, MOI.VariableIndex, MOI.ZeroOne)
     x = MOI.add_variable(model)
     MOI.add_constraint(model, x, MOI.ZeroOne())
-    MOI.add_constraint(model, x, MOI.GreaterThan(T(0)))
-    MOI.add_constraint(model, x, MOI.LessThan(T(1)))
+    try
+        MOI.add_constraint(model, x, MOI.GreaterThan(T(0)))
+    catch err
+        @test err isa MOI.LowerBoundAlreadySet
+        return
+    end
+    try
+        MOI.add_constraint(model, x, MOI.LessThan(T(1)))
+    catch err
+        @test err isa MOI.UpperBoundAlreadySet
+        return
+    end
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     f = T(2) * x
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
@@ -576,8 +586,18 @@ function test_constraint_ZeroOne_bounds_2(
     @requires MOI.supports_constraint(model, MOI.VariableIndex, MOI.ZeroOne)
     x = MOI.add_variable(model)
     MOI.add_constraint(model, x, MOI.ZeroOne())
-    MOI.add_constraint(model, x, MOI.GreaterThan(T(0)))
-    MOI.add_constraint(model, x, MOI.LessThan(T(1 // 2)))
+    try
+        MOI.add_constraint(model, x, MOI.GreaterThan(T(0)))
+    catch err
+        @test err isa MOI.LowerBoundAlreadySet
+        return
+    end
+    try
+        MOI.add_constraint(model, x, MOI.LessThan(T(1 // 2)))
+    catch err
+        @test err isa MOI.UpperBoundAlreadySet
+        return
+    end
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     f = T(2) * x
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
@@ -619,8 +639,18 @@ function test_constraint_ZeroOne_bounds_3(
     @requires _supports(config, MOI.optimize!)
     x = MOI.add_variable(model)
     MOI.add_constraint(model, x, MOI.ZeroOne())
-    MOI.add_constraint(model, x, MOI.GreaterThan(T(1 // 5)))
-    MOI.add_constraint(model, x, MOI.LessThan(T(1 // 2)))
+    try
+        MOI.add_constraint(model, x, MOI.GreaterThan(T(1 // 5)))
+    catch err
+        @test err isa MOI.LowerBoundAlreadySet
+        return
+    end
+    try
+        MOI.add_constraint(model, x, MOI.LessThan(T(1 // 2)))
+    catch err
+        @test err isa MOI.UpperBoundAlreadySet
+        return
+    end
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     f = T(2) * x
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)

--- a/src/Test/test_variable.jl
+++ b/src/Test/test_variable.jl
@@ -370,8 +370,11 @@ function test_variable_solve_ZeroOne_with_upper_bound(
     try
         MOI.add_constraint(model, x, MOI.ZeroOne())
     catch err
-        @test err isa MOI.UpperBoundAlreadySet
-        return
+        if err isa MOI.UpperBoundAlreadySet
+            return
+        else
+            rethrow(err)
+        end
     end
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
@@ -415,8 +418,11 @@ function test_variable_solve_ZeroOne_with_0_upper_bound(
     try
         MOI.add_constraint(model, x, MOI.ZeroOne())
     catch err
-        @test err isa MOI.UpperBoundAlreadySet
-        return
+        if err isa MOI.UpperBoundAlreadySet
+            return
+        else
+            rethrow(err)
+        end
     end
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)

--- a/src/Test/test_variable.jl
+++ b/src/Test/test_variable.jl
@@ -367,7 +367,12 @@ function test_variable_solve_ZeroOne_with_upper_bound(
     x = MOI.add_variable(model)
     MOI.add_constraint(model, x, MOI.LessThan(T(2)))
     f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(T(-2), x)], T(0))
-    MOI.add_constraint(model, x, MOI.ZeroOne())
+    try
+        MOI.add_constraint(model, x, MOI.ZeroOne())
+    catch err
+        @test err isa MOI.UpperBoundAlreadySet
+        return
+    end
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     _test_model_solution(
@@ -407,7 +412,12 @@ function test_variable_solve_ZeroOne_with_0_upper_bound(
     x = MOI.add_variable(model)
     MOI.add_constraint(model, x, MOI.LessThan(T(0)))
     f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(T(1), x)], T(0))
-    MOI.add_constraint(model, x, MOI.ZeroOne())
+    try
+        MOI.add_constraint(model, x, MOI.ZeroOne())
+    catch err
+        @test err isa MOI.UpperBoundAlreadySet
+        return
+    end
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     _test_model_solution(

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -139,7 +139,10 @@ function test_double_bounds()
         bridged_mock,
         config,
     )
-    MOI.Test.test_variable_solve_ZeroOne_with_upper_bound(bridged_mock, config)
+    MOI.Test.test_variable_solve_ZeroOne_with_upper_bound(
+        bridged_mock,
+        config,
+    )
 end
 
 end  # module

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -126,6 +126,19 @@ function test_ZeroOne()
     return
 end
 
+function test_double_bounds()
+    mock = MOI.Utilities.MockOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+    )
+    config = MOI.Test.Config()
+    bridged_mock = MOI.Bridges.Constraint.ZeroOne{Float64}(mock)
+    MOI.Test.test_constraint_ZeroOne_bounds(bridged_mock, config)
+    MOI.Test.test_constraint_ZeroOne_bounds_2(bridged_mock, config)
+    MOI.Test.test_constraint_ZeroOne_bounds_3(bridged_mock, config)
+    MOI.Test.test_variable_solve_ZeroOne_with_0_upper_bound(bridged_mock, config)
+    MOI.Test.test_variable_solve_ZeroOne_with_upper_bound(bridged_mock, config)
+end
+
 end  # module
 
 TestConstraintZeroOne.runtests()

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -135,7 +135,10 @@ function test_double_bounds()
     MOI.Test.test_constraint_ZeroOne_bounds(bridged_mock, config)
     MOI.Test.test_constraint_ZeroOne_bounds_2(bridged_mock, config)
     MOI.Test.test_constraint_ZeroOne_bounds_3(bridged_mock, config)
-    MOI.Test.test_variable_solve_ZeroOne_with_0_upper_bound(bridged_mock, config)
+    MOI.Test.test_variable_solve_ZeroOne_with_0_upper_bound(
+        bridged_mock,
+        config,
+    )
     MOI.Test.test_variable_solve_ZeroOne_with_upper_bound(bridged_mock, config)
 end
 

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -139,10 +139,8 @@ function test_double_bounds()
         bridged_mock,
         config,
     )
-    MOI.Test.test_variable_solve_ZeroOne_with_upper_bound(
-        bridged_mock,
-        config,
-    )
+    MOI.Test.test_variable_solve_ZeroOne_with_upper_bound(bridged_mock, config)
+    return
 end
 
 end  # module


### PR DESCRIPTION
This is needed for Mosek as it uses the `Bridges.Constraint.ZeroOneBridge`.