### PR TITLE
[Bridges] add constraint programming bridges

### DIFF
--- a/docs/src/submodules/Bridges/list_of_bridges.md
+++ b/docs/src/submodules/Bridges/list_of_bridges.md
@@ -51,6 +51,7 @@ Bridges.Constraint.IndicatorActiveOnFalseBridge
 Bridges.Constraint.IndicatorSOS1Bridge
 Bridges.Constraint.SemiToBinaryBridge
 Bridges.Constraint.ZeroOneBridge
+Bridges.Constraint.BinPackingtoMILPBridge
 ```
 
 ## [Objective bridges](@id objective_bridges_ref)

--- a/docs/src/submodules/Bridges/list_of_bridges.md
+++ b/docs/src/submodules/Bridges/list_of_bridges.md
@@ -51,7 +51,8 @@ Bridges.Constraint.IndicatorActiveOnFalseBridge
 Bridges.Constraint.IndicatorSOS1Bridge
 Bridges.Constraint.SemiToBinaryBridge
 Bridges.Constraint.ZeroOneBridge
-Bridges.Constraint.BinPackingtoMILPBridge
+Bridges.Constraint.BinPackingToMILPBridge
+Bridges.Constraint.TableToMILPBridge
 ```
 
 ## [Objective bridges](@id objective_bridges_ref)

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -94,8 +94,8 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(bridged_model, SemiToBinaryBridge{T})
     MOI.Bridges.add_bridge(bridged_model, ZeroOneBridge{T})
     # Constraint programming bridges
-    MOI.Bridges.add_bridge(bridged_model, BinPackingToMILP{T})
-    MOI.Bridges.add_bridge(bridged_model, TableToMILP{T})
+    MOI.Bridges.add_bridge(bridged_model, BinPackingToMILPBridge{T})
+    MOI.Bridges.add_bridge(bridged_model, TableToMILPBridge{T})
     return
 end
 

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -43,6 +43,7 @@ include("bridges/soc_rsoc.jl")
 include("bridges/soc_to_nonconvex_quad.jl") # do not add these bridges by default
 include("bridges/soc_to_psd.jl")
 include("bridges/square.jl")
+include("bridges/table.jl")
 include("bridges/vectorize.jl")
 include("bridges/zero_one.jl")
 
@@ -94,6 +95,7 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(bridged_model, ZeroOneBridge{T})
     # Constraint programming bridges
     MOI.Bridges.add_bridge(bridged_model, BinPackingToMILP{T})
+    MOI.Bridges.add_bridge(bridged_model, TableToMILP{T})
     return
 end
 

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -20,6 +20,7 @@ include("map.jl")
 include("set_map.jl")
 include("single_bridge_optimizer.jl")
 
+include("bridges/bin_packing.jl")
 include("bridges/det.jl")
 include("bridges/flip_sign.jl")
 include("bridges/functionize.jl")
@@ -91,6 +92,8 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(bridged_model, IndicatorSOS1Bridge{T})
     MOI.Bridges.add_bridge(bridged_model, SemiToBinaryBridge{T})
     MOI.Bridges.add_bridge(bridged_model, ZeroOneBridge{T})
+    # Constraint programming bridges
+    MOI.Bridges.add_bridge(bridged_model, BinPackingToMILP{T})
     return
 end
 

--- a/src/Bridges/Constraint/bridges/bin_packing.jl
+++ b/src/Bridges/Constraint/bridges/bin_packing.jl
@@ -17,7 +17,7 @@
     \\sum\\limits_{i=1}^n w_i z_{ij} \\le c & \\forall j \\\\
     \\sum\\limits_{j=1}^n j z_{ij} == x_i   & \\forall i
     \\end{aligned}
-  ```
+    ```
 ## Source node
 
 `BinPackingToMILPBridge` supports:

--- a/src/Bridges/Constraint/bridges/bin_packing.jl
+++ b/src/Bridges/Constraint/bridges/bin_packing.jl
@@ -13,9 +13,9 @@
     ```math
     \\begin{aligned}
     z_{ij} \\in \\{0, 1\\}                  & \\forall i, j \\\\
-    \\sum\\limits_{j=1}^n z_{ij} = 1        & \\forall i \\\\
-    \\sum\\limits_{i=1}^n w_i z_{ij} \\le c & \\forall j \\\\
-    \\sum\\limits_{j=1}^n j z_{ij} == x_i   & \\forall i
+    \\sum\\limits_{j=1}^d z_{ij} = 1        & \\forall i \\\\
+    \\sum\\limits_{i=1}^d w_i z_{ij} \\le c & \\forall j \\\\
+    \\sum\\limits_{j=1}^d j z_{ij} == x_i   & \\forall i
     \\end{aligned}
     ```
 ## Source node

--- a/src/Bridges/Constraint/bridges/bin_packing.jl
+++ b/src/Bridges/Constraint/bridges/bin_packing.jl
@@ -10,7 +10,14 @@
 `BinPackingToMILPBridge` implements the following reformulation:
 
   * ``x \\in BinPacking(c, w)`` into
-
+    ```math
+    \\begin{aligned}
+    z_{ij} \\in \\{0, 1\\}                  & \\forall i, j \\\\
+    \\sum\\limits_{j=1}^n z_{ij} = 1        & \\forall i \\\\
+    \\sum\\limits_{i=1}^n w_i z_{ij} \\le c & \\forall j \\\\
+    \\sum\\limits_{j=1}^n j z_{ij} == x_i   & \\forall i
+    \\end{aligned}
+  ```
 ## Source node
 
 `BinPackingToMILPBridge` supports:

--- a/src/Bridges/Constraint/bridges/bin_packing.jl
+++ b/src/Bridges/Constraint/bridges/bin_packing.jl
@@ -1,0 +1,200 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+"""
+    BinPackingToMILPBridge{T,F} <: Bridges.Constraint.AbstractBridge
+
+`BinPackingToMILPBridge` implements the following reformulation:
+
+  * ``x \\in BinPacking(c, w)`` into
+
+## Source node
+
+`BinPackingToMILPBridge` supports:
+
+  * `F` in [`MOI.BinPacking{T}`](@ref)
+
+## Target nodes
+
+`BinPackingToMILPBridge` creates:
+
+  * [`MOI.VariableIndex`](@ref) in [`MOI.ZeroOne`](@ref)
+  * [`MOI.ScalarAffineFunction{T}`](@ref) in [`MOI.EqualTo{T}`](@ref)
+  * [`MOI.ScalarAffineFunction{T}`](@ref) in [`MOI.LessThan{T}`](@ref)
+"""
+struct BinPackingToMILPBridge{T,F<:MOI.AbstractVectorFunction} <: AbstractBridge
+    z::Matrix{MOI.VariableIndex}
+    capacities::Vector{
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.LessThan{T}},
+    }
+    unities::Vector{
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
+    }
+    assignment::Vector{
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
+    }
+    # Cache to simplify MOI.get
+    f::F
+    s::MOI.BinPacking{T}
+end
+
+const BinPackingToMILP{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{BinPackingToMILPBridge{T},OT}
+
+function bridge_constraint(
+    ::Type{BinPackingToMILPBridge{T,F}},
+    model::MOI.ModelLike,
+    f::F,
+    s::MOI.BinPacking{T},
+) where {T,F}
+    N = length(s.weights)
+    z = reshape(MOI.add_variables(model, N^2), N, N)
+    MOI.add_constraint.(model, z, MOI.ZeroOne())
+    # ∑w_i * z_ib <= c  ∀b
+    capacities = [
+        MOI.add_constraint(
+            model,
+            MOI.ScalarAffineFunction(
+                MOI.ScalarAffineTerm.(s.weights, z[:, b]),
+                zero(T),
+            ),
+            MOI.LessThan(s.capacity),
+        ) for b in 1:N
+    ]
+    # ∑z_ib = 1 ∀i
+    unities = [
+        MOI.add_constraint(
+            model,
+            MOI.ScalarAffineFunction(
+                MOI.ScalarAffineTerm.(one(T), z[i, :]),
+                zero(T),
+            ),
+            MOI.EqualTo(one(T)),
+        ) for i in 1:N
+    ]
+    # ∑b z_ib - f_i == 0
+    assignment =
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}[]
+    for (i, fi) in enumerate(MOI.Utilities.eachscalar(f))
+        assign_f = MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(T(b), z[i, b]) for b in 1:N],
+            zero(T),
+        )
+        assign_f = MOI.Utilities.operate!(-, T, assign_f, fi)
+        ci = MOI.add_constraint(model, assign_f, MOI.EqualTo(zero(T)))
+        push!(assignment, ci)
+    end
+    return BinPackingToMILPBridge{T,F}(z, capacities, unities, assignment, f, s)
+end
+
+function MOI.supports_constraint(
+    ::Type{<:BinPackingToMILPBridge{T}},
+    ::Type{F},
+    ::Type{MOI.BinPacking{T}},
+) where {T,F<:Union{MOI.VectorOfVariables,MOI.VectorAffineFunction{T}}}
+    return true
+end
+
+function MOI.Bridges.added_constrained_variable_types(
+    ::Type{<:BinPackingToMILPBridge},
+)
+    return Tuple{Type}[]
+end
+
+function MOI.Bridges.added_constraint_types(
+    ::Type{BinPackingToMILPBridge{T,F}},
+) where {T,F}
+    return Tuple{Type,Type}[
+        (MOI.VariableIndex, MOI.ZeroOne),
+        (MOI.ScalarAffineFunction{T}, MOI.EqualTo{T}),
+        (MOI.ScalarAffineFunction{T}, MOI.LessThan{T}),
+    ]
+end
+
+function concrete_bridge_type(
+    ::Type{<:BinPackingToMILPBridge{T}},
+    ::Type{F},
+    ::Type{MOI.BinPacking{T}},
+) where {T,F<:MOI.AbstractVectorFunction}
+    return BinPackingToMILPBridge{T,F}
+end
+
+function MOI.get(
+    ::MOI.ModelLike,
+    ::MOI.ConstraintFunction,
+    bridge::BinPackingToMILPBridge,
+)
+    return bridge.f
+end
+
+function MOI.get(
+    ::MOI.ModelLike,
+    ::MOI.ConstraintSet,
+    bridge::BinPackingToMILPBridge,
+)
+    return bridge.s
+end
+
+function MOI.delete(model::MOI.ModelLike, bridge::BinPackingToMILPBridge)
+    MOI.delete(model, bridge.capacities)
+    MOI.delete(model, bridge.unities)
+    MOI.delete(model, bridge.assignment)
+    MOI.delete.(model, bridge.z)
+    return
+end
+
+function MOI.get(bridge::BinPackingToMILPBridge, ::MOI.NumberOfVariables)::Int64
+    return length(bridge.z)
+end
+
+function MOI.get(bridge::BinPackingToMILPBridge, ::MOI.ListOfVariableIndices)
+    return [bridge.z[i] for i in eachindex(bridge.z)]
+end
+
+function MOI.get(
+    bridge::BinPackingToMILPBridge,
+    ::MOI.NumberOfConstraints{MOI.VariableIndex,MOI.ZeroOne},
+)::Int64
+    return length(bridge.z)
+end
+
+function MOI.get(
+    bridge::BinPackingToMILPBridge,
+    ::MOI.ListOfConstraintIndices{MOI.VariableIndex,MOI.ZeroOne},
+)
+    return [
+        MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(z.value) for
+        z in bridge.z
+    ]
+end
+
+function MOI.get(
+    bridge::BinPackingToMILPBridge{T},
+    ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
+)::Int64 where {T}
+    return length(bridge.unities) + length(bridge.assignment)
+end
+
+function MOI.get(
+    bridge::BinPackingToMILPBridge{T},
+    ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
+) where {T}
+    return vcat(bridge.unities, bridge.assignment)
+end
+
+function MOI.get(
+    bridge::BinPackingToMILPBridge{T},
+    ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}},
+)::Int64 where {T}
+    return length(bridge.capacities)
+end
+
+function MOI.get(
+    bridge::BinPackingToMILPBridge{T},
+    ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T},MOI.LessThan{T}},
+) where {T}
+    return copy(bridge.capacities)
+end

--- a/src/Bridges/Constraint/bridges/table.jl
+++ b/src/Bridges/Constraint/bridges/table.jl
@@ -9,7 +9,14 @@
 
 `TableToMILPBridge` implements the following reformulation:
 
-  * ``x \\in Table(c, w)`` into
+  * ``x \\in Table(t)`` into
+    ```math
+    \\begin{aligned}
+    z_{j} \\in \\{0, 1\\}                     & \\forall i, j \\\\
+    \\sum\\limits_{j=1}^n z_{j} = 1                           \\\\
+    \\sum\\limits_{j=1}^n t_{ij} z_{j} == x_i & \\forall i
+    \\end{aligned}
+    ```
 
 ## Source node
 

--- a/src/Bridges/Constraint/bridges/table.jl
+++ b/src/Bridges/Constraint/bridges/table.jl
@@ -1,0 +1,166 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+"""
+    TableToMILPBridge{T,F} <: Bridges.Constraint.AbstractBridge
+
+`TableToMILPBridge` implements the following reformulation:
+
+  * ``x \\in Table(c, w)`` into
+
+## Source node
+
+`TableToMILPBridge` supports:
+
+  * `F` in [`MOI.Table{T}`](@ref)
+
+## Target nodes
+
+`TableToMILPBridge` creates:
+
+  * [`MOI.VariableIndex`](@ref) in [`MOI.ZeroOne`](@ref)
+  * [`MOI.ScalarAffineFunction{T}`](@ref) in [`MOI.EqualTo{T}`](@ref)
+  * [`MOI.ScalarAffineFunction{T}`](@ref) in [`MOI.LessThan{T}`](@ref)
+"""
+struct TableToMILPBridge{T,F<:MOI.AbstractVectorFunction} <: AbstractBridge
+    z::Vector{MOI.VariableIndex}
+    unity::MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}
+    assignment::Vector{
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
+    }
+    # Cache to simplify MOI.get
+    f::F
+    s::MOI.Table{T}
+end
+
+const TableToMILP{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{TableToMILPBridge{T},OT}
+
+function bridge_constraint(
+    ::Type{TableToMILPBridge{T,F}},
+    model::MOI.ModelLike,
+    f::F,
+    s::MOI.Table{T},
+) where {T,F}
+    m = size(s.table, 1)
+    z = MOI.add_variables(model, m)
+    MOI.add_constraint.(model, z, MOI.ZeroOne())
+    # ∑z_j = 1
+    unity = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(one(T), z), zero(T)),
+        MOI.EqualTo(one(T)),
+    )
+    # ∑t_ij z_j == f_i
+    assignment =
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}[]
+    for (i, fi) in enumerate(MOI.Utilities.eachscalar(f))
+        terms = MOI.ScalarAffineTerm{T}[]
+        for j in 1:m
+            if !iszero(s.table[j, i])
+                push!(terms, MOI.ScalarAffineTerm(s.table[j, i], z[j]))
+            end
+        end
+        assign_f = MOI.ScalarAffineFunction(terms, zero(T))
+        assign_f = MOI.Utilities.operate!(-, T, assign_f, fi)
+        ci = MOI.add_constraint(model, assign_f, MOI.EqualTo(zero(T)))
+        push!(assignment, ci)
+    end
+    return TableToMILPBridge{T,F}(z, unity, assignment, f, s)
+end
+
+function MOI.supports_constraint(
+    ::Type{<:TableToMILPBridge{T}},
+    ::Type{F},
+    ::Type{MOI.Table{T}},
+) where {T,F<:Union{MOI.VectorOfVariables,MOI.VectorAffineFunction{T}}}
+    return true
+end
+
+function MOI.Bridges.added_constrained_variable_types(
+    ::Type{<:TableToMILPBridge},
+)
+    return Tuple{Type}[]
+end
+
+function MOI.Bridges.added_constraint_types(
+    ::Type{TableToMILPBridge{T,F}},
+) where {T,F}
+    return Tuple{Type,Type}[
+        (MOI.VariableIndex, MOI.ZeroOne),
+        (MOI.ScalarAffineFunction{T}, MOI.EqualTo{T}),
+    ]
+end
+
+function concrete_bridge_type(
+    ::Type{<:TableToMILPBridge{T}},
+    ::Type{F},
+    ::Type{MOI.Table{T}},
+) where {T,F<:MOI.AbstractVectorFunction}
+    return TableToMILPBridge{T,F}
+end
+
+function MOI.get(
+    ::MOI.ModelLike,
+    ::MOI.ConstraintFunction,
+    bridge::TableToMILPBridge,
+)
+    return bridge.f
+end
+
+function MOI.get(
+    ::MOI.ModelLike,
+    ::MOI.ConstraintSet,
+    bridge::TableToMILPBridge,
+)
+    return bridge.s
+end
+
+function MOI.delete(model::MOI.ModelLike, bridge::TableToMILPBridge)
+    MOI.delete(model, bridge.assignment)
+    MOI.delete(model, bridge.unity)
+    MOI.delete(model, bridge.z)
+    return
+end
+
+function MOI.get(bridge::TableToMILPBridge, ::MOI.NumberOfVariables)::Int64
+    return length(bridge.z)
+end
+
+function MOI.get(bridge::TableToMILPBridge, ::MOI.ListOfVariableIndices)
+    return copy(bridge.z)
+end
+
+function MOI.get(
+    bridge::TableToMILPBridge,
+    ::MOI.NumberOfConstraints{MOI.VariableIndex,MOI.ZeroOne},
+)::Int64
+    return length(bridge.z)
+end
+
+function MOI.get(
+    bridge::TableToMILPBridge,
+    ::MOI.ListOfConstraintIndices{MOI.VariableIndex,MOI.ZeroOne},
+)
+    return [
+        MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(z.value) for
+        z in bridge.z
+    ]
+end
+
+function MOI.get(
+    bridge::TableToMILPBridge{T},
+    ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
+)::Int64 where {T}
+    return length(bridge.assignment) + 1
+end
+
+function MOI.get(
+    bridge::TableToMILPBridge{T},
+    ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
+) where {T}
+    return vcat(bridge.assignment, bridge.unity)
+end

--- a/test/Bridges/Constraint/bin_packing.jl
+++ b/test/Bridges/Constraint/bin_packing.jl
@@ -1,0 +1,59 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestConstraintBinPacking
+
+using Test
+
+using MathOptInterface
+const MOI = MathOptInterface
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function test_runtests()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.BinPackingToMILPBridge,
+        """
+        variables: x, y, z
+        [x, y, z] in BinPacking(3.0, [1.0, 2.0, 3.0])
+        """,
+        """
+        variables: x, y, z, a11, a12, a13, a21, a22, a23, a31, a32, a33
+        1.0 * a11 + 2.0 * a12 + 3.0 * a13 <= 3.0
+        1.0 * a21 + 2.0 * a22 + 3.0 * a23 <= 3.0
+        1.0 * a31 + 2.0 * a32 + 3.0 * a33 <= 3.0
+        a11 + a21 + a31 == 1.0
+        a12 + a22 + a32 == 1.0
+        a13 + a23 + a33 == 1.0
+        1.0 * a11 + 2.0 * a21 + 3.0 * a31 + -1.0 * x == 0.0
+        1.0 * a12 + 2.0 * a22 + 3.0 * a32 + -1.0 * y == 0.0
+        1.0 * a13 + 2.0 * a23 + 3.0 * a33 + -1.0 * z == 0.0
+        a11 in ZeroOne()
+        a12 in ZeroOne()
+        a13 in ZeroOne()
+        a21 in ZeroOne()
+        a22 in ZeroOne()
+        a23 in ZeroOne()
+        a31 in ZeroOne()
+        a32 in ZeroOne()
+        a33 in ZeroOne()
+        """,
+    )
+    return
+end
+
+end  # module
+
+TestConstraintBinPacking.runtests()

--- a/test/Bridges/Constraint/table.jl
+++ b/test/Bridges/Constraint/table.jl
@@ -4,7 +4,7 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-module TestConstraintBinPacking
+module TestConstraintTable
 
 using Test
 
@@ -46,4 +46,4 @@ end
 
 end  # module
 
-TestConstraintBinPacking.runtests()
+TestConstraintTable.runtests()

--- a/test/Bridges/Constraint/table.jl
+++ b/test/Bridges/Constraint/table.jl
@@ -1,0 +1,49 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestConstraintBinPacking
+
+using Test
+
+using MathOptInterface
+const MOI = MathOptInterface
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function test_runtests()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.TableToMILPBridge,
+        """
+        variables: x, y, z
+        [x, y, z] in Table(Float64[1 1 0; 0 1 1; 1 0 1; 1 1 1])
+        """,
+        """
+        variables: x, y, z, a1, a2, a3, a4
+        a1 + a2 + a3 + a4 == 1.0
+        a1 +      a3 + a4 + -1.0 * x == 0.0
+        a1 + a2 +      a4 + -1.0 * y == 0.0
+             a2 + a3 + a4 + -1.0 * z == 0.0
+        a1 in ZeroOne()
+        a2 in ZeroOne()
+        a3 in ZeroOne()
+        a4 in ZeroOne()
+        """,
+    )
+    return
+end
+
+end  # module
+
+TestConstraintBinPacking.runtests()


### PR DESCRIPTION
This is quite a naïve reformulation. We could make it stronger by computing a smaller set of bins (e.g., greedily assignment), and we could add ordering constraints on the bins, so that you can only use bin 2 if bin 1 is full.