### PR TITLE
[Bridges] re-organize the Variable bridges folder

### DIFF
--- a/src/Bridges/Variable/Variable.jl
+++ b/src/Bridges/Variable/Variable.jl
@@ -45,13 +45,13 @@ Add all bridges defined in the `Bridges.Variable` submodule to `model`.
 The coefficient type used is `T`.
 """
 function add_all_bridges(model, ::Type{T}) where {T}
-    MOI.Bridges.add_bridge(model, NonposToNonnegBridge{T})
+    MOI.Bridges.add_bridge(model, ZerosBridge{T})
     MOI.Bridges.add_bridge(model, FreeBridge{T})
-    MOI.Bridges.add_bridge(model, RSOCtoPSDBridge{T})
+    MOI.Bridges.add_bridge(model, NonposToNonnegBridge{T})
+    MOI.Bridges.add_bridge(model, VectorizeBridge{T})
     MOI.Bridges.add_bridge(model, SOCtoRSOCBridge{T})
     MOI.Bridges.add_bridge(model, RSOCtoSOCBridge{T})
-    MOI.Bridges.add_bridge(model, VectorizeBridge{T})
-    MOI.Bridges.add_bridge(model, ZerosBridge{T})
+    MOI.Bridges.add_bridge(model, RSOCtoPSDBridge{T})
     return
 end
 

--- a/src/Bridges/Variable/Variable.jl
+++ b/src/Bridges/Variable/Variable.jl
@@ -7,17 +7,14 @@
 module Variable
 
 using MathOptInterface
+
 const MOI = MathOptInterface
 const MOIU = MOI.Utilities
 const MOIB = MOI.Bridges
 
-# Definition of a variable bridge
 include("bridge.jl")
-
-# Mapping between variable indices and bridges
 include("map.jl")
-
-# Bridge optimizer bridging a specific variable bridge
+include("set_map.jl")
 include("single_bridge_optimizer.jl")
 
 # TODO(odow): the compiler in Julia <= 1.2 (and in later versions unless
@@ -33,38 +30,28 @@ function MOI.Bridges.Variable.bridge_constrained_variable(BridgeType, b, s)
     )
 end
 
-# Variable bridges
-# Transformation between a set S1 and a set S2 such that A*S1 = S2 for some linear map A
-include("set_map.jl")
-
-include("zeros.jl")
-const Zeros{T,OT<:MOI.ModelLike} = SingleBridgeOptimizer{ZerosBridge{T},OT}
-
-include("free.jl")
-const Free{T,OT<:MOI.ModelLike} = SingleBridgeOptimizer{FreeBridge{T},OT}
-
-include("vectorize.jl")
-const Vectorize{T,OT<:MOI.ModelLike} =
-    SingleBridgeOptimizer{VectorizeBridge{T},OT}
-
-include("rsoc_to_psd.jl")
-const RSOCtoPSD{T,OT<:MOI.ModelLike} =
-    SingleBridgeOptimizer{RSOCtoPSDBridge{T},OT}
+include("bridges/flip_sign.jl")
+include("bridges/free.jl")
+include("bridges/rsoc_to_psd.jl")
+include("bridges/soc_rsoc.jl")
+include("bridges/vectorize.jl")
+include("bridges/zeros.jl")
 
 """
-    add_all_bridges(bridged_model, ::Type{T}) where {T}
+    add_all_bridges(model, ::Type{T}) where {T}
 
-Add all bridges defined in the `Bridges.Variable` submodule to `bridged_model`.
+Add all bridges defined in the `Bridges.Variable` submodule to `model`.
+
 The coefficient type used is `T`.
 """
-function add_all_bridges(bridged_model, ::Type{T}) where {T}
-    MOIB.add_bridge(bridged_model, ZerosBridge{T})
-    MOIB.add_bridge(bridged_model, FreeBridge{T})
-    MOIB.add_bridge(bridged_model, NonposToNonnegBridge{T})
-    MOIB.add_bridge(bridged_model, VectorizeBridge{T})
-    MOIB.add_bridge(bridged_model, SOCtoRSOCBridge{T})
-    MOIB.add_bridge(bridged_model, RSOCtoSOCBridge{T})
-    MOIB.add_bridge(bridged_model, RSOCtoPSDBridge{T})
+function add_all_bridges(model, ::Type{T}) where {T}
+    MOI.Bridges.add_bridge(model, NonposToNonnegBridge{T})
+    MOI.Bridges.add_bridge(model, FreeBridge{T})
+    MOI.Bridges.add_bridge(model, RSOCtoPSDBridge{T})
+    MOI.Bridges.add_bridge(model, SOCtoRSOCBridge{T})
+    MOI.Bridges.add_bridge(model, RSOCtoSOCBridge{T})
+    MOI.Bridges.add_bridge(model, VectorizeBridge{T})
+    MOI.Bridges.add_bridge(model, ZerosBridge{T})
     return
 end
 

--- a/src/Bridges/Variable/bridges/flip_sign.jl
+++ b/src/Bridges/Variable/bridges/flip_sign.jl
@@ -28,6 +28,9 @@ struct NonposToNonnegBridge{T} <:
     constraint::MOI.ConstraintIndex{MOI.VectorOfVariables,MOI.Nonnegatives}
 end
 
+const NonposToNonneg{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{NonposToNonnegBridge{T},OT}
+
 function MOI.delete(
     model::MOI.ModelLike,
     bridge::NonposToNonnegBridge,

--- a/src/Bridges/Variable/bridges/free.jl
+++ b/src/Bridges/Variable/bridges/free.jl
@@ -15,6 +15,8 @@ struct FreeBridge{T} <: AbstractBridge
     constraint::MOI.ConstraintIndex{MOI.VectorOfVariables,MOI.Nonnegatives}
 end
 
+const Free{T,OT<:MOI.ModelLike} = SingleBridgeOptimizer{FreeBridge{T},OT}
+
 function bridge_constrained_variable(
     ::Type{FreeBridge{T}},
     model::MOI.ModelLike,

--- a/src/Bridges/Variable/bridges/rsoc_to_psd.jl
+++ b/src/Bridges/Variable/bridges/rsoc_to_psd.jl
@@ -30,6 +30,9 @@ struct RSOCtoPSDBridge{T} <: AbstractBridge
     }
 end
 
+const RSOCtoPSD{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{RSOCtoPSDBridge{T},OT}
+
 function bridge_constrained_variable(
     ::Type{RSOCtoPSDBridge{T}},
     model::MOI.ModelLike,

--- a/src/Bridges/Variable/bridges/soc_rsoc.jl
+++ b/src/Bridges/Variable/bridges/soc_rsoc.jl
@@ -18,6 +18,9 @@ struct SOCtoRSOCBridge{T} <:
     }
 end
 
+const SOCtoRSOC{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{SOCtoRSOCBridge{T},OT}
+
 """
     RSOCtoSOCBridge{T} <: Bridges.Variable.SetMapBridge{T,MOI.SecondOrderCone,MOI.RotatedSecondOrderCone}
 
@@ -28,3 +31,6 @@ struct RSOCtoSOCBridge{T} <:
     variables::Vector{MOI.VariableIndex}
     constraint::MOI.ConstraintIndex{MOI.VectorOfVariables,MOI.SecondOrderCone}
 end
+
+const RSOCtoSOC{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{RSOCtoSOCBridge{T},OT}

--- a/src/Bridges/Variable/bridges/vectorize.jl
+++ b/src/Bridges/Variable/bridges/vectorize.jl
@@ -19,6 +19,9 @@ mutable struct VectorizeBridge{T,S} <: AbstractBridge
     set_constant::T # constant in scalar set
 end
 
+const Vectorize{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{VectorizeBridge{T},OT}
+
 function bridge_constrained_variable(
     ::Type{VectorizeBridge{T,S}},
     model::MOI.ModelLike,

--- a/src/Bridges/Variable/bridges/zeros.jl
+++ b/src/Bridges/Variable/bridges/zeros.jl
@@ -25,6 +25,8 @@ struct ZerosBridge{T} <: AbstractBridge
     n::Int # Number of variables
 end
 
+const Zeros{T,OT<:MOI.ModelLike} = SingleBridgeOptimizer{ZerosBridge{T},OT}
+
 function bridge_constrained_variable(
     ::Type{ZerosBridge{T}},
     model::MOI.ModelLike,

--- a/src/Bridges/Variable/set_map.jl
+++ b/src/Bridges/Variable/set_map.jl
@@ -217,13 +217,3 @@ function unbridged_map(
         bridge.variables[i] => scalars[i] for i in eachindex(vis)
     ]
 end
-
-include("flip_sign.jl")
-const NonposToNonneg{T,OT<:MOI.ModelLike} =
-    SingleBridgeOptimizer{NonposToNonnegBridge{T},OT}
-
-include("soc_rsoc.jl")
-const SOCtoRSOC{T,OT<:MOI.ModelLike} =
-    SingleBridgeOptimizer{SOCtoRSOCBridge{T},OT}
-const RSOCtoSOC{T,OT<:MOI.ModelLike} =
-    SingleBridgeOptimizer{RSOCtoSOCBridge{T},OT}


### PR DESCRIPTION
Same reason as #1851. This found some bridges hiding at the bottom of `set_map.jl`, which was confusing.