### PR TITLE
[Utilities] remove copy in modify_function

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1044,7 +1044,6 @@ function _modifycoefficient(
     variable::MOI.VariableIndex,
     new_coefficient::T,
 ) where {T}
-    terms = copy(terms)
     i = something(findfirst(t -> t.variable == variable, terms), 0)
     if iszero(i)  # The variable was not already in the function
         if !iszero(new_coefficient)
@@ -1092,7 +1091,6 @@ function _modifycoefficients(
     variable::MOI.VariableIndex,
     new_coefficients::Vector{Tuple{Int64,T}},
 ) where {T}
-    terms = copy(terms)
     coef_dict = Dict(k => v for (k, v) in new_coefficients)
     elements_to_delete = Int[]
     for (i, term) in enumerate(terms)

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1002,44 +1002,59 @@ end
 """
     modify_function(f::AbstractFunction, change::AbstractFunctionModification)
 
-Return a new function `f` modified according to `change`.
+Return a copy of the function `f`, modified according to `change`.
 """
 function modify_function(
+    f::MOI.AbstractFunction,
+    change::MOI.AbstractFunctionModification,
+)
+    new_f = copy(f)
+    modify_function!(new_f, change)
+    return new_f
+end
+
+"""
+    modify_function!(f::AbstractFunction, change::AbstractFunctionModification)
+
+Modify the function `f` in-place, according to `change`.
+"""
+function modify_function!(
     f::MOI.ScalarAffineFunction,
     change::MOI.ScalarConstantChange,
 )
-    return MOI.ScalarAffineFunction(f.terms, change.new_constant)
+    f.constant = change.new_constant
+    return f
 end
 
-function modify_function(
+function modify_function!(
     f::MOI.VectorAffineFunction,
     change::MOI.VectorConstantChange,
 )
-    return MOI.VectorAffineFunction(f.terms, change.new_constant)
+    for (i, constant) in enumerate(change.new_constant)
+        f.constants[i] = constant
+    end
+    return f
 end
 
-function modify_function(
+function modify_function!(
     f::MOI.ScalarQuadraticFunction,
     change::MOI.ScalarConstantChange,
 )
-    return MOI.ScalarQuadraticFunction(
-        f.quadratic_terms,
-        f.affine_terms,
-        change.new_constant,
-    )
+    f.constant = change.new_constant
+    return f
 end
-function modify_function(
+
+function modify_function!(
     f::MOI.VectorQuadraticFunction,
     change::MOI.VectorConstantChange,
 )
-    return MOI.VectorQuadraticFunction(
-        f.quadratic_terms,
-        f.affine_terms,
-        change.new_constant,
-    )
+    for (i, constant) in enumerate(change.new_constant)
+        f.constants[i] = constant
+    end
+    return f
 end
 
-function _modifycoefficient(
+function _modify_coefficient(
     terms::Vector{MOI.ScalarAffineTerm{T}},
     variable::MOI.VariableIndex,
     new_coefficient::T,
@@ -1063,30 +1078,30 @@ function _modifycoefficient(
             end
         end
     end
-    return terms
+    return
 end
 
-function modify_function(
+function modify_function!(
     f::MOI.ScalarAffineFunction{T},
     change::MOI.ScalarCoefficientChange{T},
 ) where {T}
-    terms = _modifycoefficient(f.terms, change.variable, change.new_coefficient)
-    return MOI.ScalarAffineFunction(terms, f.constant)
+    _modify_coefficient(f.terms, change.variable, change.new_coefficient)
+    return f
 end
 
-function modify_function(
+function modify_function!(
     f::MOI.ScalarQuadraticFunction{T},
     change::MOI.ScalarCoefficientChange{T},
 ) where {T}
-    terms = _modifycoefficient(
+    _modify_coefficient(
         f.affine_terms,
         change.variable,
         change.new_coefficient,
     )
-    return MOI.ScalarQuadraticFunction(f.quadratic_terms, terms, f.constant)
+    return f
 end
 
-function _modifycoefficients(
+function _modify_coefficients(
     terms::Vector{MOI.VectorAffineTerm{T}},
     variable::MOI.VariableIndex,
     new_coefficients::Vector{Tuple{Int64,T}},
@@ -1119,28 +1134,26 @@ function _modifycoefficients(
         end
         push!(terms, MOI.VectorAffineTerm(k, MOI.ScalarAffineTerm(v, variable)))
     end
-    return terms
+    return
 end
 
-function modify_function(
+function modify_function!(
     f::MOI.VectorAffineFunction{T},
     change::MOI.MultirowChange{T},
 ) where {T}
-    terms =
-        _modifycoefficients(f.terms, change.variable, change.new_coefficients)
-    return MOI.VectorAffineFunction(terms, f.constants)
+    _modify_coefficients(f.terms, change.variable, change.new_coefficients)
+    return f
 end
 
-function modify_function(
+function modify_function!(
     f::MOI.VectorQuadraticFunction{T},
     change::MOI.MultirowChange{T},
 ) where {T}
-    terms = _modifycoefficients(
-        f.affine_terms,
+    _modify_coefficients(f.affine_terms,
         change.variable,
         change.new_coefficients,
     )
-    return MOI.VectorQuadraticFunction(f.quadratic_terms, terms, f.constants)
+    return f
 end
 
 # Arithmetic

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1093,11 +1093,7 @@ function modify_function!(
     f::MOI.ScalarQuadraticFunction{T},
     change::MOI.ScalarCoefficientChange{T},
 ) where {T}
-    _modify_coefficient(
-        f.affine_terms,
-        change.variable,
-        change.new_coefficient,
-    )
+    _modify_coefficient(f.affine_terms, change.variable, change.new_coefficient)
     return f
 end
 
@@ -1149,7 +1145,8 @@ function modify_function!(
     f::MOI.VectorQuadraticFunction{T},
     change::MOI.MultirowChange{T},
 ) where {T}
-    _modify_coefficients(f.affine_terms,
+    _modify_coefficients(
+        f.affine_terms,
         change.variable,
         change.new_coefficients,
     )

--- a/src/Utilities/objective_container.jl
+++ b/src/Utilities/objective_container.jl
@@ -165,13 +165,13 @@ function MOI.modify(
     change::MOI.AbstractFunctionModification,
 )
     if o.single_variable !== nothing
-        o.single_variable = modify_function(o.single_variable, change)
+        o.single_variable = modify_function!(o.single_variable, change)
     elseif o.scalar_quadratic !== nothing
-        o.scalar_quadratic = modify_function(o.scalar_quadratic, change)
+        o.scalar_quadratic = modify_function!(o.scalar_quadratic, change)
     else
         @assert o.scalar_affine !== nothing
         o.is_function_set = true
-        o.scalar_affine = modify_function(o.scalar_affine, change)
+        o.scalar_affine = modify_function!(o.scalar_affine, change)
     end
     return
 end

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -163,7 +163,7 @@ function MOI.modify(
     change::MOI.AbstractFunctionModification,
 ) where {F,S}
     func, set = v.constraints[ci]
-    v.constraints[ci] = (modify_function(func, change), set)
+    v.constraints[ci] = (modify_function!(func, change), set)
     return
 end
 


### PR DESCRIPTION
Closes #1921

Just seeing if how this fares in CI. We'd have to be careful here. 

From what I can tell, no one is using `modify_function` other than StochasticPrograms, which should be okay with modifying the function: https://juliahub.com/ui/Search?q=modify_function&type=code

I'll see if I can come up with an example where this would matter. My guess is something like a function being re-used in an objective and a constraint.