### PR TITLE
[Bridges] fix supports for VariableIndex: Take II

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1373,9 +1373,16 @@ function MOI.supports(
                 return MOI.supports(recursive_model(b), attr, bridge)
             end
         else
-            # If S doesn't need to be bridged, it either means that the solver
-            # supports add_constrained_variable, or it supports free variables
-            # and add_constraint. Either way, we can defer to the model.
+            # If S doesn't need to be bridged, it usually means that either the
+            # solver supports add_constrained_variable, or it supports free
+            # variables and add_constraint.
+            #
+            # In some cases, it might be that the solver supports
+            # add_constrained_variable, but ends up bridging add_constraint.
+            # Because MOI lacks the ability to tell which one was called based
+            # on the index type, asking the model might give a false negative
+            # (we support the attribute via add_constrained_variable, but the
+            # bridge doesn't via add_constraint because it will be bridged).
             return MOI.supports(b.model, attr, MOI.ConstraintIndex{F,S})
         end
     else

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -904,24 +904,16 @@ function test_Issue1992_supports_ConstraintDualStart_VariableIndex()
     # supports should be false
     model = MOI.Bridges.full_bridge_optimizer(_Issue1992(false), Float64)
     x, _ = MOI.add_constrained_variables(model, MOI.Nonpositives(1))
-    c2 = MOI.add_constraint(
-        model,
-        MOI.VectorOfVariables(x),
-        MOI.Nonnegatives(1),
-    )
-    @test !MOI.supports(model, MOI.ConstraintDualStart(), typeof(c2))
+    c = MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Nonnegatives(1))
+    @test !MOI.supports(model, MOI.ConstraintDualStart(), typeof(c))
     # supports should be true
     model = MOI.Bridges.full_bridge_optimizer(_Issue1992(true), Float64)
     x, _ = MOI.add_constrained_variables(model, MOI.Nonpositives(1))
-    c2 = MOI.add_constraint(
-        model,
-        MOI.VectorOfVariables(x),
-        MOI.Nonnegatives(1),
-    )
+    c = MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Nonnegatives(1))
     # !!! warning
     #     This test is broken with a false negative. See the discussion in
     #     PR#1992.
-    @test_broken MOI.supports(model, MOI.ConstraintDualStart(), typeof(c2))
+    @test_broken MOI.supports(model, MOI.ConstraintDualStart(), typeof(c))
     return
 end
 

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -847,11 +847,6 @@ function test_IssueIpopt333_supports_ConstraintDualStart_VariableIndex()
     return
 end
 
-"""
-This optimizer mimics SDPA, that is, an optimizer that does not support free
-variables. This can cause all sorts of problems, because it involves both
-variable and constraint bridges.
-"""
 mutable struct _Issue1992 <: MOI.AbstractOptimizer
     supports::Bool
     variables::Int

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -918,6 +918,26 @@ function test_Issue1992_supports_ConstraintDualStart_VariableIndex()
     return
 end
 
+function test_bridge_supports_issue_1992()
+    inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    model = MOI.Bridges.Variable.NonposToNonneg{Float64}(inner)
+    x = MOI.add_variable(model)
+    c = MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables([x]),
+        MOI.Nonpositives(1),
+    )
+    # !!! warning
+    #     This test is broken with a false negative. (Getting and setting the
+    #     attribute works, even though supports is false) See the discussion in
+    #     PR#1992.
+    @test_broken MOI.supports(model, MOI.ConstraintDualStart(), typeof(c))
+    @test MOI.get(model, MOI.ConstraintDualStart(), c) === nothing
+    MOI.set(model, MOI.ConstraintDualStart(), c, [1.0])
+    @test MOI.get(model, MOI.ConstraintDualStart(), c) == [1.0]
+    return
+end
+
 end  # module
 
 TestBridgeOptimizer.runtests()


### PR DESCRIPTION
A fix for the fix in https://github.com/jump-dev/MathOptInterface.jl/pull/1991.

This is actually a super subtle part of the bridging system, and we don't have good test coverage. I think I understand the space of possible outcomes, and I've tested with Ipopt, SCS, and SDPA etc.

So before merging:

 * [x] Add better tests