### PR TITLE
Add fallback for ListOfConstraintIndices and NumberOfConstraints

### DIFF
--- a/src/Test/test_attribute.jl
+++ b/src/Test/test_attribute.jl
@@ -276,3 +276,20 @@ function test_attribute_after_empty(model::MOI.AbstractOptimizer, ::Config)
 end
 
 test_attribute_after_empty(::MOI.ModelLike, ::Config) = nothing
+
+struct _UnsupportedVectorSet2010 <: MOI.AbstractVectorSet end
+
+"""
+    test_attribute_unsupported_constraint(model::MOI.ModelLike, config::Config)
+
+Test that `ListOfConstraintIndices` and `NumberOfConstraints` return the correct
+values if the constraint type is unsupported.
+"""
+function test_attribute_unsupported_constraint(model::MOI.ModelLike, ::Config)
+    F, S = MOI.VectorOfVariables, _UnsupportedVectorSet2010
+    @requires !MOI.supports_constraint(model, F, S)
+    @test MOI.get(model, MOI.ListOfConstraintIndices{F,S}()) ==
+          MOI.ConstraintIndex{F,S}[]
+    @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == Int64(0)
+    return
+end

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1142,8 +1142,8 @@ function get_fallback(
     model::ModelLike,
     ::ListOfConstraintIndices{F,S},
 ) where {F,S}
-    if MOI.supports_constraint(model, F, S)
-        throw(MOI.GetAttributeNotAllowed(MOI.ListOfConstraintIndices{F,S}()))
+    if supports_constraint(model, F, S)
+        throw(GetAttributeNotAllowed(ListOfConstraintIndices{F,S}()))
     end
     return ConstraintIndex{F,S}[]
 end
@@ -1159,8 +1159,8 @@ struct NumberOfConstraints{F,S} <: AbstractModelAttribute end
 attribute_value_type(::NumberOfConstraints) = Int64
 
 function get_fallback(model::ModelLike, ::NumberOfConstraints{F,S}) where {F,S}
-    if MOI.supports_constraint(model, F, S)
-        throw(MOI.GetAttributeNotAllowed(MOI.NumberOfConstraints{F,S}()))
+    if supports_constraint(model, F, S)
+        throw(GetAttributeNotAllowed(NumberOfConstraints{F,S}()))
     end
     return Int64(0)
 end

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1138,7 +1138,13 @@ indices of type `F`-in-`S` in the model (i.e., of length equal to the value of
 """
 struct ListOfConstraintIndices{F,S} <: AbstractModelAttribute end
 
-function get_fallback(::ModelLike, ::ListOfConstraintIndices{F,S}) where {F,S}
+function get_fallback(
+    model::ModelLike,
+    ::ListOfConstraintIndices{F,S},
+) where {F,S}
+    if MOI.supports_constraint(model, F, S)
+        throw(MOI.GetAttributeNotAllowed(MOI.ListOfConstraintIndices{F,S}()))
+    end
     return ConstraintIndex{F,S}[]
 end
 
@@ -1152,7 +1158,12 @@ struct NumberOfConstraints{F,S} <: AbstractModelAttribute end
 
 attribute_value_type(::NumberOfConstraints) = Int64
 
-get_fallback(::ModelLike, ::NumberOfConstraints{F,S}) where {F,S} = Int64(0)
+function get_fallback(model::ModelLike, ::NumberOfConstraints{F,S}) where {F,S}
+    if MOI.supports_constraint(model, F, S)
+        throw(MOI.GetAttributeNotAllowed(MOI.NumberOfConstraints{F,S}()))
+    end
+    return Int64(0)
+end
 
 """
     ListOfConstraintTypesPresent()

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1142,6 +1142,8 @@ function get_fallback(
     model::ModelLike,
     ::ListOfConstraintIndices{F,S},
 ) where {F,S}
+    # Throw error here so that we don't return an incorrect value if solvers
+    # don't implement this method for some constraints they support.
     if supports_constraint(model, F, S) ||
        (S === VariableIndex && supports_add_constrained_variable(model, S)) ||
        (S === VectorOfVariables && supports_add_constrained_variables(model, S))
@@ -1161,6 +1163,8 @@ struct NumberOfConstraints{F,S} <: AbstractModelAttribute end
 attribute_value_type(::NumberOfConstraints) = Int64
 
 function get_fallback(model::ModelLike, ::NumberOfConstraints{F,S}) where {F,S}
+    # Throw error here so that we don't return an incorrect value if solvers
+    # don't implement this method for constraints they support.
     if supports_constraint(model, F, S) ||
        (S === VariableIndex && supports_add_constrained_variable(model, S)) ||
        (S === VectorOfVariables && supports_add_constrained_variables(model, S))

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1138,6 +1138,10 @@ indices of type `F`-in-`S` in the model (i.e., of length equal to the value of
 """
 struct ListOfConstraintIndices{F,S} <: AbstractModelAttribute end
 
+function get_fallback(::ModelLike, ::ListOfConstraintIndices{F,S}) where {F,S}
+    return ConstraintIndex{F,S}[]
+end
+
 """
     NumberOfConstraints{F,S}()
 
@@ -1147,6 +1151,8 @@ in the model.
 struct NumberOfConstraints{F,S} <: AbstractModelAttribute end
 
 attribute_value_type(::NumberOfConstraints) = Int64
+
+get_fallback(::ModelLike, ::NumberOfConstraints{F,S}) where {F,S} = Int64(0)
 
 """
     ListOfConstraintTypesPresent()

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1142,7 +1142,9 @@ function get_fallback(
     model::ModelLike,
     ::ListOfConstraintIndices{F,S},
 ) where {F,S}
-    if supports_constraint(model, F, S)
+    if supports_constraint(model, F, S) ||
+       (S === VariableIndex && supports_add_constrained_variable(model, S)) ||
+       (S === VectorOfVariables && supports_add_constrained_variables(model, S))
         throw(GetAttributeNotAllowed(ListOfConstraintIndices{F,S}()))
     end
     return ConstraintIndex{F,S}[]
@@ -1159,7 +1161,9 @@ struct NumberOfConstraints{F,S} <: AbstractModelAttribute end
 attribute_value_type(::NumberOfConstraints) = Int64
 
 function get_fallback(model::ModelLike, ::NumberOfConstraints{F,S}) where {F,S}
-    if supports_constraint(model, F, S)
+    if supports_constraint(model, F, S) ||
+       (S === VariableIndex && supports_add_constrained_variable(model, S)) ||
+       (S === VectorOfVariables && supports_add_constrained_variables(model, S))
         throw(GetAttributeNotAllowed(NumberOfConstraints{F,S}()))
     end
     return Int64(0)

--- a/test/Test/Test.jl
+++ b/test/Test/Test.jl
@@ -4,6 +4,8 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
+using Test
+
 using MathOptInterface
 const MOI = MathOptInterface
 
@@ -88,7 +90,24 @@ MOI.Test.runtests(
 
 struct _UnsupportedModel <: MOI.ModelLike end
 
+function MOI.supports_constraint(
+    ::_UnsupportedModel,
+    ::Type{MOI.VariableIndex},
+    ::Type{MOI.ZeroOne},
+)
+    return true
+end
+
 MOI.Test.test_attribute_unsupported_constraint(
     _UnsupportedModel(),
     MOI.Test.Config(),
 )
+
+@testset "test_attribute_unsupported_constraint_fallback" begin
+    model = _UnsupportedModel()
+    F, S = MOI.VariableIndex, MOI.ZeroOne
+    attr = MOI.ListOfConstraintIndices{F,S}()
+    @test_throws MOI.GetAttributeNotAllowed(attr) MOI.get(model, attr)
+    attr = MOI.NumberOfConstraints{F,S}()
+    @test_throws MOI.GetAttributeNotAllowed(attr) MOI.get(model, attr)
+end

--- a/test/Test/Test.jl
+++ b/test/Test/Test.jl
@@ -83,3 +83,12 @@ MOI.Test.runtests(
         "test_model_supports_constraint_VectorOfVariables_Nonnegatives",
     ],
 )
+
+# Special test for issue #2010
+
+struct _UnsupportedModel <: MOI.ModelLike end
+
+MOI.Test.test_attribute_unsupported_constraint(
+    _UnsupportedModel(),
+    MOI.Test.Config(),
+)


### PR DESCRIPTION
This PR adds a fallback for `ListOfConstraintIndices` and `NumberOfConstraints` to return default values in the case that the solver does't support the particular function-set combination.

This has come up a few times:

Closes #2011 
Closes #2010
Follow-up to #2008

We already had something similar in two places:

https://github.com/jump-dev/MathOptInterface.jl/blob/71defad7679ca34987860bbfd660fc290b1e2290/src/Utilities/struct_of_constraints.jl#L142-L150

https://github.com/jump-dev/MathOptInterface.jl/blob/71defad7679ca34987860bbfd660fc290b1e2290/src/Utilities/struct_of_constraints.jl#L132-L140

#2008 added it to two more:

https://github.com/jump-dev/MathOptInterface.jl/blob/71defad7679ca34987860bbfd660fc290b1e2290/src/Utilities/model.jl#L416-L424

https://github.com/jump-dev/MathOptInterface.jl/blob/71defad7679ca34987860bbfd660fc290b1e2290/src/Utilities/model.jl#L443-L451

So this PR is essentially just making some implied behavior concrete.

I've tested with Gurobi:

```julia
julia> model = Gurobi.Optimizer();

julia> MOI.Test.test_attribute_unsupported_list_of_constraint_indices(model, config)

```

But once this PR is open, I'll run SolverTests to see the damage: https://github.com/jump-dev/SolverTests/pull/19