### PR TITLE
[Test] fix numerics of test_cpsat_CountGreaterThan

### DIFF
--- a/src/Test/test_cpsat.jl
+++ b/src/Test/test_cpsat.jl
@@ -207,6 +207,7 @@ function test_cpsat_CountGreaterThan(
     c, _ = MOI.add_constrained_variable(model, MOI.Integer())
     y, _ = MOI.add_constrained_variable(model, MOI.Integer())
     x = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
+    MOI.add_constraint(model, c, MOI.Interval(T(0), T(6)))
     MOI.add_constraint.(model, x, MOI.Interval(T(0), T(4)))
     MOI.add_constraint(model, y, MOI.Interval(T(0), T(4)))
     MOI.add_constraint(


### PR DESCRIPTION
SCIP was failing this test because the c variable was unbounded.
A trivial fix is to give it some finite bounds.

x-ref: https://github.com/scipopt/SCIP.jl/pull/239