### PR TITLE
[FileFormats] fix default lower bound in LP reader

### DIFF
--- a/src/FileFormats/LP/LP.jl
+++ b/src/FileFormats/LP/LP.jl
@@ -602,7 +602,9 @@ function _parse_section(
 )
     tokens = _tokenize(line)
     if length(tokens) == 2 && tokens[2] == "free"
-        return  # Do nothing. Variable is free
+        x = _get_variable_from_name(model, cache, tokens[1])
+        _delete_default_lower_bound_if_present(model, cache, x)
+        return
     end
     lb, ub, name = -Inf, Inf, ""
     if length(tokens) == 5

--- a/test/FileFormats/LP/LP.jl
+++ b/test/FileFormats/LP/LP.jl
@@ -423,6 +423,27 @@ function test_default_bound()
     return
 end
 
+function test_default_bound_double_bound()
+    io = IOBuffer()
+    write(io, "minimize\nobj: x\nsubject to\nbounds\n x <= -1\n x >= -2")
+    seekstart(io)
+    model = LP.Model()
+    MOI.read!(io, model)
+    x = first(MOI.get(model, MOI.ListOfVariableIndices()))
+    F = MOI.VariableIndex
+    @test MOI.get(
+        model,
+        MOI.ConstraintSet(),
+        MOI.ConstraintIndex{F,MOI.GreaterThan{Float64}}(x.value),
+    ) == MOI.GreaterThan(-2.0)
+    @test MOI.get(
+        model,
+        MOI.ConstraintSet(),
+        MOI.ConstraintIndex{F,MOI.LessThan{Float64}}(x.value),
+    ) == MOI.LessThan(-1.0)
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__, all = true)
         if startswith("$(name)", "test_")

--- a/test/FileFormats/LP/LP.jl
+++ b/test/FileFormats/LP/LP.jl
@@ -408,6 +408,21 @@ function test_read_maximum_length_error()
     return
 end
 
+function test_default_bound()
+    io = IOBuffer()
+    write(io, "minimize\nobj: x + y")
+    seekstart(io)
+    model = LP.Model()
+    MOI.read!(io, model)
+    x = MOI.get(model, MOI.ListOfVariableIndices())
+    F, S = MOI.VariableIndex,MOI.GreaterThan{Float64}
+    c = [MOI.ConstraintIndex{F,S}(xi.value) for xi in x]
+    sets = MOI.get.(model, MOI.ConstraintSet(), c)
+    @test all(s -> s == MOI.GreaterThan(0.0), sets)
+    @test length(sets) == 2
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__, all = true)
         if startswith("$(name)", "test_")

--- a/test/FileFormats/LP/LP.jl
+++ b/test/FileFormats/LP/LP.jl
@@ -415,7 +415,7 @@ function test_default_bound()
     model = LP.Model()
     MOI.read!(io, model)
     x = MOI.get(model, MOI.ListOfVariableIndices())
-    F, S = MOI.VariableIndex,MOI.GreaterThan{Float64}
+    F, S = MOI.VariableIndex, MOI.GreaterThan{Float64}
     c = [MOI.ConstraintIndex{F,S}(xi.value) for xi in x]
     sets = MOI.get.(model, MOI.ConstraintSet(), c)
     @test all(s -> s == MOI.GreaterThan(0.0), sets)


### PR DESCRIPTION
Closes #1809. The LP reader is still immature compared to the other formats.