### PR TITLE
Prep for v1.8.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.8.1"
+version = "1.8.2"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -1,5 +1,16 @@
 # Release notes
 
+## v1.8.2 (September 20, 2022)
+
+For a detailed list of the closed issues and pull requests from this release,
+see the [tag notes](https://github.com/jump-dev/MathOptInterface.jl/releases/tag/v1.8.2).
+
+### Documentation
+
+ - Add vale as a documentation linter
+ - Improve styling of code blocks in the PDF
+ - Fix a number of typos in the documentation
+
 ## v1.8.1 (September 12, 2022)
 
 For a detailed list of the closed issues and pull requests from this release,


### PR DESCRIPTION
We need a release so that JuMP can build the updated docs: https://github.com/jump-dev/JuMP.jl/pull/3080