### PR TITLE
[Bridges] Fix bug in dual of PSDConeSquare bridge

### DIFF
--- a/src/Bridges/Constraint/bridges/square.jl
+++ b/src/Bridges/Constraint/bridges/square.jl
@@ -119,14 +119,6 @@ function bridge_constraint(
             # This avoid generating symmetrization constraints when the
             # functions at entries (i, j) and (j, i) are almost identical
             if !MOI.Utilities.isapprox_zero(diff, 1e-10)
-                if MOIU.isapprox_zero(diff, 1e-8)
-                    @warn "The entries ($i, $j) and ($j, $i) of the" *
-                          " positive semidefinite constraint are almost" *
-                          " identical but a constraint is added to ensure their" *
-                          " equality because the largest difference between the" *
-                          " coefficients is smaller than 1e-8 but larger than" *
-                          " 1e-10."
-                end
                 ci = MOI.Utilities.normalize_and_add_constraint(
                     model,
                     diff,

--- a/src/Bridges/Constraint/bridges/square.jl
+++ b/src/Bridges/Constraint/bridges/square.jl
@@ -255,9 +255,13 @@ function MOI.get(
     attr::MOI.ConstraintDual,
     bridge::SquareBridge,
 )
+    # The constraint dual of the triangular constraint.
     tri = MOI.get(model, attr, bridge.triangle)
+    # Our output will be a dense square matrix.
     dim = MOI.side_dimension(bridge.square_set)
-    sqr = Vector{eltype(tri)}(undef, dim^2)
+    dual = Vector{eltype(tri)}(undef, dim^2)
+    # Start by converting the triangular dual to the square dual, assuming that
+    # all elements are symmetrical.
     k = 0
     for j in 1:dim, i in 1:j
         k += 1
@@ -274,5 +278,5 @@ function MOI.get(
         sqr[i+(j-1)*dim] += dual
         sqr[j+(i-1)*dim] -= dual
     end
-    return sqr
+    return dual
 end

--- a/test/Bridges/Constraint/square.jl
+++ b/test/Bridges/Constraint/square.jl
@@ -114,6 +114,7 @@ function test_runtests()
         [x11, x12, x22] in PositiveSemidefiniteConeTriangle(2)
         """,
     )
+    return
 end
 
 function test_symmetric_square()


### PR DESCRIPTION
Closes #1830

If there are no symmetry constraints added, then we can copy-across the duals from the upper triangle to the lower triangle.