### PR TITLE
[Bridges] re-organize the Objective bridges folder

### DIFF
--- a/src/Bridges/Objective/Objective.jl
+++ b/src/Bridges/Objective/Objective.jl
@@ -7,36 +7,28 @@
 module Objective
 
 using MathOptInterface
+
 const MOI = MathOptInterface
 const MOIU = MOI.Utilities
 const MOIB = MOI.Bridges
 
-# Definition of an objective bridge
 include("bridge.jl")
-
-# Mapping between objective function attributes and bridges
 include("map.jl")
-
-# Bridge optimizer bridging a specific objective bridge
 include("single_bridge_optimizer.jl")
 
-# Objective bridges
-include("functionize.jl")
-const Functionize{T,OT<:MOI.ModelLike} =
-    SingleBridgeOptimizer{FunctionizeBridge{T},OT}
-
-include("slack.jl")
-const Slack{T,OT<:MOI.ModelLike} = SingleBridgeOptimizer{SlackBridge{T},OT}
+include("bridges/functionize.jl")
+include("bridges/slack.jl")
 
 """
-    add_all_bridges(bridged_model, ::Type{T}) where {T}
+    add_all_bridges(model, ::Type{T}) where {T}
 
-Add all bridges defined in the `Bridges.Objective` submodule to `bridged_model`.
+Add all bridges defined in the `Bridges.Objective` submodule to `model`.
+
 The coefficient type used is `T`.
 """
-function add_all_bridges(bridged_model, ::Type{T}) where {T}
-    MOIB.add_bridge(bridged_model, FunctionizeBridge{T})
-    MOIB.add_bridge(bridged_model, SlackBridge{T})
+function add_all_bridges(model, ::Type{T}) where {T}
+    MOI.Bridges.add_bridge(model, FunctionizeBridge{T})
+    MOI.Bridges.add_bridge(model, SlackBridge{T})
     return
 end
 

--- a/src/Bridges/Objective/bridges/functionize.jl
+++ b/src/Bridges/Objective/bridges/functionize.jl
@@ -12,6 +12,9 @@ The `FunctionizeBridge` converts a `VariableIndex` objective into a
 """
 struct FunctionizeBridge{T} <: AbstractBridge end
 
+const Functionize{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{FunctionizeBridge{T},OT}
+
 function bridge_objective(
     ::Type{FunctionizeBridge{T}},
     model::MOI.ModelLike,

--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -28,6 +28,8 @@ struct SlackBridge{
     }
 end
 
+const Slack{T,OT<:MOI.ModelLike} = SingleBridgeOptimizer{SlackBridge{T},OT}
+
 function bridge_objective(
     ::Type{SlackBridge{T,F,G}},
     model::MOI.ModelLike,


### PR DESCRIPTION
Navigating the Bridges submodule is confusing, because there are a large number of files, and they aren't clear whether it's a utility file used in lots of places, or a single implementation of a bridge. 

This PR creates a directory structure like:
 ```
/src
    /Bridges
        /Objective
            Objective.jl
            bridge.jl
            map.jl
            single_bridge_optimizer.jl
            /bridges
                functionize.jl
                slack.jl
```
and moves the definition of each bridges constant into the corresponding file.