### PR TITLE
Revert "[Utilities] fix unsupported get in model.jl (#2008)"

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -416,10 +416,7 @@ end
 function MOI.get(
     model::AbstractModel,
     attr::MOI.NumberOfConstraints{MOI.VariableIndex,S},
-)::Int64 where {S}
-    if !MOI.supports_constraint(model, MOI.VariableIndex, S)
-        return 0
-    end
+) where {S}
     return MOI.get(model.variables, attr)
 end
 
@@ -444,9 +441,6 @@ function MOI.get(
     model::AbstractModel,
     attr::MOI.ListOfConstraintIndices{MOI.VariableIndex,S},
 ) where {S}
-    if !MOI.supports_constraint(model, MOI.VariableIndex, S)
-        return MOI.ConstraintIndex{MOI.VariableIndex,S}[]
-    end
     return MOI.get(model.variables, attr)
 end
 

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -493,19 +493,6 @@ function test_extension_dictionary()
     return
 end
 
-struct _UnsupportedSetIssue2005 <: MOI.AbstractScalarSet end
-
-function test_get_unsupported_constraint()
-    model = MOI.Utilities.Model{Float64}()
-    S = _UnsupportedSetIssue2005
-    for F in (MOI.VariableIndex, MOI.ScalarAffineFunction{Float64})
-        @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 0
-        @test MOI.get(model, MOI.ListOfConstraintIndices{F,S}()) ==
-              MOI.ConstraintIndex{F,S}[]
-    end
-    return
-end
-
 end  # module
 
 TestModel.runtests()


### PR DESCRIPTION
This reverts https://github.com/jump-dev/MathOptInterface.jl/pull/2008 for the reason detailed in https://github.com/jump-dev/MathOptInterface.jl/pull/2008#issuecomment-1260701844