### PR TITLE
Add GetAttributeNotAllowed error

### DIFF
--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -939,11 +939,11 @@ function MOI.get(
             model.model_to_optimizer_map[index],
         )
     catch err
-        if err isa ArgumentError  # Thrown if .optimizer doesn't support attr
-            return get_fallback(model, attr, index)
-        else
+        # Thrown if .optimizer doesn't support attr
+        if !(err isa MOI.GetAttributeNotAllowed)
             rethrow(err)
         end
+        return get_fallback(model, attr, index)
     end
 end
 
@@ -965,11 +965,11 @@ function MOI.get(
             [model.model_to_optimizer_map[i] for i in indices],
         )
     catch err
-        if err isa ArgumentError  # Thrown if .optimizer doesn't support attr
-            return [get_fallback(model, attr, i) for i in indices]
-        else
+        # Thrown if .optimizer doesn't support attr
+        if !(err isa MOI.GetAttributeNotAllowed)
             rethrow(err)
         end
+        return [get_fallback(model, attr, i) for i in indices]
     end
 end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -101,6 +101,26 @@ operation_name(err::SetAttributeNotAllowed) = "Setting attribute $(err.attr)"
 message(err::SetAttributeNotAllowed) = err.message
 
 """
+    struct GetAttributeNotAllowed{AttrType} <: NotAllowedError
+        attr::AttrType
+        message::String
+    end
+
+An error indicating that the attribute `attr` cannot be got for some reason (see
+the error string).
+"""
+struct GetAttributeNotAllowed{AttrType<:AnyAttribute} <: NotAllowedError
+    attr::AttrType
+    message::String
+end
+
+GetAttributeNotAllowed(attr::AnyAttribute) = GetAttributeNotAllowed(attr, "")
+
+operation_name(err::GetAttributeNotAllowed) = "Getting attribute $(err.attr)"
+
+message(err::GetAttributeNotAllowed) = err.message
+
+"""
     AbstractSubmittable
 
 Abstract supertype for objects that can be submitted to the model.
@@ -341,7 +361,8 @@ function get_fallback(
     attr::Union{AbstractModelAttribute,AbstractOptimizerAttribute},
 )
     return throw(
-        ArgumentError(
+        GetAttributeNotAllowed(
+            attr,
             "$(typeof(model)) does not support getting the attribute $(attr).",
         ),
     )
@@ -353,7 +374,8 @@ function get_fallback(
     ::VariableIndex,
 )
     return throw(
-        ArgumentError(
+        GetAttributeNotAllowed(
+            attr,
             "$(typeof(model)) does not support getting the attribute $(attr).",
         ),
     )
@@ -365,7 +387,8 @@ function get_fallback(
     ::ConstraintIndex,
 )
     return throw(
-        ArgumentError(
+        GetAttributeNotAllowed(
+            attr,
             "$(typeof(model)) does not support getting the attribute $(attr).",
         ),
     )
@@ -373,7 +396,8 @@ end
 
 function get_fallback(::ModelLike, attr::AnyAttribute, args...)
     return throw(
-        ArgumentError(
+        GetAttributeNotAllowed(
+            attr,
             "Unable to get attribute $(attr): invalid arguments $(args).",
         ),
     )

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -112,9 +112,11 @@ the error string).
 struct GetAttributeNotAllowed{AttrType<:AnyAttribute} <: NotAllowedError
     attr::AttrType
     message::String
-end
 
-GetAttributeNotAllowed(attr::AnyAttribute) = GetAttributeNotAllowed(attr, "")
+    function GetAttributeNotAllowed(attr::AnyAttribute, message::String = "")
+        return new(attr, message)
+    end
+end
 
 operation_name(err::GetAttributeNotAllowed) = "Getting attribute $(err.attr)"
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -114,7 +114,7 @@ struct GetAttributeNotAllowed{AttrType<:AnyAttribute} <: NotAllowedError
     message::String
 
     function GetAttributeNotAllowed(attr::AnyAttribute, message::String = "")
-        return new(attr, message)
+        return new{typeof(attr)}(attr, message)
     end
 end
 

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -150,30 +150,48 @@ function test_get_fallback()
     model = DummyModelWithAdd()
     x = MOI.add_variable(model)
     c = MOI.add_constraint(model, x, MOI.EqualTo(0.0))
-    err = ArgumentError(
-        "$(typeof(model)) does not support getting the attribute " *
-        "$(MOI.SolveTimeSec()).",
-    )
-    @test_throws(err, MOI.get(model, MOI.SolveTimeSec()))
-    output = Ref{Cdouble}()
-    @test_throws(err, MOI.get!(output, model, MOI.SolveTimeSec()))
-    errv = ArgumentError(
-        "$(typeof(model)) does not support getting the attribute " *
-        "$(MOI.VariablePrimal()).",
-    )
-    @test_throws(errv, MOI.get(model, MOI.VariablePrimal(), x))
-    errc = ArgumentError(
-        "$(typeof(model)) does not support getting the attribute " *
-        "$(MOI.ConstraintPrimal()).",
-    )
-    @test_throws(errc, MOI.get(model, MOI.ConstraintPrimal(), c))
     @test_throws(
-        ArgumentError(
+        MOI.GetAttributeNotAllowed(
+            MOI.SolveTimeSec(),
+            "$(typeof(model)) does not support getting the attribute " *
+            "$(MOI.SolveTimeSec()).",
+        ),
+        MOI.get(model, MOI.SolveTimeSec()),
+    )
+    output = Ref{Cdouble}()
+    @test_throws(
+        MOI.GetAttributeNotAllowed(
+            MOI.SolveTimeSec(),
+            "$(typeof(model)) does not support getting the attribute " *
+            "$(MOI.SolveTimeSec()).",
+        ),
+        MOI.get!(output, model, MOI.SolveTimeSec()),
+    )
+    @test_throws(
+        MOI.GetAttributeNotAllowed(
+            MOI.VariablePrimal(),
+            "$(typeof(model)) does not support getting the attribute " *
+            "$(MOI.VariablePrimal()).",
+        ),
+        MOI.get(model, MOI.VariablePrimal(), x),
+    )
+    @test_throws(
+        MOI.GetAttributeNotAllowed(
+            MOI.ConstraintPrimal(),
+            "$(typeof(model)) does not support getting the attribute " *
+            "$(MOI.ConstraintPrimal()).",
+        ),
+        MOI.get(model, MOI.ConstraintPrimal(), c),
+    )
+    @test_throws(
+        MOI.GetAttributeNotAllowed(
+            MOI.VariablePrimal(),
             "Unable to get attribute $(MOI.VariablePrimal()): invalid " *
             "arguments $((c,)).",
         ),
         MOI.get(model, MOI.VariablePrimal(), c),
     )
+    return
 end
 
 function test_ConstraintBasisStatus_fallback()

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -334,6 +334,21 @@ function test_compute_conflict_fallback()
     return
 end
 
+function test_get_fallback_error()
+    model = MOI.Utilities.Model{Float64}()
+    @test_throws(
+        MOI.GetAttributeNotAllowed,
+        MOI.get(model, MOI.SolveTimeSec()),
+    )
+    err = MOI.GetAttributeNotAllowed(MOI.SolveTimeSec(), "")
+    @test sprint(showerror, err) ==
+          "$(typeof(err)): Getting attribute $(MOI.SolveTimeSec()) cannot be " *
+          "performed. You may want to use a `CachingOptimizer` in " *
+          "`AUTOMATIC` mode or you may need to call `reset_optimizer` before " *
+          "doing this operation if the `CachingOptimizer` is in `MANUAL` mode."
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if startswith("$name", "test_")


### PR DESCRIPTION
Closes #1777 

With @blegat's example, the state is now `EMPTY_OPTIMIZER`, and the set is `<= 2.0` as desired.
```julia
julia> using MathOptInterface

julia> const MOI = MathOptInterface
MathOptInterface

julia> MOI.Utilities.@model(
           NoFreeVariablesModel,
           (),
           (MOI.LessThan,),
           (MOI.Nonnegatives,),
           (),
           (),
           (MOI.ScalarAffineFunction,),
           (MOI.VectorOfVariables,),
           ()
       )
MathOptInterface.Utilities.GenericModel{T, MathOptInterface.Utilities.ObjectiveContainer{T}, MathOptInterface.Utilities.VariablesContainer{T}, NoFreeVariablesModelFunctionConstraints{T}} where T

julia> function MOI.supports_constraint(
           ::NoFreeVariablesModel{T},
           ::Type{MOI.VectorOfVariables},
           ::Type{MOI.Reals},
       ) where {T}
           return false
       end

julia> function MOI.supports_add_constrained_variables(
           ::NoFreeVariablesModel,
           ::Type{MOI.Nonnegatives},
       )
           return true
       end

julia> MOI.supports_add_constrained_variables(::NoFreeVariablesModel, ::Type{MOI.Reals}) = false

julia> function MOI.get(model::NoFreeVariablesModel, attr::MOI.ConstraintFunction, ci::MOI.ConstraintIndex)
           return MOI.get_fallback(model, attr, ci)
       end

julia> function bug()
           inner = NoFreeVariablesModel{Float64}()
           bridged = MOI.Bridges.full_bridge_optimizer(inner, Float64)
           model = MOI.Utilities.CachingOptimizer(
               MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
               bridged,
           )
           x = MOI.add_variable(model)
           c = MOI.add_constraint(model, 1.0 * x, MOI.LessThan(1.0))
           MOI.Utilities.attach_optimizer(model)
           MOI.set(model, MOI.ConstraintSet(), c, MOI.LessThan(2.0))
           return model
           end
bug (generic function with 1 method)

julia> bug()
MOIU.CachingOptimizer{MOIB.LazyBridgeOptimizer{MOIU.GenericModel{Float64, MOIU.ObjectiveContainer{Float64}, MOIU.VariablesContainer{Float64}, NoFreeVariablesModelFunctionConstraints{Float64}}}, MOIU.UniversalFallback{MOIU.Model{Float64}}}
in state EMPTY_OPTIMIZER
in mode AUTOMATIC
with model cache MOIU.UniversalFallback{MOIU.Model{Float64}}
  fallback for MOIU.Model{Float64}
with optimizer MOIB.LazyBridgeOptimizer{MOIU.GenericModel{Float64, MOIU.ObjectiveContainer{Float64}, MOIU.VariablesContainer{Float64}, NoFreeVariablesModelFunctionConstraints{Float64}}}
  with 0 variable bridges
  with 0 constraint bridges
  with 0 objective bridges
  with inner model MOIU.GenericModel{Float64, MOIU.ObjectiveContainer{Float64}, MOIU.VariablesContainer{Float64}, NoFreeVariablesModelFunctionConstraints{Float64}}

julia> print(bug())
Feasibility

Subject to:

ScalarAffineFunction{Float64}-in-LessThan{Float64}
 0.0 + 1.0 v[1] <= 2.0
```

where previously
```Julia
julia> bug()
ERROR: ArgumentError: MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ObjectiveContainer{Float64}, MathOptInterface.Utilities.VariablesContainer{Float64}, NoFreeVariablesModelFunctionConstraints{Float64}} does not support getting the attribute MathOptInterface.ConstraintFunction().
Stacktrace:
 [1] get_fallback(model::MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ObjectiveContainer{Float64}, MathOptInterface.Utilities.VariablesContainer{Float64}, NoFreeVariablesModelFunctionConstraints{Float64}}, attr::MathOptInterface.ConstraintFunction, #unused#::MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}})
   @ MathOptInterface ~/.julia/packages/MathOptInterface/RuRWI/src/attributes.jl:367
 [2] get(model::MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ObjectiveContainer{Float64}, MathOptInterface.Utilities.VariablesContainer{Float64}, NoFreeVariablesModelFunctionConstraints{Float64}}, attr::MathOptInterface.ConstraintFunction, ci::MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}})
   @ Main ./REPL[9]:2
 [3] get(b::MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ObjectiveContainer{Float64}, MathOptInterface.Utilities.VariablesContainer{Float64}, NoFreeVariablesModelFunctionConstraints{Float64}}}, attr::MathOptInterface.ConstraintFunction, ci::MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}})
   @ MathOptInterface.Bridges ~/.julia/packages/MathOptInterface/RuRWI/src/Bridges/bridge_optimizer.jl:1222
 [4] set
   @ ~/.julia/packages/MathOptInterface/RuRWI/src/Bridges/bridge_optimizer.jl:1262 [inlined]
 [5] _replace_constraint_function_or_set(m::MathOptInterface.Utilities.CachingOptimizer{MathOptInterface.Bridges.LazyBridgeOptimizer{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ObjectiveContainer{Float64}, MathOptInterface.Utilities.VariablesContainer{Float64}, NoFreeVariablesModelFunctionConstraints{Float64}}}, MathOptInterface.Utilities.UniversalFallback{MathOptInterface.Utilities.Model{Float64}}}, attr::MathOptInterface.ConstraintSet, cindex::MathOptInterface.ConstraintIndex{MathOptInterface.ScalarAffineFunction{Float64}, MathOptInterface.LessThan{Float64}}, replacement::MathOptInterface.LessThan{Float64})
   @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/RuRWI/src/Utilities/cachingoptimizer.jl:595
 [6] set
   @ ~/.julia/packages/MathOptInterface/RuRWI/src/Utilities/cachingoptimizer.jl:627 [inlined]
 [7] bug()
   @ Main ./REPL[10]:11
 [8] top-level scope
   @ REPL[11]:1
```