### PR TITLE
Add CountBelongs set

### DIFF
--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -101,6 +101,7 @@ Complements
 ```@docs
 AllDifferent
 Among
+CountAtLeast
 CountDistinct
 ```
 

--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -100,6 +100,7 @@ Complements
 
 ```@docs
 AllDifferent
+Among
 CountDistinct
 ```
 

--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -103,6 +103,7 @@ AllDifferent
 Among
 CountAtLeast
 CountDistinct
+CountGreaterThan
 ```
 
 ## Matrix sets

--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -101,9 +101,14 @@ Complements
 ```@docs
 AllDifferent
 Among
+BinPacking
 CountAtLeast
 CountDistinct
 CountGreaterThan
+Circuit
+Cumulative
+Path
+Table
 ```
 
 ## Matrix sets

--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -100,7 +100,7 @@ Complements
 
 ```@docs
 AllDifferent
-Among
+CountBelongs
 BinPacking
 CountAtLeast
 CountDistinct

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -114,6 +114,17 @@ _set(::Type{MOI.CountDistinct}) = MOI.CountDistinct(4)
 _set(::Type{MOI.Among}) = MOI.Among(4, Set([3, 4]))
 _set(::Type{MOI.CountAtLeast}) = MOI.CountAtLeast(1, [2, 2], Set([3]))
 _set(::Type{MOI.CountGreaterThan}) = MOI.CountGreaterThan(5)
+_set(::Type{MOI.Circuit}) = MOI.Circuit(3)
+_set(::Type{MOI.Cumulative}) = MOI.Cumulative(7)
+_set(::Type{MOI.Path}) = MOI.Path([1, 1, 2, 2, 3], [2, 3, 3, 4, 4])
+
+function _set(::Type{T}, ::Type{MOI.BinPacking}) where {T}
+    return MOI.BinPacking(T(2), T[1, 2])
+end
+
+function _set(::Type{T}, ::Type{MOI.Table}) where {T}
+    return MOI.Table(T[0 1 1; 1 0 1; 1 1 0])
+end
 
 function _set(
     ::Type{MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.LessThan{T}}},
@@ -282,6 +293,11 @@ for s in [
     :Among,
     :CountAtLeast,
     :CountGreaterThan,
+    :BinPacking,
+    :Circuit,
+    :Cumulative,
+    :Table,
+    :Path,
 ]
     S = getfield(MOI, s)
     functions = if S <: MOI.AbstractScalarSet

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -113,6 +113,7 @@ _set(::Type{MOI.AllDifferent}) = MOI.AllDifferent(3)
 _set(::Type{MOI.CountDistinct}) = MOI.CountDistinct(4)
 _set(::Type{MOI.Among}) = MOI.Among(4, Set([3, 4]))
 _set(::Type{MOI.CountAtLeast}) = MOI.CountAtLeast(1, [2, 2], Set([3]))
+_set(::Type{MOI.CountGreaterThan}) = MOI.CountGreaterThan(5)
 
 function _set(
     ::Type{MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.LessThan{T}}},
@@ -280,6 +281,7 @@ for s in [
     :CountDistinct,
     :Among,
     :CountAtLeast,
+    :CountGreaterThan,
 ]
     S = getfield(MOI, s)
     functions = if S <: MOI.AbstractScalarSet

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -112,6 +112,7 @@ _set(::Type{MOI.Complements}) = MOI.Complements(2)
 _set(::Type{MOI.AllDifferent}) = MOI.AllDifferent(3)
 _set(::Type{MOI.CountDistinct}) = MOI.CountDistinct(4)
 _set(::Type{MOI.Among}) = MOI.Among(4, Set([3, 4]))
+_set(::Type{MOI.CountAtLeast}) = MOI.CountAtLeast(1, [2, 2], Set([3]))
 
 function _set(
     ::Type{MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.LessThan{T}}},
@@ -278,6 +279,7 @@ for s in [
     :AllDifferent,
     :CountDistinct,
     :Among,
+    :CountAtLeast,
 ]
     S = getfield(MOI, s)
     functions = if S <: MOI.AbstractScalarSet

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -111,7 +111,7 @@ _set(::Type{MOI.RootDetConeSquare}) = MOI.RootDetConeSquare(3)
 _set(::Type{MOI.Complements}) = MOI.Complements(2)
 _set(::Type{MOI.AllDifferent}) = MOI.AllDifferent(3)
 _set(::Type{MOI.CountDistinct}) = MOI.CountDistinct(4)
-_set(::Type{MOI.Among}) = MOI.Among(4, Set([3, 4]))
+_set(::Type{MOI.CountBelongs}) = MOI.CountBelongs(4, Set([3, 4]))
 _set(::Type{MOI.CountAtLeast}) = MOI.CountAtLeast(1, [2, 2], Set([3]))
 _set(::Type{MOI.CountGreaterThan}) = MOI.CountGreaterThan(5)
 _set(::Type{MOI.Circuit}) = MOI.Circuit(3)
@@ -290,7 +290,7 @@ for s in [
     :Complements,
     :AllDifferent,
     :CountDistinct,
-    :Among,
+    :CountBelongs,
     :CountAtLeast,
     :CountGreaterThan,
     :BinPacking,

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -111,6 +111,7 @@ _set(::Type{MOI.RootDetConeSquare}) = MOI.RootDetConeSquare(3)
 _set(::Type{MOI.Complements}) = MOI.Complements(2)
 _set(::Type{MOI.AllDifferent}) = MOI.AllDifferent(3)
 _set(::Type{MOI.CountDistinct}) = MOI.CountDistinct(4)
+_set(::Type{MOI.Among}) = MOI.Among(4, Set([3, 4]))
 
 function _set(
     ::Type{MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.LessThan{T}}},
@@ -276,6 +277,7 @@ for s in [
     :Complements,
     :AllDifferent,
     :CountDistinct,
+    :Among,
 ]
     S = getfield(MOI, s)
     functions = if S <: MOI.AbstractScalarSet

--- a/src/Test/test_cpsat.jl
+++ b/src/Test/test_cpsat.jl
@@ -90,18 +90,29 @@ function setup_test(
 end
 
 """
-    test_cpsat_Among(model::MOI.ModelLike, config::Config)
+    test_cpsat_CountBelongs(model::MOI.ModelLike, config::Config)
 
-Add a VectorOfVariables-in-Among constraint.
+Add a VectorOfVariables-in-CountBelongs constraint.
 """
-function test_cpsat_Among(model::MOI.ModelLike, config::Config{T}) where {T}
-    @requires MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.Among)
+function test_cpsat_CountBelongs(
+    model::MOI.ModelLike,
+    config::Config{T},
+) where {T}
+    @requires MOI.supports_constraint(
+        model,
+        MOI.VectorOfVariables,
+        MOI.CountBelongs,
+    )
     @requires MOI.supports_add_constrained_variable(model, MOI.Integer)
     @requires _supports(config, MOI.optimize!)
     y = [MOI.add_constrained_variable(model, MOI.Integer()) for _ in 1:4]
     x = first.(y)
     set = Set([3, 4])
-    MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Among(4, set))
+    MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables(x),
+        MOI.CountBelongs(4, set),
+    )
     MOI.optimize!(model)
     x_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), x))
     @test x_val[1] == sum(x_val[i] in set for i in 2:length(x))
@@ -109,7 +120,7 @@ function test_cpsat_Among(model::MOI.ModelLike, config::Config{T}) where {T}
 end
 
 function setup_test(
-    ::typeof(test_cpsat_Among),
+    ::typeof(test_cpsat_CountBelongs),
     model::MOIU.MockOptimizer,
     ::Config{T},
 ) where {T}

--- a/src/Test/test_cpsat.jl
+++ b/src/Test/test_cpsat.jl
@@ -65,6 +65,7 @@ function test_cpsat_CountDistinct(
     @requires _supports(config, MOI.optimize!)
     y = [MOI.add_constrained_variable(model, MOI.Integer()) for _ in 1:4]
     x = first.(y)
+    MOI.add_constraint.(model, x, MOI.Interval(T(0), T(4)))
     MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.CountDistinct(4))
     MOI.optimize!(model)
     x_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), x))
@@ -142,6 +143,7 @@ function test_cpsat_CountAtLeast(
     x, _ = MOI.add_constrained_variable(model, MOI.Integer())
     y, _ = MOI.add_constrained_variable(model, MOI.Integer())
     z, _ = MOI.add_constrained_variable(model, MOI.Integer())
+    MOI.add_constraint.(model, [x, y, z], MOI.Interval(T(0), T(3)))
     variables = [x, y, y, z]
     partitions = [2, 2]
     set = Set([3])
@@ -216,6 +218,256 @@ function setup_test(
             mock,
             MOI.OPTIMAL,
             (MOI.FEASIBLE_POINT, T[2, 4, 0, 4, 0]),
+        ),
+    )
+    return
+end
+
+"""
+    test_cpsat_BinPacking(model::MOI.ModelLike, config::Config)
+
+Add a VectorOfVariables-in-BinPacking constraint.
+"""
+function test_cpsat_BinPacking(
+    model::MOI.ModelLike,
+    config::Config{T},
+) where {T}
+    @requires MOI.supports_constraint(
+        model,
+        MOI.VectorOfVariables,
+        MOI.BinPacking{T},
+    )
+    @requires MOI.supports_add_constrained_variable(model, MOI.Integer)
+    @requires _supports(config, MOI.optimize!)
+    N = 5
+    bins = MOI.add_variables(model, N)
+    weights = T[1, 1, 2, 2, 3]
+    MOI.add_constraint.(model, bins, MOI.Integer())
+    MOI.add_constraint.(model, bins, MOI.Interval(T(1), T(3)))
+    MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables(bins),
+        MOI.BinPacking(T(3), weights),
+    )
+    MOI.optimize!(model)
+    x_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), bins))
+    sol = zeros(3)
+    for i in 1:N
+        sol[x_val[i]] += weights[i]
+    end
+    @test all(sol .<= 3)
+    return
+end
+
+function setup_test(
+    ::typeof(test_cpsat_BinPacking),
+    model::MOIU.MockOptimizer,
+    ::Config{T},
+) where {T}
+    MOIU.set_mock_optimize!(
+        model,
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+            mock,
+            MOI.OPTIMAL,
+            (MOI.FEASIBLE_POINT, T[1, 2, 1, 2, 3]),
+        ),
+    )
+    return
+end
+
+"""
+    test_cpsat_Cumulative(model::MOI.ModelLike, config::Config)
+
+Add a VectorOfVariables-in-Cumulative constraint.
+"""
+function test_cpsat_Cumulative(
+    model::MOI.ModelLike,
+    config::Config{T},
+) where {T}
+    @requires MOI.supports_constraint(
+        model,
+        MOI.VectorOfVariables,
+        MOI.Cumulative,
+    )
+    @requires MOI.supports_add_constrained_variable(model, MOI.Integer)
+    @requires _supports(config, MOI.optimize!)
+    s = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
+    MOI.add_constraint.(model, s, MOI.Interval(T(0), T(3)))
+    d = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
+    MOI.add_constraint.(model, d, MOI.EqualTo(T(2)))
+    r = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
+    MOI.add_constraint.(model, r, MOI.EqualTo.(T[3, 2, 1]))
+    b, _ = MOI.add_constrained_variable(model, MOI.Integer())
+    MOI.add_constraint.(model, b, MOI.EqualTo(T(5)))
+    MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables([s; d; r; b]),
+        MOI.Cumulative(10),
+    )
+    MOI.optimize!(model)
+    s_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), s))
+    d_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), d))
+    r_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), r))
+    b_val = round(Int, MOI.get(model, MOI.VariablePrimal(), b))
+    times = zeros(1 + maximum(s_val) + maximum(d_val))
+    for i in 1:3
+        for j in 0:(d_val[i]-1)
+            t = s_val[i] + j
+            times[t+1] += r_val[i]
+        end
+    end
+    @test all(times .<= b_val)
+    return
+end
+
+function setup_test(
+    ::typeof(test_cpsat_Cumulative),
+    model::MOIU.MockOptimizer,
+    ::Config{T},
+) where {T}
+    MOIU.set_mock_optimize!(
+        model,
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+            mock,
+            MOI.OPTIMAL,
+            (MOI.FEASIBLE_POINT, T[0, 1, 2, 2, 2, 2, 3, 2, 1, 5]),
+        ),
+    )
+    return
+end
+
+"""
+    test_cpsat_Table(model::MOI.ModelLike, config::Config)
+
+Add a VectorOfVariables-in-Table constraint.
+"""
+function test_cpsat_Table(model::MOI.ModelLike, config::Config{T}) where {T}
+    @requires MOI.supports_constraint(
+        model,
+        MOI.VectorOfVariables,
+        MOI.Table{T},
+    )
+    @requires MOI.supports_add_constrained_variable(model, MOI.Integer)
+    @requires _supports(config, MOI.optimize!)
+    x = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
+    table = T[1 1 0; 0 1 1]
+    MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Table(table))
+    MOI.optimize!(model)
+    x_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), x))
+    @test x_val == [1, 1, 0] || x_val == [0, 1, 1]
+    return
+end
+
+function setup_test(
+    ::typeof(test_cpsat_Table),
+    model::MOIU.MockOptimizer,
+    ::Config{T},
+) where {T}
+    MOIU.set_mock_optimize!(
+        model,
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+            mock,
+            MOI.OPTIMAL,
+            (MOI.FEASIBLE_POINT, T[1, 1, 0]),
+        ),
+    )
+    return
+end
+
+"""
+    test_cpsat_Circuit(model::MOI.ModelLike, config::Config)
+
+Add a VectorOfVariables-in-Circuit constraint.
+"""
+function test_cpsat_Circuit(model::MOI.ModelLike, config::Config{T}) where {T}
+    @requires MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.Circuit)
+    @requires MOI.supports_add_constrained_variable(model, MOI.Integer)
+    @requires _supports(config, MOI.optimize!)
+    x = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
+    MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Circuit(3))
+    MOI.optimize!(model)
+    x_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), x))
+    @test x_val == [3, 1, 2] || x_val == [2, 3, 1]
+    return
+end
+
+function setup_test(
+    ::typeof(test_cpsat_Circuit),
+    model::MOIU.MockOptimizer,
+    ::Config{T},
+) where {T}
+    MOIU.set_mock_optimize!(
+        model,
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+            mock,
+            MOI.OPTIMAL,
+            (MOI.FEASIBLE_POINT, T[3, 1, 2]),
+        ),
+    )
+    return
+end
+
+"""
+    test_cpsat_Path(model::MOI.ModelLike, config::Config)
+
+Add a VectorOfVariables-in-Path constraint.
+"""
+function test_cpsat_Path(model::MOI.ModelLike, config::Config{T}) where {T}
+    @requires MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.Path)
+    @requires MOI.supports_add_constrained_variable(model, MOI.Integer)
+    @requires _supports(config, MOI.optimize!)
+    from = [1, 1, 2, 2, 3]
+    to = [2, 3, 3, 4, 4]
+    N, E = 4, 5
+    s, _ = MOI.add_constrained_variable(model, MOI.Integer())
+    t, _ = MOI.add_constrained_variable(model, MOI.Integer())
+    ns = MOI.add_variables(model, N)
+    MOI.add_constraint.(model, ns, MOI.ZeroOne())
+    es = MOI.add_variables(model, E)
+    MOI.add_constraint.(model, es, MOI.ZeroOne())
+    MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables([s; t; ns; es]),
+        MOI.Path(from, to),
+    )
+    MOI.optimize!(model)
+    s_val = round(Int, MOI.get(model, MOI.VariablePrimal(), s))
+    @test 1 <= s_val <= 4
+    t_val = round(Int, MOI.get(model, MOI.VariablePrimal(), t))
+    @test 1 <= t_val <= 4
+    ns_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), ns))
+    es_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), es))
+    outs = Vector{Int}[[1, 2], [3, 4], [5], Int[]]
+    ins = Vector{Int}[[], [1], [2, 3], [4, 5]]
+    has_edges = s_val == t_val ? 0 : 1
+    # source: must have no incoming and one outgoing (if s != t)
+    @test sum(es_val[o] for o in ins[s_val]; init = 0) == 0
+    @test sum(es_val[o] for o in outs[s_val]; init = 0) == has_edges
+    # dest: must have no outgoing and one incoming (if s != t)
+    @test sum(es_val[o] for o in ins[t_val]; init = 0) == has_edges
+    @test sum(es_val[o] for o in outs[t_val]; init = 0) == 0
+    for i in 1:4
+        if i != s_val && i != t_val
+            # other nodes: must have one incoming and one outgoing iff node is
+            # in subgraph.
+            @test sum(es_val[o] for o in outs[i]; init = 0) == ns_val[i]
+            @test sum(es_val[o] for o in ins[i]; init = 0) == ns_val[i]
+        end
+    end
+    return
+end
+
+function setup_test(
+    ::typeof(test_cpsat_Path),
+    model::MOIU.MockOptimizer,
+    ::Config{T},
+) where {T}
+    MOIU.set_mock_optimize!(
+        model,
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+            mock,
+            MOI.OPTIMAL,
+            (MOI.FEASIBLE_POINT, T[1, 4, 1, 1, 0, 1, 1, 0, 0, 1, 0]),
         ),
     )
     return

--- a/src/Test/test_cpsat.jl
+++ b/src/Test/test_cpsat.jl
@@ -87,3 +87,38 @@ function setup_test(
     )
     return
 end
+
+"""
+    test_cpsat_Among(model::MOI.ModelLike, config::Config)
+
+Add a VectorOfVariables-in-Among constraint.
+"""
+function test_cpsat_Among(model::MOI.ModelLike, config::Config{T}) where {T}
+    @requires MOI.supports_constraint(model, MOI.VectorOfVariables, MOI.Among)
+    @requires MOI.supports_add_constrained_variable(model, MOI.Integer)
+    @requires _supports(config, MOI.optimize!)
+    y = [MOI.add_constrained_variable(model, MOI.Integer()) for _ in 1:4]
+    x = first.(y)
+    set = Set([3, 4])
+    MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Among(4, set))
+    MOI.optimize!(model)
+    x_val = round.(Int, MOI.get.(model, MOI.VariablePrimal(), x))
+    @test x_val[1] == sum(x_val[i] in set for i in 2:length(x))
+    return
+end
+
+function setup_test(
+    ::typeof(test_cpsat_Among),
+    model::MOIU.MockOptimizer,
+    ::Config{T},
+) where {T}
+    MOIU.set_mock_optimize!(
+        model,
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+            mock,
+            MOI.OPTIMAL,
+            (MOI.FEASIBLE_POINT, T[2, 3, 4, 0]),
+        ),
+    )
+    return
+end

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -791,6 +791,7 @@ const LessThanIndicatorZero{T} =
         MOI.CountDistinct,
         MOI.Among,
         MOI.CountAtLeast,
+        MOI.CountGreaterThan,
     ),
     (
         MOI.PowerCone,

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -790,6 +790,7 @@ const LessThanIndicatorZero{T} =
         MOI.AllDifferent,
         MOI.CountDistinct,
         MOI.Among,
+        MOI.CountAtLeast,
     ),
     (
         MOI.PowerCone,

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -789,7 +789,7 @@ const LessThanIndicatorZero{T} =
         MOI.LogDetConeSquare,
         MOI.AllDifferent,
         MOI.CountDistinct,
-        MOI.Among,
+        MOI.CountBelongs,
         MOI.CountAtLeast,
         MOI.CountGreaterThan,
         MOI.Circuit,

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -789,6 +789,7 @@ const LessThanIndicatorZero{T} =
         MOI.LogDetConeSquare,
         MOI.AllDifferent,
         MOI.CountDistinct,
+        MOI.Among,
     ),
     (
         MOI.PowerCone,

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -792,6 +792,9 @@ const LessThanIndicatorZero{T} =
         MOI.Among,
         MOI.CountAtLeast,
         MOI.CountGreaterThan,
+        MOI.Circuit,
+        MOI.Cumulative,
+        MOI.Path,
     ),
     (
         MOI.PowerCone,
@@ -800,6 +803,8 @@ const LessThanIndicatorZero{T} =
         MOI.SOS2,
         LessThanIndicatorOne,
         LessThanIndicatorZero,
+        MOI.Table,
+        MOI.BinPacking,
     ),
     (),
     (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1186,6 +1186,36 @@ struct CountDistinct <: AbstractVectorSet
     end
 end
 
+"""
+    Among(dimension::Int, set::Set{Int})
+
+The set ``\\{(n, x) \\in \\mathbb{R}^{1+d}\\}`` such that `n` elements of the
+vector `x` take on of the values in `set`.
+
+This constraint is sometimes called `among`.
+
+## Example
+
+```julia
+model = Utilities.Model{Float64}()
+n = add_constrained_variable(model, MOI.Integer())
+x = [add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
+add_constraint(model, VectorOfVariables(vcat(n, x)), Among(2, Set([3, 4, 5])))
+```
+"""
+struct Among <: AbstractVectorSet
+    dimension::Int
+    set::Set{Int}
+    function Among(dimension::Base.Integer, set::Set{Int})
+        if dimension < 1
+            throw(DimensionMismatch("Dimension of Among must be >= 1."))
+        end
+        return new(dimension, set)
+    end
+end
+
+Base.:(==)(x::Among, y::Among) = x.dimension == y.dimension && x.set == y.set
+
 # isbits types, nothing to copy
 function Base.copy(
     set::Union{
@@ -1222,11 +1252,13 @@ function Base.copy(
         Semiinteger,
         AllDifferent,
         CountDistinct,
+        Among,
     },
 )
     return set
 end
 Base.copy(set::S) where {S<:Union{SOS1,SOS2}} = S(copy(set.weights))
+Base.copy(set::Among) = Among(set.dimension, copy(set.set))
 
 """
     supports_dimension_update(S::Type{<:MOI.AbstractVectorSet})

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1187,12 +1187,14 @@ struct CountDistinct <: AbstractVectorSet
 end
 
 """
-    Among(dimension::Int, set::Set{Int})
+    CountBelongs(d::Int, set::Set{Int})
 
-The set ``\\{(n, x) \\in \\mathbb{R}^{1+d}\\}`` such that `n` elements of the
+The set ``\\{(n, x) \\in \\mathbb{Z}^{d}\\}`` such that `n` elements of the
 vector `x` take on of the values in `set`.
 
-This constraint is sometimes called `among`.
+## Also known as
+
+This constraint is called `among` by MiniZinc.
 
 ## Example
 
@@ -1200,21 +1202,24 @@ This constraint is sometimes called `among`.
 model = Utilities.Model{Float64}()
 n = add_constrained_variable(model, MOI.Integer())
 x = [add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
-add_constraint(model, VectorOfVariables(vcat(n, x)), Among(2, Set([3, 4, 5])))
+set = Set([3, 4, 5])
+add_constraint(model, VectorOfVariables([n; x]), CountBelongs(4, set))
 ```
 """
-struct Among <: AbstractVectorSet
+struct CountBelongs <: AbstractVectorSet
     dimension::Int
     set::Set{Int}
-    function Among(dimension::Base.Integer, set::Set{Int})
+    function CountBelongs(dimension::Base.Integer, set::Set{Int})
         if dimension < 1
-            throw(DimensionMismatch("Dimension of Among must be >= 1."))
+            throw(DimensionMismatch("Dimension of CountBelongs must be >= 1."))
         end
         return new(dimension, set)
     end
 end
 
-Base.:(==)(x::Among, y::Among) = x.dimension == y.dimension && x.set == y.set
+function Base.:(==)(x::CountBelongs, y::CountBelongs)
+    return x.dimension == y.dimension && x.set == y.set
+end
 
 """
     CountAtLeast(n::Int, d::Vector{Int}, set::Set{Int})
@@ -1524,7 +1529,7 @@ function Base.copy(
         Semiinteger,
         AllDifferent,
         CountDistinct,
-        Among,
+        CountBelongs,
         CountAtLeast,
         CountGreaterThan,
         Circuit,
@@ -1534,7 +1539,7 @@ function Base.copy(
     return set
 end
 Base.copy(set::S) where {S<:Union{SOS1,SOS2}} = S(copy(set.weights))
-Base.copy(set::Among) = Among(set.dimension, copy(set.set))
+Base.copy(set::CountBelongs) = CountBelongs(set.dimension, copy(set.set))
 
 function Base.copy(set::CountAtLeast)
     return CountAtLeast(set.n, copy(set.partitions), copy(set.set))

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1296,6 +1296,198 @@ struct CountGreaterThan <: AbstractVectorSet
     end
 end
 
+"""
+    BinPacking(c::T, w::Vector{T}) where {T}
+
+The set ``\\{x \\in \\mathbb{R}^d\\}`` such that each item `i` in `1:d` of
+weight `w[i]` is put into bin `x[i]`, and the total weight of each bin does not
+exceed `c`.
+
+There are additional assumptions that the capacity, `c`, and the weights, `w`,
+must all be non-negative.
+
+## Also known as
+
+This constraint is called `bin_packing` in MiniZinc.
+
+## Example
+
+```julia
+model = Utilities.Model{Float64}()
+bins = add_variables(model, 5)
+weights = [1, 1, 2, 2, 3]
+add_constraint.(model, bins, MOI.Integer())
+add_constraint.(model, bins, MOI.Interval(1, 3))
+add_constraint(model, VectorOfVariables(bins), BinPacking(3, weights))
+```
+"""
+struct BinPacking{T} <: AbstractVectorSet
+    capacity::T
+    weights::Vector{T}
+    function BinPacking(capacity::T, weights::Vector{T}) where {T}
+        if capacity < zero(T)
+            throw(DomainError(capacity, "capacity must be non-negative"))
+        end
+        if any(w -> w < zero(T), weights)
+            throw(DomainError(weights, "weights must be non-negative"))
+        end
+        return new{T}(capacity, weights)
+    end
+end
+
+dimension(set::BinPacking) = length(set.weights)
+
+function Base.copy(set::BinPacking{T}) where {T}
+    return BinPacking(set.capacity, copy(set.weights))
+end
+
+function Base.:(==)(x::BinPacking{T}, y::BinPacking{T}) where {T}
+    return x.capacity == y.capacity && x.weights == y.weights
+end
+
+"""
+    Cumulative(dimension::Int)
+
+The set ``\\{(s, d, r, b) \\in \\mathbb{Z}^{length(s)+length(d)+length(r)+1}\\}``
+representing the ``cumulative`` global constraint.
+
+It requires that a set of tasks given by start times ``s``, durations ``d``, and
+resource requirements ``r``, never requires more than the global resource bound
+``b`` at any one time.
+
+## Also known as
+
+This constraint is called `cumulative` in MiniZinc.
+
+## Example
+
+```julia
+model = Utilities.Model{Float64}()
+s = [add_constrained_variable(model, Integer())[1] for _ in 1:3]
+d = [add_constrained_variable(model, Integer())[1] for _ in 1:3]
+r = [add_constrained_variable(model, Integer())[1] for _ in 1:3]
+b, _ = add_constrained_variable(model, Integer())
+add_constraint(model, VectorOfVariables([s; d; r; b]), Cumulative(10))
+```
+"""
+struct Cumulative <: AbstractVectorSet
+    dimension::Int
+    function Cumulative(dimension::Base.Integer)
+        if dimension < 1
+            throw(DimensionMismatch("Dimension of Cumulative must be >= 1."))
+        end
+        return new(dimension)
+    end
+end
+
+"""
+    Table(table::Matrix{T}) where {T}
+
+The set ``\\{x \\in \\mathbb{R}^d\\}`` where `d = size(table, 2)`, such that `x`
+belongs to one row of `table`. That is, there exists some `j` in
+`1:size(table, 1)`, such that `x[i] = table[j, i]` for all `i=1:size(table, 2)`.
+
+## Also known as
+
+This constraint is called `table` in MiniZinc.
+
+## Example
+
+```julia
+model = Utilities.Model{Float64}()
+x = add_variables(model, 3)
+table = [1 1 0; 0 1 1; 1 0 1; 1 1 1]
+add_constraint(model, VectorOfVariables(x), Table(table))
+```
+"""
+struct Table{T} <: AbstractVectorSet
+    table::Matrix{T}
+end
+
+dimension(set::Table) = size(set.table, 2)
+
+Base.copy(set::Table) = Table(copy(set.table))
+
+Base.:(==)(x::Table{T}, y::Table{T}) where {T} = x.table == y.table
+
+"""
+    Circuit(dimension::Int)
+
+The set ``\\{x \\in \\{1..d\\}^d\\}`` that constraints ``x`` to be a circuit,
+such that ``x_i = j`` means that ``j`` is the successor of ``i``.
+
+## Also known as
+
+This constraint is called `circuit` in MiniZinc.
+
+## Example
+
+```julia
+model = Utilities.Model{Float64}()
+x = [add_constrained_variable(model, Integer())[1] for _ in 1:3]
+add_constraint(model, VectorOfVariables(x), Circuit(3))
+```
+"""
+struct Circuit <: AbstractVectorSet
+    dimension::Int
+    function Circuit(dimension::Base.Integer)
+        if dimension < 0
+            throw(DimensionMismatch("Dimension of Circuit must be >= 0."))
+        end
+        return new(dimension)
+    end
+end
+
+"""
+    Path(from::Vector{Int}, to::Vector{Int})
+
+Given a graph comprised of a set of nodes `1..N` and a set of arcs `1..E`
+represented by an edge from node `from[i]` to node `to[i]`, `Path` constraints
+the set
+``(s, t, ns, es) \\in (1..N)\\times(1..N)\\times\\{0,1\\}^N\\times\\{0,1\\}^E``,
+to form subgraph that is a path from node `s` to node `t`, where node `n` is in
+the path if `ns[n]` is `1`, and edge `e` is in the path if `es[e]` is `1`.
+
+## Also known as
+
+This constraint is called `path` in MiniZinc.
+
+## Example
+
+```julia
+model = Utilities.Model{Float64}()
+from = [1, 1, 2, 2, 3]
+to = [2, 3, 3, 4, 4]
+s, _ = add_constrained_variable(model, Integer())
+t, _ = add_constrained_variable(model, Integer())
+ns = add_variables(model, N)
+add_constraint.(model, ns, ZeroOne())
+es = add_variables(model, E)
+add_constraint.(model, es, ZeroOne())
+add_constraint(model, VectorOfVariables([s; t; ns; es]), Path(from, to))
+```
+"""
+struct Path <: AbstractVectorSet
+    N::Int
+    E::Int
+    from::Vector{Int}
+    to::Vector{Int}
+    function Path(from::Vector{Int}, to::Vector{Int})
+        @assert length(from) == length(to)
+        E = length(from)
+        N = max(maximum(from), maximum(to))
+        return new(N, E, from, to)
+    end
+end
+
+dimension(set::Path) = 2 + set.N + set.E
+
+Base.copy(set::Path) = Path(copy(set.from), copy(set.to))
+
+function Base.:(==)(x::Path, y::Path)
+    return x.N == y.N && x.E == y.E && x.from == y.from && x.to == y.to
+end
+
 # isbits types, nothing to copy
 function Base.copy(
     set::Union{
@@ -1335,6 +1527,8 @@ function Base.copy(
         Among,
         CountAtLeast,
         CountGreaterThan,
+        Circuit,
+        Cumulative,
     },
 )
     return set

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1262,6 +1262,40 @@ function Base.:(==)(x::CountAtLeast, y::CountAtLeast)
     return x.n == y.n && x.partitions == y.partitions && x.set == y.set
 end
 
+"""
+    CountGreaterThan(dimension::Int)
+
+The set ``\\{(c, y, x) \\in \\mathbb{Z}^{1+1+d}\\}`` such that `c` is strictly
+greater than the number of occurances of `y` in `x`.
+
+## Also known as
+
+This constraint is called `count_gt` in MiniZinc.
+
+## Example
+
+```julia
+model = Utilities.Model{Float64}()
+c, _ = add_constrained_variable(model, Integer())
+y, _ = add_constrained_variable(model, Integer())
+x = [add_constrained_variable(model, Integer())[1] for _ in 1:3]
+add_constraint(model, VectorOfVariables([c; y; x]), CountGreaterThan(5))
+```
+"""
+struct CountGreaterThan <: AbstractVectorSet
+    dimension::Int
+    function CountGreaterThan(dimension::Base.Integer)
+        if dimension < 2
+            throw(
+                DimensionMismatch(
+                    "Dimension of CountGreaterThan must be >= 2.",
+                ),
+            )
+        end
+        return new(dimension)
+    end
+end
+
 # isbits types, nothing to copy
 function Base.copy(
     set::Union{
@@ -1300,6 +1334,7 @@ function Base.copy(
         CountDistinct,
         Among,
         CountAtLeast,
+        CountGreaterThan,
     },
 )
     return set

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1216,6 +1216,52 @@ end
 
 Base.:(==)(x::Among, y::Among) = x.dimension == y.dimension && x.set == y.set
 
+"""
+    CountAtLeast(n::Int, d::Vector{Int}, set::Set{Int})
+
+The set ``\\{x \\in \\mathbb{Z}^{d_1 + d_2 + \\ldots d_N}\\}``, where `x` is
+partitioned into `N` subsets (``\\{x_1,  \\ldots, x_{d_1}\\}``,
+``\\{x_{d_1, 1},  \\ldots, x_{d_1 + d_2}\\}`` and so on), and at least ``n``
+elements of each subset take one of the values in `set`.
+
+## Also known as
+
+This constraint is called `at_least` in MiniZinc.
+
+## Example
+
+```julia
+model = Utilities.Model{Float64}()
+a, _ = add_constrained_variable(model, Integer())
+b, _ = add_constrained_variable(model, Integer())
+c, _ = add_constrained_variable(model, Integer())
+# To ensure that `3` appears at least once in each of the subsets {a, b}, {b, c}
+x, d, set = [a, b, b, c], [2, 2], [3]
+add_constraint(model, VectorOfVariables(x), CountAtLeast(1, d, Set(set)))
+```
+"""
+struct CountAtLeast <: AbstractVectorSet
+    n::Int
+    partitions::Vector{Int}
+    set::Set{Int}
+    function CountAtLeast(
+        n::Base.Integer,
+        partitions::Vector{Int},
+        set::Set{Int},
+    )
+        if any(p <= 0 for p in partitions)
+            throw(DimensionMismatch("Invalid partition dimension."))
+        end
+        return new(n, partitions, set)
+    end
+end
+
+dimension(s::CountAtLeast) = sum(s.partitions)
+
+function Base.:(==)(x::CountAtLeast, y::CountAtLeast)
+    return x.n == y.n && x.partitions == y.partitions && x.set == y.set
+end
+
 # isbits types, nothing to copy
 function Base.copy(
     set::Union{
@@ -1253,12 +1299,17 @@ function Base.copy(
         AllDifferent,
         CountDistinct,
         Among,
+        CountAtLeast,
     },
 )
     return set
 end
 Base.copy(set::S) where {S<:Union{SOS1,SOS2}} = S(copy(set.weights))
 Base.copy(set::Among) = Among(set.dimension, copy(set.set))
+
+function Base.copy(set::CountAtLeast)
+    return CountAtLeast(set.n, copy(set.partitions), copy(set.set))
+end
 
 """
     supports_dimension_update(S::Type{<:MOI.AbstractVectorSet})

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -141,6 +141,7 @@ function test_sets_DimensionMismatch()
         (MOI.RootDetConeSquare, 0),
         (MOI.AllDifferent, 0),
         (MOI.CountDistinct, 1),
+        (MOI.CountGreaterThan, 2),
     )
         @test_throws DimensionMismatch S(min_dimension - 1)
         @test S(min_dimension) isa S

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -120,6 +120,12 @@ function test_sets_dimension()
     @test MOI.dimension(MOI.Complements(10)) == 10
 end
 
+function test_sets_bin_packing_errors()
+    @test_throws DomainError MOI.BinPacking(-1.0, [1.0, 2.0])
+    @test_throws DomainError MOI.BinPacking(1.0, [1.0, -2.0])
+    return
+end
+
 function test_sets_DimensionMismatch()
     for (S, min_dimension) in (
         (MOI.Reals, 0),
@@ -142,6 +148,8 @@ function test_sets_DimensionMismatch()
         (MOI.AllDifferent, 0),
         (MOI.CountDistinct, 1),
         (MOI.CountGreaterThan, 2),
+        (MOI.Cumulative, 1),
+        (MOI.Circuit, 0),
     )
         @test_throws DimensionMismatch S(min_dimension - 1)
         @test S(min_dimension) isa S

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -156,6 +156,7 @@ function test_sets_DimensionMismatch()
     @test_throws DimensionMismatch MOI.Complements(-3)
     @test_throws DimensionMismatch MOI.Complements(3)
     @test_throws DimensionMismatch MOI.Among(0, Set([1, 2]))
+    @test_throws DimensionMismatch MOI.CountAtLeast(1, [-1, 2], Set([1, 2]))
     return
 end
 

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -155,6 +155,7 @@ function test_sets_DimensionMismatch()
     @test_throws DimensionMismatch MOI.RelativeEntropyCone(2)
     @test_throws DimensionMismatch MOI.Complements(-3)
     @test_throws DimensionMismatch MOI.Complements(3)
+    @test_throws DimensionMismatch MOI.Among(0, Set([1, 2]))
     return
 end
 

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -164,7 +164,7 @@ function test_sets_DimensionMismatch()
     @test_throws DimensionMismatch MOI.RelativeEntropyCone(2)
     @test_throws DimensionMismatch MOI.Complements(-3)
     @test_throws DimensionMismatch MOI.Complements(3)
-    @test_throws DimensionMismatch MOI.Among(0, Set([1, 2]))
+    @test_throws DimensionMismatch MOI.CountBelongs(0, Set([1, 2]))
     @test_throws DimensionMismatch MOI.CountAtLeast(1, [-1, 2], Set([1, 2]))
     return
 end


### PR DESCRIPTION
Part of #1805

Stacked on #1826 to avoid conflicts.

This set could use some bikeshedding. 

Minizinc calls it `among`, https://www.minizinc.org/doc-2.5.5/en/lib-globals.html, but what about:
 * `Count`
 * `CountAmong`
 * `CountIn`
 * `CountWithin`
 * `CountInSet`
 * `CountBelongs`

ConstraintProgrammingExtensions had a much more complicated setup, where there was `Count{<:AbstractSet}`, https://github.com/JuliaConstraints/ConstraintProgrammingExtensions.jl/blob/master/src/sets_count.jl. The generality was nice, but it would be quite hard to implement and might be too general.