### PR TITLE
MOI.modify version for multiple changes at once

### DIFF
--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -102,9 +102,9 @@ end
 
 function modify(
     model::ModelLike,
-    cis::AbstractVector{ConstraintIndex},
+    cis::AbstractVector{ConstraintIndex{F,S}},
     changes::AbstractVector{<:AbstractFunctionModification},
-)
+) where {F,S}
     @assert length(cis) == length(changes)
     for (i, ci) in enumerate(cis)
         MOI.modify(model, ci, changes[i])

--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -89,6 +89,36 @@ objectives is not supported by the model `model`.
 ```julia
 modify(model, ObjectiveFunction{ScalarAffineFunction{Float64}}(), ScalarConstantChange(10.0))
 ```
+
+## Multiple modifications in Constraint Functions
+
+    modify(model::ModelLike, cis::AbstractVector{<:ConstraintIndex}, changes::AbstractVector{<:AbstractFunctionModification})
+
+Apply multiple modifications specified by `changes` to the functions of constraints `cis`.
+
+An [`ModifyConstraintNotAllowed`](@ref) error is thrown if modifying
+constraints is not supported by the model `model`.
+
+### Examples
+
+```julia
+modify(model, [ci, ci], [ScalarCoefficientChange{Float64}(VariableIndex(1), 1.0); ScalarCoefficientChange{Float64}(VariableIndex(2), 0.5)])
+```
+
+## Multiple modifications in the Objective Function
+
+    modify(model::ModelLike, attr::ObjectiveFunction, changes::AbstractVector{<:AbstractFunctionModification})
+
+Apply multiple modifications specified by `changes` to the functions of constraints `cis`.
+
+An [`ModifyConstraintNotAllowed`](@ref) error is thrown if modifying
+constraints is not supported by the model `model`.
+
+### Examples
+
+```julia
+modify(model, ObjectiveFunction{ScalarAffineFunction{Float64}}(), [ScalarCoefficientChange{Float64}(VariableIndex(1), 1.0); ScalarCoefficientChange{Float64}(VariableIndex(2), 0.5)])
+```
 """
 function modify end
 
@@ -102,12 +132,12 @@ end
 
 function modify(
     model::ModelLike,
-    cis::AbstractVector{ConstraintIndex{F,S}},
+    cis::AbstractVector{<:ConstraintIndex},
     changes::AbstractVector{<:AbstractFunctionModification},
-) where {F,S}
+)
     @assert length(cis) == length(changes)
     for (i, ci) in enumerate(cis)
-        MOI.modify(model, ci, changes[i])
+        modify(model, ci, changes[i])
     end
     return
 end
@@ -126,7 +156,7 @@ function modify(
     changes::AbstractVector{<:AbstractFunctionModification},
 )
     for change in changes
-        MOI.modify(model, attr, change)
+        modify(model, attr, change)
     end
     return
 end

--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -100,8 +100,8 @@ modify(model, ObjectiveFunction{ScalarAffineFunction{Float64}}(), ScalarConstant
 
 Apply multiple modifications specified by `changes` to the functions of constraints `cis`.
 
-An [`ModifyConstraintNotAllowed`](@ref) error is thrown if modifying
-constraints is not supported by the model `model`.
+A [`ModifyConstraintNotAllowed`](@ref) error is thrown if modifying
+constraints is not supported by `model`.
 
 ### Examples
 
@@ -126,8 +126,8 @@ modify(
 
 Apply multiple modifications specified by `changes` to the functions of constraints `cis`.
 
-An [`ModifyConstraintNotAllowed`](@ref) error is thrown if modifying
-constraints is not supported by the model `model`.
+A [`ModifyObjectiveNotAllowed`](@ref) error is thrown if modifying
+objective coefficients is not supported by `model`.
 
 ### Examples
 

--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -102,10 +102,14 @@ end
 
 function modify(
     model::ModelLike,
-    cis::Vector{ConstraintIndex},
-    changes::Vector{AbstractFunctionModification},
+    cis::AbstractVector{ConstraintIndex},
+    changes::AbstractVector{<:AbstractFunctionModification},
 )
-    return throw_modify_not_allowed.(cis, changes)
+    @assert length(cis) == length(changes)
+    for (i, ci) in enumerate(cis)
+        MOI.modify(model, ci, changes[i])
+    end
+    return
 end
 
 function modify(
@@ -119,7 +123,10 @@ end
 function modify(
     model::ModelLike,
     attr::ObjectiveFunction,
-    changes::Vector{AbstractFunctionModification},
+    changes::AbstractVector{<:AbstractFunctionModification},
 )
-    return throw_modify_not_allowed.(attr, changes)
+    for change in changes
+        MOI.modify(model, attr, change)
+    end
+    return
 end

--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -92,7 +92,11 @@ modify(model, ObjectiveFunction{ScalarAffineFunction{Float64}}(), ScalarConstant
 
 ## Multiple modifications in Constraint Functions
 
-    modify(model::ModelLike, cis::AbstractVector{<:ConstraintIndex}, changes::AbstractVector{<:AbstractFunctionModification})
+    modify(
+        model::ModelLike,
+        cis::AbstractVector{<:ConstraintIndex},
+        changes::AbstractVector{<:AbstractFunctionModification},
+    )
 
 Apply multiple modifications specified by `changes` to the functions of constraints `cis`.
 
@@ -102,12 +106,23 @@ constraints is not supported by the model `model`.
 ### Examples
 
 ```julia
-modify(model, [ci, ci], [ScalarCoefficientChange{Float64}(VariableIndex(1), 1.0); ScalarCoefficientChange{Float64}(VariableIndex(2), 0.5)])
+modify(
+    model,
+    [ci, ci],
+    [
+        ScalarCoefficientChange{Float64}(VariableIndex(1), 1.0),
+        ScalarCoefficientChange{Float64}(VariableIndex(2), 0.5),
+    ],
+)
 ```
 
 ## Multiple modifications in the Objective Function
 
-    modify(model::ModelLike, attr::ObjectiveFunction, changes::AbstractVector{<:AbstractFunctionModification})
+    modify(
+        model::ModelLike,
+        attr::ObjectiveFunction,
+        changes::AbstractVector{<:AbstractFunctionModification},
+    )
 
 Apply multiple modifications specified by `changes` to the functions of constraints `cis`.
 
@@ -117,7 +132,14 @@ constraints is not supported by the model `model`.
 ### Examples
 
 ```julia
-modify(model, ObjectiveFunction{ScalarAffineFunction{Float64}}(), [ScalarCoefficientChange{Float64}(VariableIndex(1), 1.0); ScalarCoefficientChange{Float64}(VariableIndex(2), 0.5)])
+modify(
+    model,
+    ObjectiveFunction{ScalarAffineFunction{Float64}}(),
+    [
+        ScalarCoefficientChange{Float64}(VariableIndex(1), 1.0),
+        ScalarCoefficientChange{Float64}(VariableIndex(2), 0.5),
+    ],
+)
 ```
 """
 function modify end
@@ -136,8 +158,8 @@ function modify(
     changes::AbstractVector{<:AbstractFunctionModification},
 )
     @assert length(cis) == length(changes)
-    for (i, ci) in enumerate(cis)
-        modify(model, ci, changes[i])
+    for (ci, change) in zip(cis, changes)
+        modify(model, ci, change)
     end
     return
 end

--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -102,8 +102,24 @@ end
 
 function modify(
     model::ModelLike,
+    cis::Vector{ConstraintIndex},
+    changes::Vector{AbstractFunctionModification},
+)
+    return throw_modify_not_allowed.(cis, changes)
+end
+
+function modify(
+    model::ModelLike,
     attr::ObjectiveFunction,
     change::AbstractFunctionModification,
 )
     return throw_modify_not_allowed(attr, change)
+end
+
+function modify(
+    model::ModelLike,
+    attr::ObjectiveFunction,
+    changes::Vector{AbstractFunctionModification},
+)
+    return throw_modify_not_allowed.(attr, changes)
 end


### PR DESCRIPTION
Many solvers support changing many coefficients at once.

Some examples are functions in Gurobi (https://www.gurobi.com/documentation/9.5/refman/c_xchgcoeffs.html) and Xpress (https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/HTML/XPRSchgmcoef.html).

This is a draft about making an MOI version of such methods and a proper fallback. Honestly, I don't know what would be the best approach but I am happy to make a PR with the correct implementation.