### PR TITLE
[Bridges] remove unused ObjectiveAttribute

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -144,9 +144,6 @@ function is_bridged(b::AbstractBridgeOptimizer, attr::MOI.ObjectiveFunction)
     return haskey(Objective.bridges(b), attr)
 end
 
-const ObjectiveAttribute =
-    Union{MOI.ObjectiveSense,MOI.ObjectiveFunction,MOI.ObjectiveFunctionType}
-
 """
     supports_bridging_constrained_variable(
         ::AbstractBridgeOptimizer,


### PR DESCRIPTION
Added here: https://github.com/jump-dev/MathOptInterface.jl/commit/703a3ce000407b2ef14b69762bbc2f36b560586b#diff-981d3b9e81384ac450930a71b03861f26b60ba3f6435942ae7d965037106f2edR77
but seem to have never been used.