### PR TITLE
Clarify assumption for SOC bridge

### DIFF
--- a/src/Bridges/Constraint/bridges/soc_rsoc.jl
+++ b/src/Bridges/Constraint/bridges/soc_rsoc.jl
@@ -13,7 +13,7 @@
 
 ## Assumptions
 
-  * `SOCtoRSOCBridge` assumes that the dimension of the cone is at least one.
+  * `SOCtoRSOCBridge` assumes that the length of `x` is at least one.
 
 ## Source node
 

--- a/src/Bridges/Constraint/bridges/soc_rsoc.jl
+++ b/src/Bridges/Constraint/bridges/soc_rsoc.jl
@@ -13,7 +13,7 @@
 
 ## Assumptions
 
-  * `SOCtoRSOCBridge` assumes that ``|x| \\ge 1``.
+  * `SOCtoRSOCBridge` assumes that the dimension of the cone is at least one.
 
 ## Source node
 


### PR DESCRIPTION
I was a bit confused by `|x|`, I was wondering what was the absolute value of a vector. I agree it's a common notation for the cardinality of set but here I didn't think about it since it's not a set.