### PR TITLE
Update PSDSquare_3 test after bridge change

### DIFF
--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -5640,7 +5640,7 @@ function _test_conic_PositiveSemidefiniteCone_helper_3(
                 @assert psdcone == MOI.PositiveSemidefiniteConeSquare
                 @test ≈(
                     MOI.get(model, MOI.ConstraintDual(), c),
-                    T[1, 0, 0, -1, 1, 0, -1, -1, 1] / T(3),
+                    T[1, -1/2, -1/2, -1/2, 1, -1/2, -1/2, -1/2, 1] / T(3),
                     config,
                 )
             end
@@ -5714,7 +5714,7 @@ function setup_test(
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             ones(T, 1),
-            (MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeSquare) => [T[1, 0, 0, -1, 1, 0, -1, -1, 1] / 3],
+            (MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeSquare) => [T[1, -1/2, -1/2, -1/2, 1, -1/2, -1/2, -1/2, 1] / 3],
         ),
     )
     return


### PR DESCRIPTION
Needed after https://github.com/jump-dev/MathOptInterface.jl/pull/1839
All SDP solvers are currently failing this test, see e.g., https://github.com/jump-dev/SDPA.jl/runs/7246518765?check_suite_focus=true#step:6:128