### PR TITLE
MOI.modify version for multiple changes at once

### DIFF
--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -102,8 +102,24 @@ end
 
 function modify(
     model::ModelLike,
+    cis::Vector{ConstraintIndex},
+    changes::Vector{AbstractFunctionModification},
+)
+    return throw_modify_not_allowed.(cis, changes)
+end
+
+function modify(
+    model::ModelLike,
     attr::ObjectiveFunction,
     change::AbstractFunctionModification,
 )
     return throw_modify_not_allowed(attr, change)
+end
+
+function modify(
+    model::ModelLike,
+    attr::ObjectiveFunction,
+    changes::Vector{AbstractFunctionModification},
+)
+    return throw_modify_not_allowed.(attr, changes)
 end


### PR DESCRIPTION
Many solvers support changing many coefficients at once. 

Some examples are functions in Gurobi (https://www.gurobi.com/documentation/9.5/refman/c_xchgcoeffs.html) and Xpress (https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/HTML/XPRSchgmcoef.html).

This is a draft about making an MOI version of such methods and a proper fallback. Honestly, I don't know what would be the best approach but I am happy to make a PR with the correct implementation.