### PR TITLE
[Bridges] remove reduce_bridged in favor of explicit methods

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -743,7 +743,7 @@ function MOI.get(
     # If constraint bridged, get the indices from the constraint bridges.
     if is_bridged(b, F, S) ||
        (is_variable_function && supports_constraint_bridges(b))
-       num += Constraint.number_of_type(
+        num += Constraint.number_of_type(
             Constraint.bridges(b),
             MOI.ConstraintIndex{F,S},
         )


### PR DESCRIPTION
Chipping away at #1504, and the complications are largely limited to `bridge_optimizer.jl`. This `reduce_bridged` method confuses me everything I read it, because it uses too many magic anonymous function calls.