### PR TITLE
[FileFormats.MPS] fix reading of free rows

### DIFF
--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -1170,10 +1170,12 @@ function copy_to(model::Model, data::TempMPSModel)
     _add_objective(model, data, variable_map)
     for (j, c_name) in enumerate(data.row_to_name)
         set = bounds_to_set(data.row_lower[j], data.row_upper[j])
-        if set !== nothing
+        if set === nothing
+            free_set = MOI.Interval(-Inf, Inf)
+            _add_constraint(model, data, variable_map, j, c_name, free_set)
+        else
             _add_constraint(model, data, variable_map, j, c_name, set)
         end
-        # `else` is a free constraint. Don't add it.
     end
     for sos in data.sos_constraints
         MOI.add_constraint(

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -1313,11 +1313,11 @@ function parse_rows_line(data::TempMPSModel, items::Vector{String})
         error("Invalid row sense: $(join(items, " "))")
     end
     if sense == SENSE_N
-        if data.obj_name != ""
-            return name  # Detected a duplicate objective. Skip it.
+        if data.obj_name == ""
+            # The first N row is the objective
+            data.obj_name = name
+            return
         end
-        data.obj_name = name
-        return
     end
     if name == data.obj_name
         error("Found row with same name as objective: $(join(items, " ")).")
@@ -1335,10 +1335,13 @@ function parse_rows_line(data::TempMPSModel, items::Vector{String})
     elseif sense == SENSE_L
         push!(data.row_lower, -Inf)
         push!(data.row_upper, 0.0)
-    else
-        @assert sense == SENSE_E
+    elseif sense == SENSE_E
         push!(data.row_lower, 0.0)
         push!(data.row_upper, 0.0)
+    else
+        @assert sense == SENSE_N
+        push!(data.row_lower, -Inf)
+        push!(data.row_upper, Inf)
     end
     return
 end

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -137,6 +137,7 @@ function test_stacked_data()
         """
 variables: x, y, z
 maxobjective: x + y + z + 2.5
+blank_obj: 1.0 * x + 2.0 * y in Interval(-Inf, Inf)
 con1: 1.0 * x in Interval(1.0, 5.0)
 con2: 1.0 * x in Interval(2.0, 6.0)
 con3: 1.0 * x in Interval(3.0, 7.0)
@@ -151,7 +152,7 @@ z in ZeroOne()
         model,
         model_2,
         ["x", "y", "z"],
-        ["con1", "con2", "con3", "con4"],
+        ["blank_obj", "con1", "con2", "con3", "con4"],
         [
             ("y", MOI.Integer()),
             ("y", MOI.Interval{Float64}(1.0, 4.0)),


### PR DESCRIPTION
<s>Currently, these changes mean we can read the example from #2006 without erroring, but we don't actually add the free rows to the model. I guess we could/should with a `Interval(-Inf, Inf)` set, but free rows in a MILP are pretty poor form.</s> I added the free rows; they're in the file so we should respect the user.

Closes #2006