### PR TITLE
[Bridges] fix Constraint.ZeroOne bridge with existing bounds

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -239,7 +239,7 @@ julia> MOI.Bridges.runtests(
            \"\"\"
            variables: x
            x in Integer()
-           x in Interval(0.0, 1.0)
+           1.0 * x in Interval(0.0, 1.0)
            \"\"\",
        )
 ```

--- a/src/Bridges/Constraint/bridges/zero_one.jl
+++ b/src/Bridges/Constraint/bridges/zero_one.jl
@@ -13,7 +13,7 @@
 
 !!! note
     `ZeroOneBridge` adds a linear constraint instead of adding variable bounds
-    to avoid modifying bounds set by the user.
+    to avoid conflicting with bounds set by the user.
 
 ## Source node
 

--- a/src/Bridges/Constraint/bridges/zero_one.jl
+++ b/src/Bridges/Constraint/bridges/zero_one.jl
@@ -11,6 +11,10 @@
 
   * ``x \\in \\{0, 1\\}`` into ``x \\in \\mathbb{Z}``, ``1x \\in [0, 1]``.
 
+!!! note
+    `ZeroOneBridge` adds a linear constraint instead of adding variable bounds
+    to avoid modifying bounds set by the user.
+
 ## Source node
 
 `ZeroOneBridge` supports:

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -225,7 +225,7 @@ julia> MOI.Bridges.added_constraint_types(
            MOI.Bridges.Constraint.ZeroOneBridge{Float64},
        )
 2-element Vector{Tuple{Type, Type}}:
- (MathOptInterface.VariableIndex, MathOptInterface.Interval{Float64})
+ (MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.Interval{Float64})
  (MathOptInterface.VariableIndex, MathOptInterface.Integer)
 ```
 """

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -150,7 +150,7 @@ function test_runtests()
         """
         variables: x
         x in Integer()
-        x in Interval(0.0, 1.0)
+        1.0 * x in Interval(0.0, 1.0)
         """,
     )
     return


### PR DESCRIPTION
Alternative to #1787. I think this is preferable as it's more correct in allowing other bounds to be set, even if it's a little slower by adding scalar affine inequalities (although these should get presolved out).

It also fits with the ethos of allowing users to move closer to the solver: if they use Mosek they can remove the bridges by declaring `@variable(model, 0 <= x <= 1, Int)` instead of `@variable(model, x, Bin)`.

Closes #1787
Closes #1431 