### PR TITLE
[Bridges] update BinPackingToMILPBridge to final_touch

### DIFF
--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -97,9 +97,7 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(bridged_model, ZeroOneBridge{T})
     # Constraint programming bridges
     MOI.Bridges.add_bridge(bridged_model, AllDifferentToCountDistinctBridge{T})
-    # TODO(odow): this reformulation assumes the bins are numbered 1..N. We
-    # should fix this to use the variable bounds before adding automatically.
-    # MOI.Bridges.add_bridge(bridged_model, BinPackingToMILPBridge{T})
+    MOI.Bridges.add_bridge(bridged_model, BinPackingToMILPBridge{T})
     MOI.Bridges.add_bridge(bridged_model, CountAtLeastToCountBelongsBridge{T})
     MOI.Bridges.add_bridge(bridged_model, CountBelongsToMILPBridge{T})
     MOI.Bridges.add_bridge(bridged_model, CountDistinctToMILPBridge{T})

--- a/src/Bridges/Constraint/bridges/bin_packing.jl
+++ b/src/Bridges/Constraint/bridges/bin_packing.jl
@@ -12,15 +12,12 @@
   * ``x \\in BinPacking(c, w)`` into
     ```math
     \\begin{aligned}
-    z_{ij} \\in \\{0, 1\\}                  & \\forall i, j \\\\
-    \\sum\\limits_{j=1}^d z_{ij} = 1        & \\forall i \\\\
-    \\sum\\limits_{i=1}^d w_i z_{ij} \\le c & \\forall j \\\\
-    \\sum\\limits_{j=1}^d j z_{ij} == x_i   & \\forall i
+    z_{ij} \\in \\{0, 1\\}              & \\forall i, j \\\\
+    \\sum\\limits_{j} z_{ij} = 1        & \\forall i \\\\
+    \\sum\\limits_{i} w_i z_{ij} \\le c & \\forall j \\\\
+    \\sum\\limits_{j} j z_{ij} == x_i   & \\forall i
     \\end{aligned}
     ```
-
-!!! warning
-    This reformulation assumes the bins are numbered ``1\\ldots d``.
 
 ## Source node
 
@@ -36,20 +33,20 @@
   * [`MOI.ScalarAffineFunction{T}`](@ref) in [`MOI.EqualTo{T}`](@ref)
   * [`MOI.ScalarAffineFunction{T}`](@ref) in [`MOI.LessThan{T}`](@ref)
 """
-struct BinPackingToMILPBridge{T,F<:MOI.AbstractVectorFunction} <: AbstractBridge
-    z::Matrix{MOI.VariableIndex}
-    capacities::Vector{
-        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.LessThan{T}},
-    }
-    unities::Vector{
-        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
-    }
-    assignment::Vector{
-        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
-    }
-    # Cache to simplify MOI.get
+struct BinPackingToMILPBridge{
+    T,
+    F<:Union{MOI.VectorOfVariables,MOI.VectorAffineFunction{T}},
+} <: AbstractBridge
     f::F
     s::MOI.BinPacking{T}
+
+    variables::Vector{MOI.VariableIndex}
+    less_than::Vector{
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.LessThan{T}},
+    }
+    equal_to::Vector{
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
+    }
 end
 
 const BinPackingToMILP{T,OT<:MOI.ModelLike} =
@@ -61,44 +58,13 @@ function bridge_constraint(
     f::F,
     s::MOI.BinPacking{T},
 ) where {T,F}
-    N = length(s.weights)
-    z = reshape(MOI.add_variables(model, N^2), N, N)
-    MOI.add_constraint.(model, z, MOI.ZeroOne())
-    # ∑w_i * z_ib <= c  ∀b
-    capacities = [
-        MOI.add_constraint(
-            model,
-            MOI.ScalarAffineFunction(
-                MOI.ScalarAffineTerm.(s.weights, z[:, b]),
-                zero(T),
-            ),
-            MOI.LessThan(s.capacity),
-        ) for b in 1:N
-    ]
-    # ∑z_ib = 1 ∀i
-    unities = [
-        MOI.add_constraint(
-            model,
-            MOI.ScalarAffineFunction(
-                MOI.ScalarAffineTerm.(one(T), z[i, :]),
-                zero(T),
-            ),
-            MOI.EqualTo(one(T)),
-        ) for i in 1:N
-    ]
-    # ∑b z_ib - f_i == 0
-    assignment =
-        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}[]
-    for (i, fi) in enumerate(MOI.Utilities.eachscalar(f))
-        assign_f = MOI.ScalarAffineFunction(
-            [MOI.ScalarAffineTerm(T(b), z[i, b]) for b in 1:N],
-            zero(T),
-        )
-        assign_f = MOI.Utilities.operate!(-, T, assign_f, fi)
-        ci = MOI.add_constraint(model, assign_f, MOI.EqualTo(zero(T)))
-        push!(assignment, ci)
-    end
-    return BinPackingToMILPBridge{T,F}(z, capacities, unities, assignment, f, s)
+    return BinPackingToMILPBridge{T,F}(
+        f,
+        s,
+        MOI.VariableIndex[],
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}[],
+        MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}[],
+    )
 end
 
 function MOI.supports_constraint(
@@ -112,14 +78,13 @@ end
 function MOI.Bridges.added_constrained_variable_types(
     ::Type{<:BinPackingToMILPBridge},
 )
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.ZeroOne,)]
 end
 
 function MOI.Bridges.added_constraint_types(
-    ::Type{BinPackingToMILPBridge{T,F}},
-) where {T,F}
+    ::Type{<:BinPackingToMILPBridge{T}},
+) where {T}
     return Tuple{Type,Type}[
-        (MOI.VariableIndex, MOI.ZeroOne),
         (MOI.ScalarAffineFunction{T}, MOI.EqualTo{T}),
         (MOI.ScalarAffineFunction{T}, MOI.LessThan{T}),
     ]
@@ -129,7 +94,7 @@ function concrete_bridge_type(
     ::Type{<:BinPackingToMILPBridge{T}},
     ::Type{F},
     ::Type{MOI.BinPacking{T}},
-) where {T,F<:MOI.AbstractVectorFunction}
+) where {T,F<:Union{MOI.VectorOfVariables,MOI.VectorAffineFunction{T}}}
     return BinPackingToMILPBridge{T,F}
 end
 
@@ -150,26 +115,28 @@ function MOI.get(
 end
 
 function MOI.delete(model::MOI.ModelLike, bridge::BinPackingToMILPBridge)
-    MOI.delete(model, bridge.capacities)
-    MOI.delete(model, bridge.unities)
-    MOI.delete(model, bridge.assignment)
-    MOI.delete.(model, bridge.z)
+    MOI.delete.(model, bridge.less_than)
+    empty!(bridge.less_than)
+    MOI.delete.(model, bridge.equal_to)
+    empty!(bridge.equal_to)
+    MOI.delete.(model, bridge.variables)
+    empty!(bridge.variables)
     return
 end
 
 function MOI.get(bridge::BinPackingToMILPBridge, ::MOI.NumberOfVariables)::Int64
-    return length(bridge.z)
+    return length(bridge.variables)
 end
 
 function MOI.get(bridge::BinPackingToMILPBridge, ::MOI.ListOfVariableIndices)
-    return [bridge.z[i] for i in eachindex(bridge.z)]
+    return copy(bridge.variables)
 end
 
 function MOI.get(
     bridge::BinPackingToMILPBridge,
     ::MOI.NumberOfConstraints{MOI.VariableIndex,MOI.ZeroOne},
 )::Int64
-    return length(bridge.z)
+    return length(bridge.variables)
 end
 
 function MOI.get(
@@ -177,8 +144,8 @@ function MOI.get(
     ::MOI.ListOfConstraintIndices{MOI.VariableIndex,MOI.ZeroOne},
 )
     return [
-        MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(z.value) for
-        z in bridge.z
+        MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}.(z.value) for
+        z in bridge.variables
     ]
 end
 
@@ -186,26 +153,125 @@ function MOI.get(
     bridge::BinPackingToMILPBridge{T},
     ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
 )::Int64 where {T}
-    return length(bridge.unities) + length(bridge.assignment)
+    return length(bridge.equal_to)
 end
 
 function MOI.get(
     bridge::BinPackingToMILPBridge{T},
     ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
 ) where {T}
-    return vcat(bridge.unities, bridge.assignment)
+    return copy(bridge.equal_to)
 end
 
 function MOI.get(
     bridge::BinPackingToMILPBridge{T},
     ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.LessThan{T}},
 )::Int64 where {T}
-    return length(bridge.capacities)
+    return length(bridge.less_than)
 end
 
 function MOI.get(
     bridge::BinPackingToMILPBridge{T},
     ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T},MOI.LessThan{T}},
 ) where {T}
-    return copy(bridge.capacities)
+    return copy(bridge.less_than)
 end
+
+MOI.Bridges.needs_final_touch(::BinPackingToMILPBridge) = true
+
+# We use the bridge as the first argument to avoid type piracy of other methods.
+function _get_bounds(
+    bridge::BinPackingToMILPBridge{T},
+    model::MOI.ModelLike,
+    bounds::Dict{MOI.VariableIndex,NTuple{2,T}},
+    f::MOI.ScalarAffineFunction{T},
+) where {T}
+    lb = ub = f.constant
+    for term in f.terms
+        ret = _get_bounds(bridge, model, bounds, term.variable)
+        if ret === nothing
+            return nothing
+        end
+        lb += term.coefficient * ret[1]
+        ub += term.coefficient * ret[2]
+    end
+    return lb, ub
+end
+
+# We use the bridge as the first argument to avoid type piracy of other methods.
+function _get_bounds(
+    ::BinPackingToMILPBridge{T},
+    model::MOI.ModelLike,
+    bounds::Dict{MOI.VariableIndex,NTuple{2,T}},
+    x::MOI.VariableIndex,
+) where {T}
+    if haskey(bounds, x)
+        return bounds[x]
+    end
+    ret = MOI.Utilities.get_bounds(model, T, x)
+    if ret == (typemin(T), typemax(T))
+        return nothing
+    end
+    bounds[x] = ret
+    return ret
+end
+
+function MOI.Bridges.final_touch(
+    bridge::BinPackingToMILPBridge{T,F},
+    model::MOI.ModelLike,
+) where {T,F}
+    # Clear any existing reformulations!
+    MOI.delete(model, bridge)
+    S = Dict{T,Vector{Tuple{Float64,MOI.VariableIndex}}}()
+    scalars = collect(MOI.Utilities.eachscalar(bridge.f))
+    bounds = Dict{MOI.VariableIndex,NTuple{2,T}}()
+    for i in 1:length(scalars)
+        x = scalars[i]
+        ret = _get_bounds(bridge, model, bounds, x)
+        if ret === nothing
+            error(
+                "Unable to use CountDistinctToMILPBridge because element $i " *
+                "in the function has a non-finite domain: $x",
+            )
+        end
+        unit_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
+        convex_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
+        for xi in ret[1]::T:ret[2]::T
+            new_var, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+            push!(bridge.variables, new_var)
+            if !haskey(S, xi)
+                S[xi] = Tuple{Float64,MOI.VariableIndex}[]
+            end
+            push!(S[xi], (bridge.s.weights[i], new_var))
+            push!(unit_f.terms, MOI.ScalarAffineTerm(T(-xi), new_var))
+            push!(convex_f.terms, MOI.ScalarAffineTerm(one(T), new_var))
+        end
+        push!(
+            bridge.equal_to,
+            MOI.Utilities.normalize_and_add_constraint(
+                model,
+                MOI.Utilities.operate(+, T, x, unit_f),
+                MOI.EqualTo(zero(T));
+                allow_modify_function = true,
+            ),
+        )
+        push!(
+            bridge.equal_to,
+            MOI.add_constraint(model, convex_f, MOI.EqualTo(one(T))),
+        )
+    end
+    # We use a sort so that the model order is deterministic.
+    for s in sort!(collect(keys(S)))
+        ci = MOI.add_constraint(
+            model,
+            MOI.ScalarAffineFunction(
+                [MOI.ScalarAffineTerm(w, z) for (w, z) in S[s]],
+                zero(T),
+            ),
+            MOI.LessThan(bridge.s.capacity),
+        )
+        push!(bridge.less_than, ci)
+    end
+    return
+end
+

--- a/src/Bridges/Constraint/bridges/bin_packing.jl
+++ b/src/Bridges/Constraint/bridges/bin_packing.jl
@@ -230,8 +230,8 @@ function MOI.Bridges.final_touch(
         ret = _get_bounds(bridge, model, bounds, x)
         if ret === nothing
             error(
-                "Unable to use CountDistinctToMILPBridge because element $i " *
-                "in the function has a non-finite domain: $x",
+                "Unable to use $(typeof(bridge)) because an element in the " *
+                "function has a non-finite domain: $x",
             )
         end
         unit_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
@@ -274,4 +274,3 @@ function MOI.Bridges.final_touch(
     end
     return
 end
-

--- a/test/Bridges/Constraint/bin_packing.jl
+++ b/test/Bridges/Constraint/bin_packing.jl
@@ -102,10 +102,8 @@ function test_runtests_error_variable()
     x = MOI.add_variables(model, 3)
     f = MOI.VectorOfVariables(x)
     MOI.add_constraint(model, f, MOI.BinPacking(3, [1, 2, 3]))
-    BT = MOI.Bridges.Constraint.BinPackingToMILPBridge{
-        Int,
-        MOI.VectorOfVariables,
-    }
+    BT =
+        MOI.Bridges.Constraint.BinPackingToMILPBridge{Int,MOI.VectorOfVariables}
     @test_throws(
         ErrorException(
             "Unable to use $BT because an element in the " *

--- a/test/Bridges/Constraint/bin_packing.jl
+++ b/test/Bridges/Constraint/bin_packing.jl
@@ -22,33 +22,75 @@ function runtests()
     return
 end
 
-function test_runtests()
+function test_runtests_VectorOfVariables()
     MOI.Bridges.runtests(
         MOI.Bridges.Constraint.BinPackingToMILPBridge,
         """
         variables: x, y, z
-        [x, y, z] in BinPacking(3.0, [1.0, 2.0, 3.0])
+        [x, y, z] in BinPacking(3.0, [1.1, 1.9, 2.8])
+        x in Interval(1.0, 3.0)
+        y >= 2.0
+        y <= 3.0
+        z == 3.0
         """,
         """
-        variables: x, y, z, a11, a12, a13, a21, a22, a23, a31, a32, a33
-        1.0 * a11 + 2.0 * a12 + 3.0 * a13 <= 3.0
-        1.0 * a21 + 2.0 * a22 + 3.0 * a23 <= 3.0
-        1.0 * a31 + 2.0 * a32 + 3.0 * a33 <= 3.0
-        a11 + a21 + a31 == 1.0
-        a12 + a22 + a32 == 1.0
-        a13 + a23 + a33 == 1.0
-        1.0 * a11 + 2.0 * a21 + 3.0 * a31 + -1.0 * x == 0.0
-        1.0 * a12 + 2.0 * a22 + 3.0 * a32 + -1.0 * y == 0.0
-        1.0 * a13 + 2.0 * a23 + 3.0 * a33 + -1.0 * z == 0.0
-        a11 in ZeroOne()
-        a12 in ZeroOne()
-        a13 in ZeroOne()
-        a21 in ZeroOne()
-        a22 in ZeroOne()
-        a23 in ZeroOne()
-        a31 in ZeroOne()
-        a32 in ZeroOne()
-        a33 in ZeroOne()
+        variables: x, y, z, x1, x2, x3, y2, y3, z3
+        1.1 * x1 <= 3.0
+        1.1 * x2 + 1.9 * y2 <= 3.0
+        1.1 * x3 + 1.9 * y3 + 2.8 * z3 <= 3.0
+        1.0 * x + -1.0 * x1 + -2.0 * x2 + -3.0 * x3 == 0.0
+        1.0 * y + -2.0 * y2 + -3.0 * y3 == 0.0
+        1.0 * z + -3.0 * z3 == 0.0
+        1.0 * x1 + 1.0 * x2 + 1.0 * x3 == 1.0
+        1.0 * y2 + 1.0 * y3 == 1.0
+        1.0 * z3 == 1.0
+        x1 in ZeroOne()
+        x2 in ZeroOne()
+        x3 in ZeroOne()
+        y2 in ZeroOne()
+        y3 in ZeroOne()
+        z3 in ZeroOne()
+        x in Interval(1.0, 3.0)
+        y >= 2.0
+        y <= 3.0
+        z == 3.0
+        """,
+    )
+    return
+end
+
+function test_runtests_VectorAffineFunction()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.BinPackingToMILPBridge,
+        """
+        variables: x, y, z
+        [1.0 * x + 1.0, 1.0 * y, z] in BinPacking(3.0, [1.1, 1.9, 2.8])
+        x in Interval(1.0, 3.0)
+        y >= 2.0
+        y <= 3.0
+        z == 3.0
+        """,
+        """
+        variables: x, y, z, x2, x3, x4, y2, y3, z3
+        1.1 * x2 + 1.9 * y2 <= 3.0
+        1.1 * x3 + 1.9 * y3 + 2.8 * z3 <= 3.0
+        1.1 * x4 <= 3.0
+        1.0 * x + -2.0 * x2 + -3.0 * x3 + -4.0 * x4 == -1.0
+        1.0 * y + -2.0 * y2 + -3.0 * y3 == 0.0
+        1.0 * z + -3.0 * z3 == 0.0
+        1.0 * x2 + 1.0 * x3 + 1.0 * x4 == 1.0
+        1.0 * y2 + 1.0 * y3 == 1.0
+        1.0 * z3 == 1.0
+        x2 in ZeroOne()
+        x3 in ZeroOne()
+        x4 in ZeroOne()
+        y2 in ZeroOne()
+        y3 in ZeroOne()
+        z3 in ZeroOne()
+        x in Interval(1.0, 3.0)
+        y >= 2.0
+        y <= 3.0
+        z == 3.0
         """,
     )
     return


### PR DESCRIPTION
This PR update the `BinPackingToMILPBridge` to use `final_touch` and the actual bounds of the variables.