### PR TITLE
Test.jl check files ending with .jl

### DIFF
--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -567,7 +567,7 @@ end
 ###
 
 for file in readdir(@__DIR__)
-    if startswith(file, "test_")
+    if startswith(file, "test_") && endswith(file, ".jl")
         include(file)
     end
 end


### PR DESCRIPTION
This PR makes a small change in `src/Tedst/Test.jl`. Currently it runs `include` over all the files that starts with `test_` in `src/Test` directory, but this can cause an issue when the coverage data are generated (e.g., https://github.com/MadNLP/MadNLP.jl/runs/6478904950?check_suite_focus=true#step:4:272). 

To avoid this behavior, we now also check that the file ends with `.jl` extension.