### PR TITLE
[Nonlinear] add support for multivariate min and max operators

### DIFF
--- a/src/Nonlinear/operators.jl
+++ b/src/Nonlinear/operators.jl
@@ -82,7 +82,8 @@ const DEFAULT_UNIVARIATE_OPERATORS = first.(SYMBOLIC_UNIVARIATE_EXPRESSIONS)
 
 The list of multivariate operators that are supported by default.
 """
-const DEFAULT_MULTIVARIATE_OPERATORS = [:+, :-, :*, :^, :/, :ifelse, :atan]
+const DEFAULT_MULTIVARIATE_OPERATORS =
+    [:+, :-, :*, :^, :/, :ifelse, :atan, :min, :max]
 
 """
     OperatorRegistry()
@@ -547,6 +548,10 @@ function eval_multivariate_function(
     elseif op == :atan
         @assert length(x) == 2
         return atan(x[1], x[2])
+    elseif op == :min
+        return minimum(x)
+    elseif op == :max
+        return maximum(x)
     end
     id = registry.multivariate_operator_to_id[op]
     offset = id - registry.multivariate_user_operator_start
@@ -627,6 +632,14 @@ function eval_multivariate_gradient(
         base = x[1]^2 + x[2]^2
         g[1] = x[2] / base
         g[2] = -x[1] / base
+    elseif op == :min
+        fill!(g, zero(T))
+        _, i = findmin(x)
+        g[i] = one(T)
+    elseif op == :max
+        fill!(g, zero(T))
+        _, i = findmax(x)
+        g[i] = one(T)
     else
         id = registry.multivariate_operator_to_id[op]
         offset = id - registry.multivariate_user_operator_start
@@ -727,6 +740,12 @@ function eval_multivariate_hessian(
         H[1, 1] = -2 * x[2] * x[1] / base
         H[2, 1] = (x[1]^2 - x[2]^2) / base
         H[2, 2] = 2 * x[2] * x[1] / base
+    elseif op == :min
+        _, i = findmin(x)
+        H[i, i] = one(T)
+    elseif op == :max
+        _, i = findmax(x)
+        H[i, i] = one(T)
     else
         id = registry.multivariate_operator_to_id[op]
         offset = id - registry.multivariate_user_operator_start

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -884,6 +884,70 @@ function test_deep_recursion()
     return
 end
 
+function test_min_operator()
+    model = Nonlinear.Model()
+    x = MOI.VariableIndex(1)
+    y = MOI.VariableIndex(2)
+    Nonlinear.set_objective(model, :(min($x, $y)))
+    evaluator = Nonlinear.Evaluator(model)
+    MOI.initialize(evaluator, [:ExprGraph])
+    @test MOI.objective_expr(evaluator) == :(min(x[$x], x[$y]))
+
+    r = Nonlinear.OperatorRegistry()
+    x = [1.1, 2.2]
+    @test Nonlinear.eval_multivariate_function(r, :min, x) == 1.1
+    g = zeros(2)
+    Nonlinear.eval_multivariate_gradient(r, :min, g, x)
+    @test g == [1.0, 0.0]
+    H = LinearAlgebra.LowerTriangular(zeros(2, 2))
+    @test Nonlinear.eval_multivariate_hessian(r, :min, H, x)
+    @test H[1, 1] == 1.0
+    @test H[2, 1] == H[2, 2] == 0.0
+
+    x = [1.1, -2.2]
+    @test Nonlinear.eval_multivariate_function(r, :min, x) == -2.2
+    g = zeros(2)
+    Nonlinear.eval_multivariate_gradient(r, :min, g, x)
+    @test g == [0.0, 1.0]
+    H = LinearAlgebra.LowerTriangular(zeros(2, 2))
+    @test Nonlinear.eval_multivariate_hessian(r, :min, H, x)
+    @test H[2, 2] == 1.0
+    @test H[1, 1] == H[2, 1] == 0.0
+    return
+end
+
+function test_max_operator()
+    model = Nonlinear.Model()
+    x = MOI.VariableIndex(1)
+    y = MOI.VariableIndex(2)
+    Nonlinear.set_objective(model, :(max($x, $y)))
+    evaluator = Nonlinear.Evaluator(model)
+    MOI.initialize(evaluator, [:ExprGraph])
+    @test MOI.objective_expr(evaluator) == :(max(x[$x], x[$y]))
+
+    r = Nonlinear.OperatorRegistry()
+    x = [1.1, -2.2]
+    @test Nonlinear.eval_multivariate_function(r, :max, x) == 1.1
+    g = zeros(2)
+    Nonlinear.eval_multivariate_gradient(r, :max, g, x)
+    @test g == [1.0, 0.0]
+    H = LinearAlgebra.LowerTriangular(zeros(2, 2))
+    @test Nonlinear.eval_multivariate_hessian(r, :max, H, x)
+    @test H[1, 1] == 1.0
+    @test H[2, 1] == H[2, 2] == 0.0
+
+    x = [1.1, 2.2]
+    @test Nonlinear.eval_multivariate_function(r, :max, x) == 2.2
+    g = zeros(2)
+    Nonlinear.eval_multivariate_gradient(r, :max, g, x)
+    @test g == [0.0, 1.0]
+    H = LinearAlgebra.LowerTriangular(zeros(2, 2))
+    @test Nonlinear.eval_multivariate_hessian(r, :max, H, x)
+    @test H[2, 2] == 1.0
+    @test H[1, 1] == H[2, 1] == 0.0
+    return
+end
+
 end
 
 TestNonlinear.runtests()


### PR DESCRIPTION
Part of #1996. 

We've long had this discontinuity between JuMP+Ipopt and AMPLNLWriter+Ipopt, ever since I introduced it waaaaaay back in https://github.com/jump-dev/AmplNLWriter.jl/issues/15 and https://github.com/jump-dev/AmplNLWriter.jl/pull/17.

We've had to frequently address this problem on discourse. Here are three that I found through search, but there are probably more:

 * https://discourse.julialang.org/t/jump-using-max-x-where-x-is-a-matrix/78451/6?u=odow
 * https://discourse.julialang.org/t/using-max-in-nonlinear-constraints/21606/4?u=odow
 * https://discourse.julialang.org/t/methoderror-no-method-matching-isless-int64-affexpr/69731/3?u=odow

The derivatives are non-smooth etc. But this can work nicely in situations such as:
```Julia
julia> using JuMP

julia> import Ipopt

julia> model = Model(Ipopt.Optimizer);

julia> @variable(model, x)
x

julia> @NLobjective(model, Min, max((x-1)^2, -(x-1)^3))

julia> optimize!(model)
This is Ipopt version 3.14.4, running with linear solver MUMPS 5.4.1.

Number of nonzeros in equality constraint Jacobian...:        0
Number of nonzeros in inequality constraint Jacobian.:        0
Number of nonzeros in Lagrangian Hessian.............:        1

Total number of variables............................:        1
                     variables with only lower bounds:        0
                variables with lower and upper bounds:        0
                     variables with only upper bounds:        0
Total number of equality constraints.................:        0
Total number of inequality constraints...............:        0
        inequality constraints with only lower bounds:        0
   inequality constraints with lower and upper bounds:        0
        inequality constraints with only upper bounds:        0

iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  1.0000000e+00 0.00e+00 2.00e+00  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  4.4444444e-01 0.00e+00 1.33e+00  -1.0 3.33e-01    -  1.00e+00 1.00e+00f  1
   2  9.8423683e-02 0.00e+00 6.27e-01  -1.0 3.53e-01    -  1.00e+00 1.00e+00f  1
   3  2.6624490e-03 0.00e+00 1.03e-01  -1.7 2.62e-01    -  1.00e+00 1.00e+00f  1
   4  7.4694908e-08 0.00e+00 5.47e-04  -2.5 5.13e-02    -  1.00e+00 1.00e+00f  1
   5  1.6669897e-21 0.00e+00 8.17e-11  -5.7 2.73e-04    -  1.00e+00 1.00e+00f  1

Number of Iterations....: 5

                                   (scaled)                 (unscaled)
Objective...............:   1.6669896680403645e-21    1.6669896680403645e-21
Dual infeasibility......:   8.1657569594995039e-11    8.1657569594995039e-11
Constraint violation....:   0.0000000000000000e+00    0.0000000000000000e+00
Variable bound violation:   0.0000000000000000e+00    0.0000000000000000e+00
Complementarity.........:   0.0000000000000000e+00    0.0000000000000000e+00
Overall NLP error.......:   8.1657569594995039e-11    8.1657569594995039e-11


Number of objective function evaluations             = 6
Number of objective gradient evaluations             = 6
Number of equality constraint evaluations            = 0
Number of inequality constraint evaluations          = 0
Number of equality constraint Jacobian evaluations   = 0
Number of inequality constraint Jacobian evaluations = 0
Number of Lagrangian Hessian evaluations             = 5
Total seconds in IPOPT                               = 0.003

EXIT: Optimal Solution Found.

julia> value(x)
0.9999999999591712
```