### PR TITLE
[Bridges] add Objective.Quadratize bridge

### DIFF
--- a/docs/src/submodules/Bridges/list_of_bridges.md
+++ b/docs/src/submodules/Bridges/list_of_bridges.md
@@ -71,6 +71,7 @@ These bridges are subtyptes of [`Bridges.Objective.AbstractBridge`](@ref).
 
 ```@docs
 Bridges.Objective.FunctionizeBridge
+Bridges.Objective.QuadratizeBridge
 Bridges.Objective.SlackBridge
 ```
 

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -340,6 +340,9 @@ function _general_bridge_tests(bridge::B) where {B<:AbstractBridge}
         length(MOI.get(bridge, MOI.ListOfVariableIndices())) ==
         MOI.get(bridge, MOI.NumberOfVariables())
     )
+    if B <: Objective.AbstractBridge
+        Test.@test set_objective_function_type(B) <: MOI.AbstractScalarFunction
+    end
     return
 end
 

--- a/src/Bridges/Objective/Objective.jl
+++ b/src/Bridges/Objective/Objective.jl
@@ -15,6 +15,7 @@ include("map.jl")
 include("single_bridge_optimizer.jl")
 
 include("bridges/functionize.jl")
+include("bridges/quadratize.jl")
 include("bridges/slack.jl")
 
 """
@@ -26,6 +27,7 @@ The coefficient type used is `T`.
 """
 function add_all_bridges(model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(model, FunctionizeBridge{T})
+    MOI.Bridges.add_bridge(model, QuadratizeBridge{T})
     MOI.Bridges.add_bridge(model, SlackBridge{T})
     return
 end

--- a/src/Bridges/Objective/bridges/quadratize.jl
+++ b/src/Bridges/Objective/bridges/quadratize.jl
@@ -1,0 +1,100 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+"""
+    QuadratizeBridge{T}
+
+`QuadratizeBridge` implements the following reformulations:
+
+ * ``\\min \\{a^\\top x + b\\}`` into ``\\min\\{x^\\top \\mathbf{0} x + a^\\top x + b\\}``
+ * ``\\max \\{a^\\top x + b\\}`` into ``\\max\\{x^\\top \\mathbf{0} x + a^\\top x + b\\}``
+
+where `T` is the coefficient type of `0`.
+
+## Source node
+
+`QuadratizeBridge` supports:
+
+ * [`MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}`](@ref)
+
+## Target nodes
+
+`QuadratizeBridge` creates:
+
+ * One objective node: [`MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{T}}`](@ref)
+"""
+struct QuadratizeBridge{T} <: AbstractBridge end
+
+const Quadratize{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{QuadratizeBridge{T},OT}
+
+function bridge_objective(
+    ::Type{QuadratizeBridge{T}},
+    model::MOI.ModelLike,
+    func::MOI.ScalarAffineFunction{T},
+) where {T}
+    f = convert(MOI.ScalarQuadraticFunction{T}, func)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    return QuadratizeBridge{T}()
+end
+
+function supports_objective_function(
+    ::Type{<:QuadratizeBridge{T}},
+    ::Type{MOI.ScalarAffineFunction{T}},
+) where {T}
+    return true
+end
+
+function MOI.Bridges.added_constrained_variable_types(
+    ::Type{<:QuadratizeBridge},
+)
+    return Tuple{Type}[]
+end
+
+function MOI.Bridges.added_constraint_types(::Type{<:QuadratizeBridge})
+    return Tuple{Type,Type}[]
+end
+
+function MOI.Bridges.set_objective_function_type(
+    ::Type{QuadratizeBridge{T}},
+) where {T}
+    return MOI.ScalarQuadraticFunction{T}
+end
+
+# No variables or constraints are created in this bridge so there is nothing to
+# delete.
+MOI.delete(::MOI.ModelLike, ::QuadratizeBridge) = nothing
+
+function MOI.set(
+    ::MOI.ModelLike,
+    ::MOI.ObjectiveSense,
+    ::QuadratizeBridge,
+    ::MOI.OptimizationSense,
+)
+    # `QuadratizeBridge` is sense agnostic, therefore, we don't need to change
+    # anything.
+    return
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::MOI.Bridges.ObjectiveFunctionValue{MOI.ScalarAffineFunction{T}},
+    ::QuadratizeBridge{T},
+) where {T}
+    F = MOI.ScalarQuadraticFunction{T}
+    attr_f = MOI.Bridges.ObjectiveFunctionValue{F}(attr.result_index)
+    return MOI.get(model, attr_f)
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}},
+    ::QuadratizeBridge{T},
+) where {T}
+    F = MOI.ScalarQuadraticFunction{T}
+    func = MOI.get(model, MOI.ObjectiveFunction{F}())
+    return convert(MOI.ScalarAffineFunction{T}, func)
+end

--- a/test/Bridges/Objective/quadratize.jl
+++ b/test/Bridges/Objective/quadratize.jl
@@ -1,0 +1,107 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestObjectiveQuadratize
+
+using Test
+
+using MathOptInterface
+const MOI = MathOptInterface
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+include("../utilities.jl")
+
+function test_solve_singlevariable_obj()
+    mock = MOI.Utilities.MockOptimizer(MOI.Utilities.Model{Float64}())
+    model = MOI.Bridges.Objective.Quadratize{Float64}(mock)
+    MOI.Utilities.set_mock_optimize!(
+        mock,
+        (mock::MOI.Utilities.MockOptimizer) ->
+            MOI.Utilities.mock_optimize!(mock, [1.0], MOI.FEASIBLE_POINT),
+    )
+    MOI.Test.test_objective_ObjectiveFunction_duplicate_terms(
+        model,
+        MOI.Test.Config(),
+    )
+    @test MOI.get(mock, MOI.ObjectiveFunctionType()) ==
+          MOI.ScalarQuadraticFunction{Float64}
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) ==
+          MOI.ScalarAffineFunction{Float64}
+    @test MOI.get(mock, MOI.ObjectiveSense()) == MOI.MIN_SENSE
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
+    vis = MOI.get(model, MOI.ListOfVariableIndices())
+    func = 3.0 * vis[1] + 0.0
+    @test MOI.get(
+        mock,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+    ) ≈ convert(MOI.ScalarQuadraticFunction{Float64}, func)
+    @test MOI.get(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+    ) ≈ func
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    @test MOI.get(mock, MOI.ObjectiveSense()) == MOI.MAX_SENSE
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
+    _test_delete_objective(model, 1, tuple())
+    return
+end
+
+function test_solve_result_index()
+    mock = MOI.Utilities.MockOptimizer(MOI.Utilities.Model{Float64}())
+    model = MOI.Bridges.Objective.Quadratize{Float64}(mock)
+    MOI.Utilities.set_mock_optimize!(
+        mock,
+        (mock::MOI.Utilities.MockOptimizer) -> MOI.Utilities.mock_optimize!(
+            mock,
+            MOI.OPTIMAL,
+            (MOI.FEASIBLE_POINT, [1.0]),
+            MOI.FEASIBLE_POINT,
+            (MOI.VariableIndex, MOI.GreaterThan{Float64}) => [1.0],
+        ),
+    )
+    MOI.Test.test_solve_result_index(model, MOI.Test.Config())
+    return
+end
+
+function test_runtests()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Objective.QuadratizeBridge,
+        """
+        variables: x
+        minobjective: 1.1 * x + 2.2
+        """,
+        """
+        variables: x
+        minobjective: 0.0 * x * x + 1.1 * x + 2.2
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Objective.QuadratizeBridge,
+        """
+        variables: x
+        maxobjective: 1.1 * x + 2.2
+        """,
+        """
+        variables: x
+        maxobjective: 0.0 * x * x + 1.1 * x + 2.2
+        """,
+    )
+    return
+end
+
+end  # module
+
+TestObjectiveQuadratize.runtests()


### PR DESCRIPTION
Closes #1978

This should simplify QP solvers and allow then to support only a quadratic objective.

There's a lot of double up with the `Functionize` bridge, but it was simpler to copy-paste than to extend the existing definition of `Functionize` to add new type parameters.