### PR TITLE
ListOfConstraintIndices and NumberOfConstraints

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -417,9 +417,6 @@ function MOI.get(
     model::AbstractModel,
     attr::MOI.NumberOfConstraints{MOI.VariableIndex,S},
 )::Int64 where {S}
-    if !MOI.supports_constraint(model, MOI.VariableIndex, S)
-        return 0
-    end
     return MOI.get(model.variables, attr)
 end
 
@@ -444,9 +441,6 @@ function MOI.get(
     model::AbstractModel,
     attr::MOI.ListOfConstraintIndices{MOI.VariableIndex,S},
 ) where {S}
-    if !MOI.supports_constraint(model, MOI.VariableIndex, S)
-        return MOI.ConstraintIndex{MOI.VariableIndex,S}[]
-    end
     return MOI.get(model.variables, attr)
 end
 

--- a/src/Utilities/variables_container.jl
+++ b/src/Utilities/variables_container.jl
@@ -341,6 +341,12 @@ function MOI.set(
 end
 
 function MOI.get(
+    b::VariablesContainer,
+    ::MOI.NumberOfConstraints{MOI.VariableIndex},
+)::Int64
+    return 0
+end
+function MOI.get(
     b::VariablesContainer{T},
     ::MOI.NumberOfConstraints{MOI.VariableIndex,S},
 )::Int64 where {T,S<:SUPPORTED_VARIABLE_SCALAR_SETS{T}}
@@ -376,6 +382,12 @@ function MOI.get(
     return list
 end
 
+function MOI.get(
+    b::VariablesContainer,
+    ::MOI.ListOfConstraintIndices{MOI.VariableIndex,S},
+) where {S}
+    return MOI.ConstraintIndex{MOI.VariableIndex,S}[]
+end
 function MOI.get(
     b::VariablesContainer{T},
     ::MOI.ListOfConstraintIndices{MOI.VariableIndex,S},

--- a/src/Utilities/variables_container.jl
+++ b/src/Utilities/variables_container.jl
@@ -341,12 +341,6 @@ function MOI.set(
 end
 
 function MOI.get(
-    b::VariablesContainer,
-    ::MOI.NumberOfConstraints{MOI.VariableIndex},
-)::Int64
-    return 0
-end
-function MOI.get(
     b::VariablesContainer{T},
     ::MOI.NumberOfConstraints{MOI.VariableIndex,S},
 )::Int64 where {T,S<:SUPPORTED_VARIABLE_SCALAR_SETS{T}}
@@ -382,12 +376,6 @@ function MOI.get(
     return list
 end
 
-function MOI.get(
-    b::VariablesContainer,
-    ::MOI.ListOfConstraintIndices{MOI.VariableIndex,S},
-) where {S}
-    return MOI.ConstraintIndex{MOI.VariableIndex,S}[]
-end
 function MOI.get(
     b::VariablesContainer{T},
     ::MOI.ListOfConstraintIndices{MOI.VariableIndex,S},

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1145,7 +1145,7 @@ function _may_have_been_added(
 ) where {F, S}
     return MOI.supports_constraint(model, F, S) ||
         (S === MOI.VariableIndex && MOI.supports_add_constrained_variable(model, S)) ||
-        (S == MOI.VectorOfVariables && MOI.supports_add_constrained_variables(model, S))
+        (S === MOI.VectorOfVariables && MOI.supports_add_constrained_variables(model, S))
 end
 
 function get(

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1148,7 +1148,7 @@ function _may_have_been_added(
         (S == MOI.VectorOfVariables && MOI.supports_add_constrained_variables(model, S))
 end
 
-function get_fallback(
+function get(
     model::ModelLike,
     attr::ListOfConstraintIndices{F,S},
 ) where {F,S}

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1169,7 +1169,7 @@ struct NumberOfConstraints{F,S} <: AbstractModelAttribute end
 
 attribute_value_type(::NumberOfConstraints) = Int64
 
-function get_fallback(
+function get(
     ::ModelLike,
     ::NumberOfConstraints{F,S},
 ) where {F,S}


### PR DESCRIPTION
With https://github.com/jump-dev/MathOptInterface.jl/pull/2008, it now returns a correct value for unsupported constraints. If we want this behavior to be consistent with other implemenation of `MOI.ModelLike`, we don't want to have to implement it for all of them so we could add the following fallbacks so that we don't have to implement it for all implementations.

Closes https://github.com/jump-dev/MathOptInterface.jl/pull/2010