### PR TITLE
Prep for v1.6.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -5640,7 +5640,7 @@ function _test_conic_PositiveSemidefiniteCone_helper_3(
                 @assert psdcone == MOI.PositiveSemidefiniteConeSquare
                 @test ≈(
                     MOI.get(model, MOI.ConstraintDual(), c),
-                    T[1, 0, 0, -1, 1, 0, -1, -1, 1] / T(3),
+                    T[1, -1/2, -1/2, -1/2, 1, -1/2, -1/2, -1/2, 1] / T(3),
                     config,
                 )
             end
@@ -5714,7 +5714,7 @@ function setup_test(
         (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
             mock,
             ones(T, 1),
-            (MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeSquare) => [T[1, 0, 0, -1, 1, 0, -1, -1, 1] / 3],
+            (MOI.VectorAffineFunction{T}, MOI.PositiveSemidefiniteConeSquare) => [T[1, -1/2, -1/2, -1/2, 1, -1/2, -1/2, -1/2, 1] / 3],
         ),
     )
     return

--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -594,6 +594,16 @@ function set_with_dimension(::Type{MOI.RootDetConeSquare}, dim)
     return MOI.RootDetConeSquare(isqrt(dim - 1))
 end
 
+function set_with_dimension(::Type{MOI.ExponentialCone}, dim)
+    @assert dim == 3
+    return MOI.ExponentialCone()
+end
+
+function set_with_dimension(::Type{MOI.DualExponentialCone}, dim)
+    @assert dim == 3
+    return MOI.DualExponentialCone()
+end
+
 function set_from_constants(::Vector, ::Type{S}, rows) where {S}
     return set_with_dimension(S, length(rows))
 end

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -603,6 +603,15 @@ function test_duplicate()
     return
 end
 
+function test_set_with_dimension()
+    for S in (MOI.ExponentialCone, MOI.DualExponentialCone)
+        @test MOI.Utilities.set_with_dimension(S, 3) == S()
+        @test_throws AssertionError MOI.Utilities.set_with_dimension(S, 2)
+        @test_throws AssertionError MOI.Utilities.set_with_dimension(S, 4)
+    end
+    return
+end
+
 end
 
 TestMatrixOfConstraints.runtests()


### PR DESCRIPTION
This includes two bug fixes that would be nice to have to the ICCOPT workshop tomorrow so that v1.7 can wait for https://github.com/jump-dev/MathOptInterface.jl/pull/1962