### PR TITLE
[Test] add requires for test_constraint_get_ConstraintIndex

### DIFF
--- a/src/Test/test_constraint.jl
+++ b/src/Test/test_constraint.jl
@@ -16,10 +16,10 @@ function test_constraint_get_ConstraintIndex(
     model::MOI.ModelLike,
     ::Config{T},
 ) where {T}
+    x = MOI.add_variable(model)
     f = T(1) * x
     CI = MOI.ConstraintIndex{typeof(f),MOI.GreaterThan{T}}
     @requires MOI.supports(model, MOI.ConstraintName(), CI)
-    x = MOI.add_variable(model)
     c1 = MOI.add_constraint(model, f, MOI.GreaterThan(T(1)))
     MOI.set(model, MOI.ConstraintName(), c1, "c1")
     c2 = MOI.add_constraint(model, f, MOI.LessThan(T(2)))

--- a/src/Test/test_constraint.jl
+++ b/src/Test/test_constraint.jl
@@ -17,7 +17,8 @@ function test_constraint_get_ConstraintIndex(
     ::Config{T},
 ) where {T}
     f = T(1) * x
-    @requires MOI.supports(model, MOI.ConstraintName(), MOI.ConstraintIndex{typeof(f), MOI.GreaterThan{T}})
+    CI = MOI.ConstraintIndex{typeof(f),MOI.GreaterThan{T}}
+    @requires MOI.supports(model, MOI.ConstraintName(), CI)
     x = MOI.add_variable(model)
     c1 = MOI.add_constraint(model, f, MOI.GreaterThan(T(1)))
     MOI.set(model, MOI.ConstraintName(), c1, "c1")

--- a/src/Test/test_constraint.jl
+++ b/src/Test/test_constraint.jl
@@ -16,6 +16,7 @@ function test_constraint_get_ConstraintIndex(
     model::MOI.ModelLike,
     ::Config{T},
 ) where {T}
+    @requires MOI.supports(model, MOI.ConstraintName(), MOI.ConstraintIndex)
     x = MOI.add_variable(model)
     c1 = MOI.add_constraint(model, T(1) * x, MOI.GreaterThan(T(1)))
     MOI.set(model, MOI.ConstraintName(), c1, "c1")

--- a/src/Test/test_constraint.jl
+++ b/src/Test/test_constraint.jl
@@ -16,11 +16,12 @@ function test_constraint_get_ConstraintIndex(
     model::MOI.ModelLike,
     ::Config{T},
 ) where {T}
-    @requires MOI.supports(model, MOI.ConstraintName(), MOI.ConstraintIndex)
+    f = T(1) * x
+    @requires MOI.supports(model, MOI.ConstraintName(), MOI.ConstraintIndex{typeof(f), MOI.GreaterThan{T}})
     x = MOI.add_variable(model)
-    c1 = MOI.add_constraint(model, T(1) * x, MOI.GreaterThan(T(1)))
+    c1 = MOI.add_constraint(model, f, MOI.GreaterThan(T(1)))
     MOI.set(model, MOI.ConstraintName(), c1, "c1")
-    c2 = MOI.add_constraint(model, T(1) * x, MOI.LessThan(T(2)))
+    c2 = MOI.add_constraint(model, f, MOI.LessThan(T(2)))
     MOI.set(model, MOI.ConstraintName(), c2, "c2")
     F = MOI.ScalarAffineFunction{T}
     @test MOI.get(model, MOI.ConstraintIndex, "c3") === nothing


### PR DESCRIPTION
I got surprised the test fails for an optimizer even though it does not specify that it supports constraint names, shouldn't there be a `@requires` there?
Possibly also checking the requires with `Type{CI{F,S}}`