### PR TITLE
[FileFormats.NL] add read!(::IO, ::Model)

### DIFF
--- a/src/FileFormats/NL/read.jl
+++ b/src/FileFormats/NL/read.jl
@@ -31,6 +31,16 @@ mutable struct _CacheModel
     end
 end
 
+function Base.read!(io::IO, model::Model)
+    cache = _CacheModel()
+    _parse_header(io, cache)
+    while !eof(io)
+        _parse_section(io, cache)
+    end
+    model.model = _to_model(cache)
+    return
+end
+
 function _resize_variables(model::_CacheModel, n::Int)
     resize!(model.variable_type, n)
     fill!(model.variable_type, _CONTINUOUS)
@@ -193,15 +203,6 @@ function _to_model(data::_CacheModel)
     block = MOI.NLPBlockData(evaluator)
     MOI.set(model, MOI.NLPBlock(), block)
     return model
-end
-
-function _read_from_io(io::IO)
-    model = _CacheModel()
-    _parse_header(io, model)
-    while !eof(io)
-        _parse_section(io, model)
-    end
-    return _to_model(model)
 end
 
 function _parse_header(io::IO, model::_CacheModel)

--- a/test/FileFormats/NL/NL.jl
+++ b/test/FileFormats/NL/NL.jl
@@ -471,9 +471,6 @@ function test_nlmodel_hs071_linear_obj()
     @test MOI.supports(n, MOI.VariablePrimalStart(), MOI.VariableIndex)
     @test MOI.supports(n, MOI.ObjectiveFunction{typeof(f)}())
     index_map = MOI.copy_to(n, model)
-    for (vi, starti) in zip(v, start)
-        @test MOI.get(n, MOI.VariablePrimalStart(), index_map[vi]) == starti
-    end
     @test n.sense == MOI.MAX_SENSE
     @test n.f == NL._NLExpr(f)
     _test_nlexpr(
@@ -513,6 +510,7 @@ function test_nlmodel_hs071_linear_obj()
     types = [NL._CONTINUOUS, NL._BINARY, NL._INTEGER, NL._CONTINUOUS]
     u[2] = 1.0
     for i in 1:4
+        @test n.x[v[i]].start == start[i]
         @test n.x[v[i]].lower == l[i]
         @test n.x[v[i]].upper == u[i]
         @test n.x[v[i]].type == types[i]
@@ -1025,6 +1023,19 @@ function test_float_rounding()
     @test NL._str(1.2) == "1.2"
     @test NL._str(1e50) == "1.0e50"
     @test NL._str(-1e50) == "-1.0e50"
+    return
+end
+
+function test_attribute_error()
+    model = NL.Model()
+    attr = MOI.ObjectiveSense()
+    @test_throws(
+        ErrorException(
+            "Unable get attribute $attr because `NL.Model` only supports " *
+            "getting attributes when the model was read from a file.",
+        ),
+        MOI.get(model, attr),
+    )
     return
 end
 

--- a/test/FileFormats/NL/read.jl
+++ b/test/FileFormats/NL/read.jl
@@ -498,8 +498,9 @@ v1
 end
 
 function test_hs071()
-    model = open(joinpath(@__DIR__, "data", "hs071.nl"), "r") do io
-        return NL._read_from_io(io)
+    model = NL.Model()
+    open(joinpath(@__DIR__, "data", "hs071.nl"), "r") do io
+        return read!(io, model)
     end
     model_print = sprint(print, model)
     _in_ = @static Sys.iswindows() ? "in" : "∈"
@@ -544,8 +545,9 @@ function test_mac_minlp()
         "top1-15x05.nl",
     ]
     for file in filter(f -> !(f in exclude) && endswith(f, ".nl"), readdir(dir))
+        model = NL.Model()
         open(joinpath(dir, file), "r") do io
-            return NL._read_from_io(io)
+            return read!(io, model)
         end
     end
     return


### PR DESCRIPTION
```Julia
julia> using JuMP, Ipopt

julia> model = read_from_file("/Users/Oscar/.julia/dev/MathOptInterface/test/FileFormats/NL/data/hs071ampl.nl")
A JuMP Model
Minimization problem with:
Variables: 4
Objective function type: AffExpr
`VariableRef`-in-`MathOptInterface.GreaterThan{Float64}`: 4 constraints
`VariableRef`-in-`MathOptInterface.LessThan{Float64}`: 4 constraints
Model mode: AUTOMATIC
CachingOptimizer state: NO_OPTIMIZER
Solver name: No optimizer attached.

julia> set_optimizer(model, Ipopt.Optimizer)

julia> optimize!(model)
This is Ipopt version 3.14.4, running with linear solver MUMPS 5.4.1.

Number of nonzeros in equality constraint Jacobian...:        4
Number of nonzeros in inequality constraint Jacobian.:        4
Number of nonzeros in Lagrangian Hessian.............:       24

Total number of variables............................:        4
                     variables with only lower bounds:        0
                variables with lower and upper bounds:        4
                     variables with only upper bounds:        0
Total number of equality constraints.................:        1
Total number of inequality constraints...............:        1
        inequality constraints with only lower bounds:        1
   inequality constraints with lower and upper bounds:        0
        inequality constraints with only upper bounds:        0

iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  1.6109693e+01 1.12e+01 5.28e-01  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  1.6982239e+01 7.30e-01 1.02e+01  -1.0 6.11e-01    -  7.19e-02 1.00e+00f  1
   2  1.7318411e+01 3.60e-02 5.05e-01  -1.0 1.61e-01    -  1.00e+00 1.00e+00h  1
   3  1.6849424e+01 2.78e-01 6.68e-02  -1.7 2.85e-01    -  7.94e-01 1.00e+00h  1
   4  1.7051199e+01 4.71e-03 2.78e-03  -1.7 6.06e-02    -  1.00e+00 1.00e+00h  1
   5  1.7011979e+01 7.19e-03 8.50e-03  -3.8 3.66e-02    -  9.45e-01 9.98e-01h  1
   6  1.7014271e+01 1.74e-05 9.78e-06  -3.8 3.33e-03    -  1.00e+00 1.00e+00h  1
   7  1.7014021e+01 1.23e-07 1.82e-07  -5.7 2.69e-04    -  1.00e+00 1.00e+00h  1
   8  1.7014017e+01 1.77e-11 2.52e-11  -8.6 3.32e-06    -  1.00e+00 1.00e+00h  1

Number of Iterations....: 8

                                   (scaled)                 (unscaled)
Objective...............:   1.7014017145179164e+01    1.7014017145179164e+01
Dual infeasibility......:   2.5166932865835061e-11    2.5166932865835061e-11
Constraint violation....:   1.7706724975141697e-11    1.7706724975141697e-11
Variable bound violation:   7.6764621326219640e-09    7.6764621326219640e-09
Complementarity.........:   2.5277100427932966e-09    2.5277100427932966e-09
Overall NLP error.......:   2.5277100427932966e-09    2.5277100427932966e-09


Number of objective function evaluations             = 9
Number of objective gradient evaluations             = 9
Number of equality constraint evaluations            = 9
Number of inequality constraint evaluations          = 9
Number of equality constraint Jacobian evaluations   = 9
Number of inequality constraint Jacobian evaluations = 9
Number of Lagrangian Hessian evaluations             = 8
Total seconds in IPOPT                               = 0.004

EXIT: Optimal Solution Found.

julia> value.(all_variables(model))
4-element Vector{Float64}:
 0.9999999923235379
 4.742999641809297
 3.8211499817883072
 1.3794082897556983
```