### PR TITLE
[Bridges] remove unused methods

### DIFF
--- a/src/Bridges/Constraint/bridge.jl
+++ b/src/Bridges/Constraint/bridge.jl
@@ -96,19 +96,3 @@ a bridge object of type `BT`.
    parameters of the bridge must be set.
 """
 function bridge_constraint end
-
-function MOIB.added_constrained_variable_types(
-    BT::Type{<:AbstractBridge},
-    F::Type{<:MOI.AbstractFunction},
-    S::Type{<:MOI.AbstractSet},
-)
-    return MOIB.added_constrained_variable_types(concrete_bridge_type(BT, F, S))
-end
-
-function MOIB.added_constraint_types(
-    BT::Type{<:AbstractBridge},
-    F::Type{<:MOI.AbstractFunction},
-    S::Type{<:MOI.AbstractSet},
-)
-    return MOIB.added_constraint_types(concrete_bridge_type(BT, F, S))
-end

--- a/src/Bridges/Objective/bridge.jl
+++ b/src/Bridges/Objective/bridge.jl
@@ -122,24 +122,3 @@ function MOI.delete(::MOI.ModelLike, bridge::AbstractBridge)
         ),
     )
 end
-
-function MOIB.added_constrained_variable_types(
-    BT::Type{<:AbstractBridge},
-    F::Type{<:MOI.AbstractScalarFunction},
-)
-    return MOIB.added_constrained_variable_types(concrete_bridge_type(BT, F))
-end
-
-function MOIB.added_constraint_types(
-    BT::Type{<:AbstractBridge},
-    F::Type{<:MOI.AbstractScalarFunction},
-)
-    return MOIB.added_constraint_types(concrete_bridge_type(BT, F))
-end
-
-function MOIB.set_objective_function_type(
-    BT::Type{<:AbstractBridge},
-    F::Type{<:MOI.AbstractScalarFunction},
-)
-    return MOIB.set_objective_function_type(concrete_bridge_type(BT, F))
-end

--- a/src/Bridges/Variable/bridge.jl
+++ b/src/Bridges/Variable/bridge.jl
@@ -153,20 +153,6 @@ function MOI.set(
     end
 end
 
-function MOIB.added_constrained_variable_types(
-    BT::Type{<:AbstractBridge},
-    S::Type{<:MOI.AbstractSet},
-)
-    return MOIB.added_constrained_variable_types(concrete_bridge_type(BT, S))
-end
-
-function MOIB.added_constraint_types(
-    BT::Type{<:AbstractBridge},
-    S::Type{<:MOI.AbstractSet},
-)
-    return MOIB.added_constraint_types(concrete_bridge_type(BT, S))
-end
-
 """
    unbridged_map(
        bridge::MOI.Bridges.Variable.AbstractBridge,


### PR DESCRIPTION
As far as I can tell, these aren't used anywhere and they aren't tested (they have missing coverage). All calls to the functions just use the single-argument methods which only accept the bridge type.