### PR TITLE
[Utilities] add support for non-Float64 number types in loadfromstring

### DIFF
--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -389,8 +389,8 @@ _split_type(ex) = Float64, ex
 function _split_type(ex::Expr)
     if isexpr(ex, Symbol("::"), 1)
         return Core.eval(Base, ex.args[1]), Symbol("")
-    elseif isexpr(ex, Symbol("::"), 2)
+    else
+        @assert isexpr(ex, Symbol("::"), 2)
         return Core.eval(Base, ex.args[2]), ex.args[1]
     end
-    return Float64, ex
 end

--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -388,7 +388,7 @@ _split_type(ex) = Float64, ex
 function _split_type(ex::Expr)
     if isexpr(ex, Symbol("::"), 1)
         return Core.eval(Base, ex.args[1]), Symbol("")
-    else isexpr(ex, Symbol("::"), 2)
+    elseif isexpr(ex, Symbol("::"), 2)
         return Core.eval(Base, ex.args[2]), ex.args[1]
     end
     return Float64, ex

--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -70,30 +70,31 @@ function _parse_function(ex, ::Type{T} = Float64) where {T}
             quadratic_terms = _ParsedVectorQuadraticTerm{T}[]
             constant = T[]
             for (outindex, f) in enumerate(singlefunctions)
+                outindex = Int64(outindex)
                 if isa(f, _ParsedVariableIndex)
                     push!(
                         affine_terms,
-                        _ParsedVectorAffineTerm(
+                        _ParsedVectorAffineTerm{T}(
                             outindex,
-                            _ParsedScalarAffineTerm(one(T), f.variable),
+                            _ParsedScalarAffineTerm{T}(one(T), f.variable),
                         ),
                     )
                     push!(constant, zero(T))
                 elseif isa(f, _ParsedScalarAffineFunction{T})
                     append!(
                         affine_terms,
-                        _ParsedVectorAffineTerm.(outindex, f.terms),
+                        _ParsedVectorAffineTerm{T}.(outindex, f.terms),
                     )
                     push!(constant, f.constant)
                 else
                     @assert isa(f, _ParsedScalarQuadraticFunction{T})
                     append!(
                         affine_terms,
-                        _ParsedVectorAffineTerm.(outindex, f.affine_terms),
+                        _ParsedVectorAffineTerm{T}.(outindex, f.affine_terms),
                     )
                     append!(
                         quadratic_terms,
-                        _ParsedVectorQuadraticTerm.(
+                        _ParsedVectorQuadraticTerm{T}.(
                             outindex,
                             f.quadratic_terms,
                         ),
@@ -102,9 +103,9 @@ function _parse_function(ex, ::Type{T} = Float64) where {T}
                 end
             end
             if length(quadratic_terms) == 0
-                return _ParsedVectorAffineFunction(affine_terms, constant)
+                return _ParsedVectorAffineFunction{T}(affine_terms, constant)
             else
-                return _ParsedVectorQuadraticFunction(
+                return _ParsedVectorQuadraticFunction{T}(
                     quadratic_terms,
                     affine_terms,
                     constant,
@@ -172,16 +173,16 @@ function _parse_function(ex, ::Type{T} = Float64) where {T}
                     )
                 end
             elseif isa(subex, Symbol)
-                push!(affine_terms, _ParsedScalarAffineTerm(one(T), subex))
+                push!(affine_terms, _ParsedScalarAffineTerm{T}(one(T), subex))
             else
                 @assert isa(subex, Number)
                 constant += subex
             end
         end
         if length(quadratic_terms) == 0
-            return _ParsedScalarAffineFunction(affine_terms, constant)
+            return _ParsedScalarAffineFunction{T}(affine_terms, constant)
         else
-            return _ParsedScalarQuadraticFunction(
+            return _ParsedScalarQuadraticFunction{T}(
                 quadratic_terms,
                 affine_terms,
                 constant,

--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -94,7 +94,7 @@ function _parse_function(ex, ::Type{T} = Float64) where {T}
                     )
                     append!(
                         quadratic_terms,
-                        _ParsedVectorQuadraticTerm{T}.(
+                        _ParsedVectorQuadraticTerm.(
                             outindex,
                             f.quadratic_terms,
                         ),

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -323,6 +323,61 @@ function test_constrained_variables()
     return
 end
 
+function test_eltypes_int()
+    model = MOI.Utilities.Model{Int}()
+    text = """
+    variables: x, y
+    ::Int: x >= 1
+    c::Int: 2 * x <= 3
+    d::Int: [x, 4 * y] in Zeros(2)
+    e::Int: [2 * x * x] in Nonnegatives(1)
+    """
+    MOI.Utilities.loadfromstring!(model, text)
+    c = MOI.get(model, MOI.ConstraintIndex, "c")
+    @test isa(
+        MOI.get(model, MOI.ConstraintFunction(), c),
+        MOI.ScalarAffineFunction{Int},
+    )
+    d = MOI.get(model, MOI.ConstraintIndex, "d")
+    @test isa(
+        MOI.get(model, MOI.ConstraintFunction(), d),
+        MOI.VectorAffineFunction{Int},
+    )
+    e = MOI.get(model, MOI.ConstraintIndex, "e")
+    @test isa(
+        MOI.get(model, MOI.ConstraintFunction(), e),
+        MOI.VectorQuadraticFunction{Int},
+    )
+    return
+end
+
+function test_eltypes_rational_int()
+    model = MOI.Utilities.Model{Rational{Int}}()
+    text = """
+    variables: x, y
+    c::Rational{Int}: 2 // 1 * x <= 1 // 3
+    d::Rational{Int}: [x, 4 // 2 * y] in Zeros(2)
+    e::Rational{Int}: [2 // 2 * x * x] in Nonnegatives(1)
+    """
+    MOI.Utilities.loadfromstring!(model, text)
+    c = MOI.get(model, MOI.ConstraintIndex, "c")
+    @test isa(
+        MOI.get(model, MOI.ConstraintFunction(), c),
+        MOI.ScalarAffineFunction{Rational{Int}},
+    )
+    d = MOI.get(model, MOI.ConstraintIndex, "d")
+    @test isa(
+        MOI.get(model, MOI.ConstraintFunction(), d),
+        MOI.VectorAffineFunction{Rational{Int}},
+    )
+    e = MOI.get(model, MOI.ConstraintIndex, "e")
+    @test isa(
+        MOI.get(model, MOI.ConstraintFunction(), e),
+        MOI.VectorQuadraticFunction{Rational{Int}},
+    )
+    return
+end
+
 end  # module
 
 TestParser.runtests()

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -378,6 +378,28 @@ function test_eltypes_rational_int()
     return
 end
 
+function test_eltypes_complex_float64()
+    # Work-around for https://github.com/jump-dev/MathOptInterface.jl/issues/1947
+    model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    text = """
+    variables: x
+    c::Complex{Float64}: (2.0 + 1im) * x == 0.0 + 0.0im
+    """
+    MOI.Utilities.loadfromstring!(model, text)
+    x = MOI.get(model, MOI.VariableIndex, "x")
+    c = MOI.get(model, MOI.ConstraintIndex, "c")
+    f = MOI.get(model, MOI.ConstraintFunction(), c)
+    @test f isa MOI.ScalarAffineFunction{Complex{Float64}}
+    @test isapprox(
+        MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(2.0 + 1.0im, x)],
+            0.0 + 0.0im,
+        ),
+        f,
+    )
+    return
+end
+
 end  # module
 
 TestParser.runtests()

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -72,7 +72,7 @@ function test__parse_function()
         MOIU._parse_function(:([x, 2x + y + 5.0])),
         MOIU._ParsedVectorAffineFunction(
             MOIU._ParsedVectorAffineTerm.(
-                [1, 2, 2],
+                Int64[1, 2, 2],
                 MOIU._ParsedScalarAffineTerm.([1.0, 2.0, 1.0], [:x, :x, :y]),
             ),
             [0.0, 5.0],
@@ -82,11 +82,11 @@ function test__parse_function()
         MOIU._parse_function(:([x, 2x + y + 5.0, 1 * x * x])),
         MOIU._ParsedVectorQuadraticFunction(
             MOIU._ParsedVectorQuadraticTerm.(
-                [3],
+                Int64[3],
                 MOIU._ParsedScalarQuadraticTerm.([2.0], [:x], [:x]),
             ),
             MOIU._ParsedVectorAffineTerm.(
-                [1, 2, 2],
+                Int64[1, 2, 2],
                 MOIU._ParsedScalarAffineTerm.([1.0, 2.0, 1.0], [:x, :x, :y]),
             ),
             [0.0, 5.0, 0.0],


### PR DESCRIPTION
Part of #1945

Complex number support still not working. Debugging a problem in `Model` for some reason.