### PR TITLE
Prep for v1.7.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.6.0"
+version = "1.7.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## v1.7.0 (July 25, 2022)
+## v1.7.0 (July 23, 2022)
 
 For a detailed list of the closed issues and pull requests from this release,
 see the [tag notes](https://github.com/jump-dev/MathOptInterface.jl/releases/tag/v1.7.0).

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,5 +1,35 @@
 # Release notes
 
+## v1.7.0 (July 25, 2022)
+
+For a detailed list of the closed issues and pull requests from this release,
+see the [tag notes](https://github.com/jump-dev/MathOptInterface.jl/releases/tag/v1.7.0).
+
+### New features
+
+ - Added support for `ExponentialCone` in `MatrixOfConstraints`
+ - Added `SplitComplexZerosBridge` and `SplitComplexEqualToBridge` which bridges
+   complex-valued equality constraints into their real and imaginary parts
+ - Added support for generic nunmber types in `Utilities.loadfromstring!`
+ - Add new optimizer-independent options `RelativeGapTolerance` and
+   `AbsoluteGapTolerance`
+ - Updated `FileFormats.MOF` to MathOptFormat v1.1, enabling support for
+   constraint programming sets in the `MOF` file format
+ - Added support for quadratic constraints and an objective to `FileFormats.MPS`
+ - Added support for indicator constraints to `FileFormats.MPS`
+
+### Bug fixes
+
+ - Fix `PSDSquare_3` test to reflect a previously fixed bug getting the
+   `ConstraintDual` of a `PositiveSemidefiniteConeSquare` constraint
+ - Fixed some missing promotion rules
+
+### Performance and maintenance
+
+ - Improved the performance of Jacobian products in `Nonlinear`
+ - Removed an un-needed `copy` in `Utilities.modify_function`
+ - Various clean-ups in `Bridges/bridge_optimizer.jl`
+
 ## v1.6.0 (July 2, 2022)
 
 For a detailed list of the closed issues and pull requests from this release,


### PR DESCRIPTION
Lots of new stuff for ComplexOptInterface that would be good to get out before JuMP-dev.

Closes https://github.com/jump-dev/MathOptInterface.jl/pull/1963