### PR TITLE
Add license header to all files

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 import Documenter
 import MathOptInterface
 

--- a/perf/bellman_ford.jl
+++ b/perf/bellman_ford.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using BenchmarkTools
 using MathOptInterface
 const MOI = MathOptInterface

--- a/perf/cachingoptimizer.jl
+++ b/perf/cachingoptimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # See https://github.com/jump-dev/MathOptInterface.jl/issues/321,
 #     https://github.com/jump-dev/MathOptInterface.jl/pull/323 and
 #     https://github.com/jump-dev/MathOptInterface.jl/pull/390

--- a/perf/time_to_first_solve/script.jl
+++ b/perf/time_to_first_solve/script.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using MathOptInterface
 import GLPK
 import Clp

--- a/src/Benchmarks/Benchmarks.jl
+++ b/src/Benchmarks/Benchmarks.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module Benchmarks
 
 using BenchmarkTools, MathOptInterface

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module Bridges
 
 using MathOptInterface

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module Constraint
 
 using OrderedCollections # for OrderedDict in Map

--- a/src/Bridges/Constraint/bridge.jl
+++ b/src/Bridges/Constraint/bridge.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     AbstractBridge
 

--- a/src/Bridges/Constraint/det.jl
+++ b/src/Bridges/Constraint/det.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     extract_eigenvalues(
         model,

--- a/src/Bridges/Constraint/flip_sign.jl
+++ b/src/Bridges/Constraint/flip_sign.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     FlipSignBridge{T, S1, S2, F, G}
 

--- a/src/Bridges/Constraint/function_conversion.jl
+++ b/src/Bridges/Constraint/function_conversion.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     abstract type AbstractFunctionConversionBridge{F, S} <: AbstractBridge end
 

--- a/src/Bridges/Constraint/functionize.jl
+++ b/src/Bridges/Constraint/functionize.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # scalar version
 
 """

--- a/src/Bridges/Constraint/geomean.jl
+++ b/src/Bridges/Constraint/geomean.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     GeoMeanBridge{T, F, G, H}
 

--- a/src/Bridges/Constraint/geomean_to_relentr.jl
+++ b/src/Bridges/Constraint/geomean_to_relentr.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     GeoMeantoRelEntrBridge{T}
 

--- a/src/Bridges/Constraint/indicator_activate_on_zero.jl
+++ b/src/Bridges/Constraint/indicator_activate_on_zero.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     IndicatorActiveOnFalseBridge{T}
 

--- a/src/Bridges/Constraint/indicator_sos.jl
+++ b/src/Bridges/Constraint/indicator_sos.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     IndicatorSOS1Bridge{T,S<:MOI.AbstractScalarSet}
 

--- a/src/Bridges/Constraint/interval.jl
+++ b/src/Bridges/Constraint/interval.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 _lower_set(set::MOI.Interval) = MOI.GreaterThan(set.lower)
 function _lower_set(set::MOI.Interval{T}) where {T<:AbstractFloat}
     if set.lower == typemin(T)

--- a/src/Bridges/Constraint/ltgt_to_interval.jl
+++ b/src/Bridges/Constraint/ltgt_to_interval.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # The code here is mostly copied from the flip_sign.jl code for FlipSignBridge and GreaterToLessBridge
 
 """

--- a/src/Bridges/Constraint/map.jl
+++ b/src/Bridges/Constraint/map.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     Map <: AbstractDict{MOI.VariableIndex, AbstractBridge}
 

--- a/src/Bridges/Constraint/norm_spec_nuc_to_psd.jl
+++ b/src/Bridges/Constraint/norm_spec_nuc_to_psd.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     NormSpectralBridge{T}
 

--- a/src/Bridges/Constraint/norm_to_lp.jl
+++ b/src/Bridges/Constraint/norm_to_lp.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     NormInfinityBridge{T}
 

--- a/src/Bridges/Constraint/quad_to_soc.jl
+++ b/src/Bridges/Constraint/quad_to_soc.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 import LinearAlgebra
 import SparseArrays
 

--- a/src/Bridges/Constraint/relentr_to_exp.jl
+++ b/src/Bridges/Constraint/relentr_to_exp.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     RelativeEntropyBridge{T}
 

--- a/src/Bridges/Constraint/scalarize.jl
+++ b/src/Bridges/Constraint/scalarize.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     ScalarizeBridge{T, F, S}
 

--- a/src/Bridges/Constraint/semi_to_binary.jl
+++ b/src/Bridges/Constraint/semi_to_binary.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 const _SemiSets{T} = Union{MOI.Semicontinuous{T},MOI.Semiinteger{T}}
 
 """

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     abstract type SetMapBridge{T,S2,S1,F,G} <: AbstractBridge end
 

--- a/src/Bridges/Constraint/single_bridge_optimizer.jl
+++ b/src/Bridges/Constraint/single_bridge_optimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     SingleBridgeOptimizer{BT<:AbstractBridge, OT<:MOI.ModelLike} <:
     AbstractBridgeOptimizer

--- a/src/Bridges/Constraint/slack.jl
+++ b/src/Bridges/Constraint/slack.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 abstract type AbstractSlackBridge{T,VF,ZS,F,S} <: AbstractBridge end
 
 function MOI.Bridges.added_constrained_variable_types(

--- a/src/Bridges/Constraint/soc_rsoc.jl
+++ b/src/Bridges/Constraint/soc_rsoc.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     RSOCtoSOCBridge{T, F, G}
 

--- a/src/Bridges/Constraint/soc_to_nonconvex_quad.jl
+++ b/src/Bridges/Constraint/soc_to_nonconvex_quad.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 abstract type AbstractSOCtoNonConvexQuadBridge{T} <: AbstractBridge end
 
 """

--- a/src/Bridges/Constraint/soc_to_psd.jl
+++ b/src/Bridges/Constraint/soc_to_psd.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     _SOCtoPSDaff{T}(f::MOI.VectorAffineFunction{T}, g::MOI.ScalarAffineFunction{T})
 

--- a/src/Bridges/Constraint/square.jl
+++ b/src/Bridges/Constraint/square.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # Let S₊ be the cone of symmetric semidefinite matrices in
 # the n*(n+1)/2 dimensional space of symmetric R^{nxn} matrices.
 # It is well known that S₊ is a self-dual proper cone.

--- a/src/Bridges/Constraint/vectorize.jl
+++ b/src/Bridges/Constraint/vectorize.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     VectorizeBridge{T,F,S,G}
 

--- a/src/Bridges/Constraint/zero_one.jl
+++ b/src/Bridges/Constraint/zero_one.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     ZeroOneBridge{T}
 

--- a/src/Bridges/Objective/Objective.jl
+++ b/src/Bridges/Objective/Objective.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module Objective
 
 using MathOptInterface

--- a/src/Bridges/Objective/bridge.jl
+++ b/src/Bridges/Objective/bridge.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     AbstractBridge
 

--- a/src/Bridges/Objective/functionize.jl
+++ b/src/Bridges/Objective/functionize.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     FunctionizeBridge{T}
 

--- a/src/Bridges/Objective/map.jl
+++ b/src/Bridges/Objective/map.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     Map <: AbstractDict{MOI.ObjectiveFunction, AbstractBridge}
 

--- a/src/Bridges/Objective/single_bridge_optimizer.jl
+++ b/src/Bridges/Objective/single_bridge_optimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     SingleBridgeOptimizer{BT<:AbstractBridge, OT<:MOI.ModelLike} <: AbstractBridgeOptimizer
 

--- a/src/Bridges/Objective/slack.jl
+++ b/src/Bridges/Objective/slack.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     SlackBridge{T, F, G}
 

--- a/src/Bridges/Variable/Variable.jl
+++ b/src/Bridges/Variable/Variable.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module Variable
 
 using MathOptInterface

--- a/src/Bridges/Variable/bridge.jl
+++ b/src/Bridges/Variable/bridge.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     AbstractBridge
 

--- a/src/Bridges/Variable/flip_sign.jl
+++ b/src/Bridges/Variable/flip_sign.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     FlipSignBridge{T, S1, S2}
 

--- a/src/Bridges/Variable/free.jl
+++ b/src/Bridges/Variable/free.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     FreeBridge{T} <: Bridges.Variable.AbstractBridge
 

--- a/src/Bridges/Variable/map.jl
+++ b/src/Bridges/Variable/map.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     Map <: AbstractDict{MOI.VariableIndex, AbstractBridge}
 

--- a/src/Bridges/Variable/rsoc_to_psd.jl
+++ b/src/Bridges/Variable/rsoc_to_psd.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     RSOCtoPSDBridge{T} <: Bridges.Variable.AbstractBridge
 

--- a/src/Bridges/Variable/set_map.jl
+++ b/src/Bridges/Variable/set_map.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     abstract type SetMapBridge{T,S1,S2} <: AbstractBridge end
 

--- a/src/Bridges/Variable/single_bridge_optimizer.jl
+++ b/src/Bridges/Variable/single_bridge_optimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     SingleBridgeOptimizer{BT<:AbstractBridge, OT<:MOI.ModelLike} <:
     AbstractBridgeOptimizer

--- a/src/Bridges/Variable/soc_rsoc.jl
+++ b/src/Bridges/Variable/soc_rsoc.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     SOCtoRSOCBridge{T} <: Bridges.Variable.SetMapBridge{T,MOI.RotatedSecondOrderCone,MOI.SecondOrderCone}
 

--- a/src/Bridges/Variable/vectorize.jl
+++ b/src/Bridges/Variable/vectorize.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     VectorizeBridge{T, S}
 

--- a/src/Bridges/Variable/zeros.jl
+++ b/src/Bridges/Variable/zeros.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     ZerosBridge{T} <: Bridges.Variable.AbstractBridge
 

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     AbstractBridge
 

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     AbstractBridgeOptimizer
 

--- a/src/Bridges/debug.jl
+++ b/src/Bridges/debug.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 function print_node(io::IO, b::LazyBridgeOptimizer, node::VariableNode)
     S, = b.variable_types[node.index]
     MOIU.print_with_acronym(

--- a/src/Bridges/flip_sign.jl
+++ b/src/Bridges/flip_sign.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 const _NonnegToNonposMap{T} =
     Union{Variable.NonposToNonnegBridge{T},Constraint.NonnegToNonposBridge{T}}
 

--- a/src/Bridges/graph.jl
+++ b/src/Bridges/graph.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 const INFINITY = -1
 const INVALID_NODE_INDEX = -1
 

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using OrderedCollections
 
 include("graph.jl")

--- a/src/Bridges/precompile.jl
+++ b/src/Bridges/precompile.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     Base.precompile(

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     map_set(::Type{BT}, set) where {BT}
 

--- a/src/Bridges/soc_rsoc.jl
+++ b/src/Bridges/soc_rsoc.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 const _SOCtoRSOCMap{T} =
     Union{Constraint.SOCtoRSOCBridge{T},Variable.RSOCtoSOCBridge{T}}
 

--- a/src/FileFormats/CBF/CBF.jl
+++ b/src/FileFormats/CBF/CBF.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module CBF
 
 import ..FileFormats

--- a/src/FileFormats/CBF/read.jl
+++ b/src/FileFormats/CBF/read.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 _parse(::Type{T}, x::AbstractString) where {T} = parse(T, x)
 _parse(::Type{String}, x::AbstractString) = String(x)
 

--- a/src/FileFormats/CBF/write.jl
+++ b/src/FileFormats/CBF/write.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     _CBFDataStructure
 

--- a/src/FileFormats/FileFormats.jl
+++ b/src/FileFormats/FileFormats.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module FileFormats
 
 import MathOptInterface

--- a/src/FileFormats/LP/LP.jl
+++ b/src/FileFormats/LP/LP.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module LP
 
 import ..FileFormats

--- a/src/FileFormats/MOF/MOF.jl
+++ b/src/FileFormats/MOF/MOF.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module MOF
 
 import ..FileFormats

--- a/src/FileFormats/MOF/nonlinear.jl
+++ b/src/FileFormats/MOF/nonlinear.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # Overload for writing.
 function moi_to_object(foo::Nonlinear, name_map::Dict{MOI.VariableIndex,String})
     node_list = OrderedObject[]

--- a/src/FileFormats/MOF/read.jl
+++ b/src/FileFormats/MOF/read.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     Base.read!(io::IO, model::FileFormats.MOF.Model)
 

--- a/src/FileFormats/MOF/write.jl
+++ b/src/FileFormats/MOF/write.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     Base.write(io::IO, model::FileFormats.MOF.Model)
 

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module MPS
 
 import ..FileFormats

--- a/src/FileFormats/NL/NL.jl
+++ b/src/FileFormats/NL/NL.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module NL
 
 import MathOptInterface

--- a/src/FileFormats/NL/NLExpr.jl
+++ b/src/FileFormats/NL/NLExpr.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 ### ============================================================================
 ### Opcodes, and their AMPL <-> Julia conversions.
 ### ============================================================================

--- a/src/FileFormats/NL/opcode.jl
+++ b/src/FileFormats/NL/opcode.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # This file is automatically created by the folowing script. Only re-run it if
 # AMPL adds new opcodes (which is unlikely).
 # ```julia

--- a/src/FileFormats/SDPA/SDPA.jl
+++ b/src/FileFormats/SDPA/SDPA.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module SDPA
 
 # See http://plato.asu.edu/ftp/sdpa_format.txt

--- a/src/FileFormats/utils.jl
+++ b/src/FileFormats/utils.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 ###
 ### Re-naming utilities
 ###

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module MathOptInterface
 
 """

--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module Test
 
 using MathOptInterface

--- a/src/Test/test_attribute.jl
+++ b/src/Test/test_attribute.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     test_attribute_NumberThreads(model::MOI.AbstractOptimizer, config::Config)
 

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 function _function(
     ::Any,
     ::Type{MOI.VariableIndex},

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     _test_conic_linear_helper(
         model::MOI.ModelLike,

--- a/src/Test/test_constraint.jl
+++ b/src/Test/test_constraint.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     test_constraint_get_ConstraintIndex(
         model::MOI.ModelLike,

--- a/src/Test/test_infeasibility_certificates.jl
+++ b/src/Test/test_infeasibility_certificates.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 for sense in (MOI.MIN_SENSE, MOI.MAX_SENSE), offset in (0, 6 // 5)
     o = iszero(offset) ? "" : "_offset"
     f_unbd_name = Symbol("test_unbounded_$(Symbol(sense))$(o)")

--- a/src/Test/test_linear.jl
+++ b/src/Test/test_linear.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     test_linear_integration(model::MOI.ModelLike, config::Config{T}) where {T}
 

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 ###
 ### Define data structures used by later tests.
 ###

--- a/src/Test/test_modification.jl
+++ b/src/Test/test_modification.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     test_modification_set_function_single_variable(
         model::MOI.ModelLike,

--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     HS071(
         enable_hessian::Bool,

--- a/src/Test/test_objective.jl
+++ b/src/Test/test_objective.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     test_objective_ObjectiveSense_MAX_SENSE(
         model::MOI.ModelLike,

--- a/src/Test/test_quadratic.jl
+++ b/src/Test/test_quadratic.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     test_quadratic_integration(model::MOI.ModelLike, config::Config{T}) where {T}
 

--- a/src/Test/test_solve.jl
+++ b/src/Test/test_solve.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     test_solve_ObjectiveBound_MIN_SENSE_IP(
         model::MOI.ModelLike,

--- a/src/Test/test_variable.jl
+++ b/src/Test/test_variable.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     test_variable_add_variable(model::MOI.ModelLike, config::Config)
 

--- a/src/Utilities/CleverDicts.jl
+++ b/src/Utilities/CleverDicts.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module CleverDicts
 
 # The following two functions are overloaded for `MOI.VariableIndex` here

--- a/src/Utilities/DoubleDicts.jl
+++ b/src/Utilities/DoubleDicts.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module DoubleDicts
 
 import MathOptInterface

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module Utilities
 
 using LinearAlgebra # For dot

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # Tips for writing type stable code in this file.
 #
 # Because the .optimizer field can by an abstract type (e.g., JuMP uses

--- a/src/Utilities/constraints.jl
+++ b/src/Utilities/constraints.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     normalize_and_add_constraint(
         model::MOI.ModelLike,

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # This file contains default implementations for the `MOI.copy_to` function that
 # can be used by a model.
 

--- a/src/Utilities/copy/index_map.jl
+++ b/src/Utilities/copy/index_map.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # IndexMap is defined here because there is a boostrapping problem.
 #  * IndexMap requires `Utilities.CleverDicts` and `Utilities.DoubleDicts`, so
 #    if it were to be defined in MOI proper, it must be included after

--- a/src/Utilities/free_variables.jl
+++ b/src/Utilities/free_variables.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     mutable struct FreeVariables <: MOI.ModelLike
         n::Int64

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 variable_function_type(::Type{<:MOI.AbstractScalarSet}) = MOI.VariableIndex
 variable_function_type(::Type{<:MOI.AbstractVectorSet}) = MOI.VectorOfVariables
 

--- a/src/Utilities/lazy_iterators.jl
+++ b/src/Utilities/lazy_iterators.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 struct EmptyVector{T} <: AbstractVector{T} end
 
 Base.size(::EmptyVector) = (0,)

--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     mutable struct MatrixOfConstraints{T,AT,BT,ST} <: MOI.ModelLike
         coefficients::AT

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # An Int-valued attribute
 struct MockModelAttribute <: MOI.AbstractModelAttribute end
 

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 const EMPTYSTRING = ""
 
 # Implementation of MOI for AbstractModel

--- a/src/Utilities/mutable_arithmetics.jl
+++ b/src/Utilities/mutable_arithmetics.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # TODO The mutability of the coefficient type `T` is currently not exploited yet.
 #      We first need to make sure that it is copied with `MA.copy_if_mutable` when it
 #      is passed from one function to a mutable one.

--- a/src/Utilities/objective_container.jl
+++ b/src/Utilities/objective_container.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     ObjectiveContainer{T}
 

--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using Base.Meta: isexpr
 
 struct _ParsedScalarAffineTerm

--- a/src/Utilities/precompile.jl
+++ b/src/Utilities/precompile.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     T = Float64

--- a/src/Utilities/print.jl
+++ b/src/Utilities/print.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using Printf
 
 _drop_moi(s) = replace(string(s), "MathOptInterface." => "")

--- a/src/Utilities/product_of_sets.jl
+++ b/src/Utilities/product_of_sets.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     abstract type ProductOfSets{T} end
 

--- a/src/Utilities/results.jl
+++ b/src/Utilities/results.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # This file contains the implementation of different methods for the
 # `get_fallback` function. These methods can be used by solver wrappers as
 # fallbacks for implementing the `get` method when the solver API does not

--- a/src/Utilities/sets.jl
+++ b/src/Utilities/sets.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     shift_constant(set::MOI.AbstractScalarSet, offset)
 

--- a/src/Utilities/sparse_matrix.jl
+++ b/src/Utilities/sparse_matrix.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 import SparseArrays
 
 """

--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     abstract type StructOfConstraints <: MOI.ModelLike end
 

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     UniversalFallback
 

--- a/src/Utilities/variables.jl
+++ b/src/Utilities/variables.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     get_bounds(model::MOI.ModelLike, ::Type{T}, x::MOI.VariableIndex)
 

--- a/src/Utilities/variables_container.jl
+++ b/src/Utilities/variables_container.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 abstract type AbstractVectorBounds end
 
 function set_from_constants(

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 ## Storage of constraints
 #
 # All `F`-in-`S` constraints are stored in a vector of `ConstraintEntry{F, S}`.

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # Attributes
 
 """

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     supports_constraint(
         model::ModelLike,

--- a/src/error.jl
+++ b/src/error.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     UnsupportedError <: Exception
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     output_dimension(f::AbstractFunction)
 

--- a/src/indextypes.jl
+++ b/src/indextypes.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 import MutableArithmetics
 
 """

--- a/src/instantiate.jl
+++ b/src/instantiate.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     struct OptimizerWithAttributes
         optimizer_constructor

--- a/src/modifications.jl
+++ b/src/modifications.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 """
     struct ModifyConstraintNotAllowed{F<:AbstractFunction, S<:AbstractSet,
                                       C<:AbstractFunctionModification} <: NotAllowedError

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # This API is imported from MathProgBase and is meant to be transitional.
 # A more ideal API would pass expressions (with vector-valued nodes) directly
 # let the solver call out to AD tools.

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 function precompile_constraint(model, F, S)
     Base.precompile(get, (model, ListOfConstraintIndices{F,S}))
     Base.precompile(get, (model, ListOfConstraintAttributesSet{F,S}))

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # Sets
 
 # Note: When adding a new set, also add it to Utilities.Model.

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # Variables
 
 """

--- a/test/Benchmarks/Benchmarks.jl
+++ b/test/Benchmarks/Benchmarks.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using MathOptInterface, Test
 
 const MOI = MathOptInterface

--- a/test/Bridges/Bridges.jl
+++ b/test/Bridges/Bridges.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using Test
 
 function _timed_include(file)

--- a/test/Bridges/Constraint/bridge.jl
+++ b/test/Bridges/Constraint/bridge.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintBridge
 
 using Test

--- a/test/Bridges/Constraint/det.jl
+++ b/test/Bridges/Constraint/det.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintDet
 
 using Test

--- a/test/Bridges/Constraint/flip_sign.jl
+++ b/test/Bridges/Constraint/flip_sign.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintFlipSign
 
 using Test

--- a/test/Bridges/Constraint/functionize.jl
+++ b/test/Bridges/Constraint/functionize.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintFunctionize
 
 using Test

--- a/test/Bridges/Constraint/geomean.jl
+++ b/test/Bridges/Constraint/geomean.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintGeomean
 
 using Test

--- a/test/Bridges/Constraint/geomean_to_relentr.jl
+++ b/test/Bridges/Constraint/geomean_to_relentr.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintGeomeanToRelentr
 
 using Test

--- a/test/Bridges/Constraint/indicator_activate_on_zero.jl
+++ b/test/Bridges/Constraint/indicator_activate_on_zero.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintIndicatorActiveOnFalse
 
 using Test

--- a/test/Bridges/Constraint/indicator_sos.jl
+++ b/test/Bridges/Constraint/indicator_sos.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintIndicatorSOS1
 
 using Test

--- a/test/Bridges/Constraint/interval.jl
+++ b/test/Bridges/Constraint/interval.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintSplitInterval
 
 using Test

--- a/test/Bridges/Constraint/ltgt_to_interval.jl
+++ b/test/Bridges/Constraint/ltgt_to_interval.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintToInterval
 # These tests are mostly copies of the flip_sign.jl tests for GreaterToLess
 

--- a/test/Bridges/Constraint/map.jl
+++ b/test/Bridges/Constraint/map.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintMap
 
 using Test

--- a/test/Bridges/Constraint/norm_spec_nuc_to_psd.jl
+++ b/test/Bridges/Constraint/norm_spec_nuc_to_psd.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintNormSpectral
 
 using Test

--- a/test/Bridges/Constraint/norm_to_lp.jl
+++ b/test/Bridges/Constraint/norm_to_lp.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintNormInfinity
 
 using Test

--- a/test/Bridges/Constraint/quad_to_soc.jl
+++ b/test/Bridges/Constraint/quad_to_soc.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintQuadToSOC
 
 import LinearAlgebra

--- a/test/Bridges/Constraint/relentr_to_exp.jl
+++ b/test/Bridges/Constraint/relentr_to_exp.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintRelativeEntropyToExponential
 
 using Test

--- a/test/Bridges/Constraint/rsoc.jl
+++ b/test/Bridges/Constraint/rsoc.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintRSOC
 
 using Test

--- a/test/Bridges/Constraint/scalarize.jl
+++ b/test/Bridges/Constraint/scalarize.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintScalarize
 
 using Test

--- a/test/Bridges/Constraint/semi_to_binary.jl
+++ b/test/Bridges/Constraint/semi_to_binary.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintSemiToBinary
 
 using Test

--- a/test/Bridges/Constraint/slack.jl
+++ b/test/Bridges/Constraint/slack.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintSlack
 
 using Test

--- a/test/Bridges/Constraint/soc_to_nonconvex_quad.jl
+++ b/test/Bridges/Constraint/soc_to_nonconvex_quad.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintSOCtoNonConvexQuad
 
 using Test

--- a/test/Bridges/Constraint/soc_to_psd.jl
+++ b/test/Bridges/Constraint/soc_to_psd.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintSOCtoPSD
 
 using Test

--- a/test/Bridges/Constraint/square.jl
+++ b/test/Bridges/Constraint/square.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintSquare
 
 using Test

--- a/test/Bridges/Constraint/vectorize.jl
+++ b/test/Bridges/Constraint/vectorize.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintVectorize
 
 using Test

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraintZeroOne
 
 using Test

--- a/test/Bridges/Objective/functionize.jl
+++ b/test/Bridges/Objective/functionize.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestObjectiveFunctionize
 
 using Test

--- a/test/Bridges/Objective/map.jl
+++ b/test/Bridges/Objective/map.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestObjectiveMap
 
 using Test

--- a/test/Bridges/Objective/slack.jl
+++ b/test/Bridges/Objective/slack.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestObjectiveSlack
 
 using Test

--- a/test/Bridges/Variable/bridge.jl
+++ b/test/Bridges/Variable/bridge.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariableBridge
 
 using Test

--- a/test/Bridges/Variable/flip_sign.jl
+++ b/test/Bridges/Variable/flip_sign.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariableFlipSign
 
 using Test

--- a/test/Bridges/Variable/free.jl
+++ b/test/Bridges/Variable/free.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariableFree
 
 using Test

--- a/test/Bridges/Variable/map.jl
+++ b/test/Bridges/Variable/map.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariableMap
 
 using Test

--- a/test/Bridges/Variable/rsoc_to_psd.jl
+++ b/test/Bridges/Variable/rsoc_to_psd.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariableRSOCtoPSD
 
 using Test

--- a/test/Bridges/Variable/rsoc_to_soc.jl
+++ b/test/Bridges/Variable/rsoc_to_soc.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariableRSOCtoSOC
 
 using Test

--- a/test/Bridges/Variable/soc_to_rsoc.jl
+++ b/test/Bridges/Variable/soc_to_rsoc.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariableSOCtoRSOC
 
 using Test

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariableVectorize
 
 using Test

--- a/test/Bridges/Variable/zeros.jl
+++ b/test/Bridges/Variable/zeros.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariableZeros
 
 using Test

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestBridgeOptimizer
 
 using Test

--- a/test/Bridges/identity_bridge.jl
+++ b/test/Bridges/identity_bridge.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 # Dummy bridges used for testing
 module IdentityBridges
 

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestBridgesLazyBridgeOptimizer
 
 using Test

--- a/test/Bridges/utilities.jl
+++ b/test/Bridges/utilities.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 function _test_num_constraints(bridged_mock, F, S, n)
     @test MOI.get(bridged_mock, MOI.NumberOfConstraints{F,S}()) == n
     @test length(MOI.get(bridged_mock, MOI.ListOfConstraintIndices{F,S}())) == n

--- a/test/FileFormats/CBF/CBF.jl
+++ b/test/FileFormats/CBF/CBF.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestCBF
 
 import MathOptInterface

--- a/test/FileFormats/FileFormats.jl
+++ b/test/FileFormats/FileFormats.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestFileFormats
 
 using MathOptInterface

--- a/test/FileFormats/LP/LP.jl
+++ b/test/FileFormats/LP/LP.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestLP
 
 import MathOptInterface

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestMOF
 
 import JSON

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestMPS
 
 import MathOptInterface

--- a/test/FileFormats/NL/NL.jl
+++ b/test/FileFormats/NL/NL.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestNLModel
 
 using MathOptInterface

--- a/test/FileFormats/SDPA/SDPA.jl
+++ b/test/FileFormats/SDPA/SDPA.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestSDPA
 
 import MathOptInterface

--- a/test/Test/Test.jl
+++ b/test/Test/Test.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using MathOptInterface
 const MOI = MathOptInterface
 

--- a/test/Utilities/CleverDicts.jl
+++ b/test/Utilities/CleverDicts.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestCleverDicts
 
 using MathOptInterface

--- a/test/Utilities/DoubleDicts.jl
+++ b/test/Utilities/DoubleDicts.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestDoubleDicts
 
 using Test

--- a/test/Utilities/Utilities.jl
+++ b/test/Utilities/Utilities.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using Test
 
 for file in readdir(@__DIR__)

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestCachingOptimizer
 
 using Test

--- a/test/Utilities/constraints.jl
+++ b/test/Utilities/constraints.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraints
 
 using Test

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestCopy
 
 using Test

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestFunctions
 
 using MathOptInterface: VectorOfVariables

--- a/test/Utilities/lazy_iterators.jl
+++ b/test/Utilities/lazy_iterators.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestLazyIterators
 
 using MathOptInterface

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestMatrixOfConstraints
 
 using Test

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestMockOptimizer
 
 using Test

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestModel
 
 using Test

--- a/test/Utilities/mutable_arithmetics.jl
+++ b/test/Utilities/mutable_arithmetics.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestMutableArithmetics
 
 using Test

--- a/test/Utilities/objective_container.jl
+++ b/test/Utilities/objective_container.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestObjectiveContainer
 
 using Test

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestParser
 
 using MathOptInterface

--- a/test/Utilities/print.jl
+++ b/test/Utilities/print.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestPrint
 
 using Test

--- a/test/Utilities/product_of_sets.jl
+++ b/test/Utilities/product_of_sets.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestProductOfSets
 
 using Test

--- a/test/Utilities/sets.jl
+++ b/test/Utilities/sets.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestSets
 
 using SparseArrays

--- a/test/Utilities/sparse_matrix.jl
+++ b/test/Utilities/sparse_matrix.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestSparseMatrix
 
 import SparseArrays

--- a/test/Utilities/universalfallback.jl
+++ b/test/Utilities/universalfallback.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestUniversalFallback
 
 using Test

--- a/test/Utilities/variable_container.jl
+++ b/test/Utilities/variable_container.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariableContainer
 
 using Test

--- a/test/Utilities/variables.jl
+++ b/test/Utilities/variables.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestVariables
 
 using MathOptInterface

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestAttributes
 
 using Test

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestConstraints
 
 using Test

--- a/test/dummy.jl
+++ b/test/dummy.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 import MathOptInterface
 const MOI = MathOptInterface
 const MOIU = MOI.Utilities

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestErrors
 
 using Test

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestFunctions
 
 using Test

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module Hygiene
 
 using Test

--- a/test/instantiate.jl
+++ b/test/instantiate.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestInstantiate
 
 using Test

--- a/test/issue980.jl
+++ b/test/issue980.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module Issue980
 
 import MathOptInterface

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 using Test
 
 # This file gets called first. It it doesn't crash, all is well.

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -1,3 +1,9 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 module TestSets
 
 using Test


### PR DESCRIPTION
Closes #1812 

Header taken from https://opensource.google/documentation/reference/releasing/licenses#mit_header

Script was:
```Julia
HEADER = """
# Copyright (c) 2017: Miles Lubin and contributors
# Copyright (c) 2017: Google Inc.
#
# Use of this source code is governed by an MIT-style license that can be found
# in the LICENSE.md file or at https://opensource.org/licenses/MIT.

"""
for (root, dirs, files) in walkdir("/Users/oscar/.julia/dev/MathOptInterface")
    for file in files
        if endswith(file, ".jl")
            filename = joinpath(root, file)
            contents = read(filename, String)
            write(filename, HEADER * contents)
        end
    end
end
```