### PR TITLE
[Bridges] improvements to bridge docstrings

### DIFF
--- a/src/Bridges/Objective/bridges/functionize.jl
+++ b/src/Bridges/Objective/bridges/functionize.jl
@@ -7,8 +7,24 @@
 """
     FunctionizeBridge{T}
 
-The `FunctionizeBridge` converts a `VariableIndex` objective into a
-`ScalarAffineFunction{T}` objective.
+`FunctionizeBridge` implements the following reformulations:
+
+ * ``\\min \\{x\\}`` into ``\\min\\{1x + 0\\}``
+ * ``\\max \\{x\\}`` into ``\\max\\{1x + 0\\}``
+
+where `T` is the coefficient type of `1` and `0`.
+
+## Source node
+
+`FunctionizeBridge` supports:
+
+ * [`MOI.ObjectiveFunction{MOI.VariableIndex}`](@ref)
+
+## Target nodes
+
+`FunctionizeBridge` creates:
+
+ * One objective node: [`MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}`](@ref)
 """
 struct FunctionizeBridge{T} <: AbstractBridge end
 

--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -7,13 +7,31 @@
 """
     SlackBridge{T,F,G}
 
-The `SlackBridge` converts an objective function of type `G` into a
-[`MOI.VariableIndex`](@ref) objective by creating a slack variable and a
-`F`-in-[`MOI.LessThan`](@ref) constraint for minimization or
-`F`-in-[`MOI.GreaterThan`](@ref) constraint for maximization where `F` is
-`MOI.Utilities.promote_operation(-, T, G, MOI.VariableIndex}`.
+`SlackBridge` implements the following reformulations:
 
-!!! note
+ * ``\\min\\{f(x)\\}`` into ``\\min\\{y\\;|\\; f(x) - y \\le 0\\}``
+ * ``\\max\\{f(x)\\}`` into ``\\max\\{y\\;|\\; f(x) - y \\ge 0\\}``
+
+where `F` is the type of `f(x) - y`, `G` is the type of `f(x)`, and `T` is the
+coefficient type of `f(x)`.
+
+## Source node
+
+`SlackBridge` supports:
+
+ * [`MOI.ObjectiveFunction{G}`](@ref)
+
+## Target nodes
+
+`SlackBridge` creates:
+
+ * One variable node: [`MOI.VariableIndex`](@ref) in [`MOI.Reals`](@ref)
+ * One objective node: [`MOI.ObjectiveFunction{MOI.VariableIndex}`](@ref)
+ * One constraint node, that depends on the [`MOI.ObjectiveSense`](@ref):
+   * `F`-in-[`MOI.LessThan`](@ref) if `MIN_SENSE`
+   * `F`-in-[`MOI.GreaterThan`](@ref) if `MAX_SENSE`
+
+!!! warning
     When using this bridge, changing the optimization sense is not supported.
     Set the sense to `MOI.FEASIBILITY_SENSE` first to delete the bridge, then
     set [`MOI.ObjectiveSense`](@ref) and re-add the objective.


### PR DESCRIPTION
I started documenting the graph part of the bridges, but trying to link to existing bridges to show how they work was pretty limiting because they aren't well documented. 

I think it'd be helpful to fully document what each bridge does in terms of the mathematical reformulation, the objective/constraint that it supports, and the nodes that it targets. 

Starting with objective bridges because there's only two of them.

Part of https://github.com/jump-dev/MathOptInterface.jl/issues/1504