### PR TITLE
[Nonlinear] lazily build ::Expr representaton of subexpressions

### DIFF
--- a/src/Nonlinear/evaluator.jl
+++ b/src/Nonlinear/evaluator.jl
@@ -65,26 +65,13 @@ end
 
 function MOI.initialize(evaluator::Evaluator, features::Vector{Symbol})
     empty!(evaluator.ordered_constraints)
-    empty!(evaluator.julia_expressions)
     evaluator.eval_objective_timer = 0.0
     evaluator.eval_objective_gradient_timer = 0.0
     evaluator.eval_constraint_timer = 0.0
     evaluator.eval_constraint_jacobian_timer = 0.0
     evaluator.eval_hessian_lagrangian_timer = 0.0
     append!(evaluator.ordered_constraints, keys(evaluator.model.constraints))
-    if :ExprGraph in features
-        for i in 1:length(evaluator.model.expressions)
-            push!(
-                evaluator.julia_expressions,
-                convert_to_expr(
-                    evaluator,
-                    evaluator.model.expressions[i];
-                    moi_output_format = true,
-                ),
-            )
-        end
-        filter!(f -> f != :ExprGraph, features)
-    end
+    filter!(f -> f != :ExprGraph, features)
     if evaluator.backend !== nothing
         MOI.initialize(evaluator.backend, features)
     end
@@ -270,7 +257,11 @@ function _convert_to_moi_format(evaluator::Evaluator, p::ParameterIndex)
 end
 
 function _convert_to_moi_format(evaluator::Evaluator, x::ExpressionIndex)
-    return evaluator.julia_expressions[x.value]
+    return convert_to_expr(
+        evaluator,
+        evaluator.model.expressions[x.value];
+        moi_output_format = true,
+    )
 end
 
 _convert_to_moi_format(::Evaluator, x) = x

--- a/src/Nonlinear/types.jl
+++ b/src/Nonlinear/types.jl
@@ -198,9 +198,6 @@ mutable struct Evaluator{B} <: MOI.AbstractNLPEvaluator
     model::Model
     # The abstract-differentiation backend
     backend::B
-    # A vector to store expressions in Julia's Expr form. The eltype is Any
-    # because expressions may be constants, and `:(1)` is just `1`.
-    julia_expressions::Vector{Any}
     # ordered_constraints is needed because `OrderedDict` doesn't support
     # looking up a key by the linear index.
     ordered_constraints::Vector{ConstraintIndex}
@@ -221,7 +218,6 @@ mutable struct Evaluator{B} <: MOI.AbstractNLPEvaluator
         return new{B}(
             model,
             backend,
-            Expr[],
             ConstraintIndex[],
             Float64[],
             0.0,


### PR DESCRIPTION
The main benefit of this is that modifying a parameter no longer
needs a call to initialize to reconstruct the expressions.

This fix is needed for https://github.com/jump-dev/JuMP.jl/pull/3018#issuecomment-1192049278.

x-ref https://github.com/jump-dev/JuMP.jl/issues/1185
x-ref https://github.com/jump-dev/Ipopt.jl/pull/321