### PR TITLE
[Test] allow NORM_LIMIT in unbounded tests

### DIFF
--- a/src/Test/test_linear.jl
+++ b/src/Test/test_linear.jl
@@ -1432,9 +1432,11 @@ function test_linear_DUAL_INFEASIBLE(
     if _supports(config, MOI.optimize!)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE ||
-              MOI.get(model, MOI.TerminationStatus()) ==
-              MOI.INFEASIBLE_OR_UNBOUNDED
+        status = MOI.get(model, MOI.TerminationStatus())
+        @test in(
+            status,
+            (MOI.DUAL_INFEASIBLE, MOI.NORM_LIMIT, MOI.INFEASIBLE_OR_UNBOUNDED),
+        )
         if MOI.get(model, MOI.PrimalStatus()) == MOI.INFEASIBILITY_CERTIFICATE
             # solver returned an unbounded ray
             @test MOI.get(model, MOI.ResultCount()) >= 1
@@ -1517,9 +1519,11 @@ function test_linear_DUAL_INFEASIBLE_2(
     if _supports(config, MOI.optimize!)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE ||
-              MOI.get(model, MOI.TerminationStatus()) ==
-              MOI.INFEASIBLE_OR_UNBOUNDED
+        status = MOI.get(model, MOI.TerminationStatus())
+        @test in(
+            status,
+            (MOI.DUAL_INFEASIBLE, MOI.NORM_LIMIT, MOI.INFEASIBLE_OR_UNBOUNDED),
+        )
         if MOI.get(model, MOI.PrimalStatus()) == MOI.INFEASIBILITY_CERTIFICATE
             # solver returned an unbounded ray
             @test MOI.get(model, MOI.ResultCount()) >= 1

--- a/src/Test/test_solve.jl
+++ b/src/Test/test_solve.jl
@@ -210,7 +210,11 @@ function test_solve_TerminationStatus_DUAL_INFEASIBLE(
     )
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.optimize!(model)
-    @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE
+    status = MOI.get(model, MOI.TerminationStatus())
+    @test in(
+        status,
+        (MOI.DUAL_INFEASIBLE, MOI.NORM_LIMIT, MOI.INFEASIBLE_OR_UNBOUNDED),
+    )
     return
 end
 


### PR DESCRIPTION
It's reasonable for some solvers to return `NORM_LIMIT` instead of `DUAL_INFEASIBLE` (Ipopt is one example). 

This would help meta-solvers like Pavito pass tests: https://github.com/jump-dev/Pavito.jl/pull/65