### PR TITLE
[FileFormats.MPS] write OBJSENSE on new line, and loosen parsing rules

### DIFF
--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -250,9 +250,9 @@ function Base.write(io::IO, model::Model)
     flip_obj = false
     if options.objsense
         if MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
-            println(io, "OBJSENSE MAX")
+            println(io, "OBJSENSE\n    MAX")
         else
-            println(io, "OBJSENSE MIN")
+            println(io, "OBJSENSE\n    MIN")
         end
     else
         flip_obj = MOI.get(model, MOI.ObjectiveSense()) == MOI.MAX_SENSE
@@ -1046,16 +1046,18 @@ function Headers(s::AbstractString)
                 return HEADER_QMATRIX
             end
         end
+    elseif N == 8
+        if (x == 'O' || x == 'o') && startswith(uppercase(s), "OBJSENSE")
+            return HEADER_OBJSENSE
+        end
     elseif N == 10
         if (x == 'I' || x == 'i') && uppercase(s) == "INDICATORS"
             return HEADER_INDICATORS
         end
-    elseif N == 8 || N == 12
+    elseif N >= 12
         if (x == 'O' || x == 'o') && startswith(uppercase(s), "OBJSENSE")
             return HEADER_OBJSENSE
-        end
-    elseif N > 12
-        if (x == 'Q' || x == 'q')
+        elseif (x == 'Q' || x == 'q')
             header = uppercase(s)
             if startswith(header, "QCMATRIX")
                 return HEADER_QCMATRIX

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -508,7 +508,8 @@ function test_objsense_true()
     MOI.set(model, MOI.ObjectiveFunction{MOI.VariableIndex}(), x)
     @test sprint(write, model) ==
           "NAME          \n" *
-          "OBJSENSE MAX\n" *
+          "OBJSENSE\n" *
+          "    MAX\n" *
           "ROWS\n" *
           " N  OBJ\n" *
           "COLUMNS\n" *
@@ -961,7 +962,7 @@ function test_objsense_next_line()
             """
             NAME          model
             OBJSENSE
-            $sense
+                $sense
             ROWS
             N  Obj
             """,
@@ -978,6 +979,22 @@ function test_objsense_next_line()
             """
             NAME          model
             OBJSENSE $sense
+            ROWS
+            N  Obj
+            """,
+        )
+        seekstart(io)
+        model = MPS.Model()
+        Base.read!(io, model)
+        @test MOI.get(model, MOI.ObjectiveSense()) == enum
+    end
+    for (sense, enum) in [("MIN", MOI.MIN_SENSE), ("MAX", MOI.MAX_SENSE)]
+        io = IOBuffer()
+        write(
+            io,
+            """
+            NAME          model
+            OBJSENSE      $sense
             ROWS
             N  Obj
             """,

--- a/test/FileFormats/MPS/stacked_data.mps
+++ b/test/FileFormats/MPS/stacked_data.mps
@@ -6,7 +6,8 @@
 *       y ∈ {1, 2, 3, 4}
 *2345678901234567890123456789012345678901234567890
 NAME stacked_data
-OBJSENSE MAX
+OBJSENSE
+    MAX
 ROWS
  N  obj
  N  blank_obj


### PR DESCRIPTION
x-ref: https://github.com/jump-dev/MathOptInterface.jl/pull/2016#issuecomment-1280818477

All solvers are maddeningly different in how they want `OBJSENSE`:

Gurobi want it on the same line https://www.gurobi.com/documentation/9.5/refman/mps_format.html

<img width="916" alt="image" src="https://user-images.githubusercontent.com/8177701/196266824-b5001d42-2ef6-4d0a-ab4f-3f33087f48ee.png">

Mosek want it in field 2 (col 5) on a new line https://docs.mosek.com/10.0/pythonfusion/mps-format.html

<img width="713" alt="image" src="https://user-images.githubusercontent.com/8177701/196266879-c02c51ca-24ef-4432-8e76-3b2c3b7b2c63.png">

CPLEX wants it in column 3 (not a field!) on a new line https://www.ibm.com/docs/en/icos/22.1.0?topic=extensions-objective-sense-name-offset-in-mps-files

<img width="713" alt="image" src="https://user-images.githubusercontent.com/8177701/196266964-046d5ecd-5a72-43a5-b380-28c62849dc2d.png">

Mosek is the only sane one here, and from testing, it seems like the rest can at least read it, so I've changed to that.x