### PR TITLE
Add missing promotion rules

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -3207,7 +3207,7 @@ function Base.promote_rule(
 end
 
 function Base.promote_rule(
-    F::Type{<:Union{MOI.ScalarAffineFunction,MOI.ScalarQuadraticFunction},
+    F::Type{<:Union{MOI.ScalarAffineFunction,MOI.ScalarQuadraticFunction}},
     ::Type{MOI.VariableIndex},
 )
     return F

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -3206,6 +3206,13 @@ function Base.promote_rule(
     return F
 end
 
+function Base.promote_rule(
+    F::Type{<:Union{MOI.ScalarAffineFunction,MOI.ScalarQuadraticFunction},
+    ::Type{MOI.VariableIndex},
+)
+    return F
+end
+
 function operate_coefficient(f, term::MOI.ScalarAffineTerm)
     return MOI.ScalarAffineTerm(f(term.coefficient), term.variable)
 end

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -167,6 +167,11 @@ function test_promote_operation_Quadratic()
         MOI.VariableIndex,
         Int,
     ) == MOI.VectorQuadraticFunction{Int}
+    for T in (Float64, Int)
+        for TV in (MOI.ScalarAffineFunction{T}, MOI.ScalarQuadraticFunction{T})
+            @test promote_type(TV, MOI.VariableIndex) == TV
+        end
+    end
     return
 end
 


### PR DESCRIPTION
Just got bitten by this.
Before:
```
julia> T1 = eltype(variable_blocks)
MathOptInterface.VariableIndex

julia> T2 = eltype(1.0 * variable_blocks)
MathOptInterface.ScalarAffineFunction{Float64}

julia> promote_type(T1, T2)
MathOptInterface.AbstractScalarFunction
```

After:
```
julia> promote_type(T1, T2)
MathOptInterface.ScalarAffineFunction{Float64}
```