### PR TITLE
[Utilities] Re-enable allocation test from #2018

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -833,7 +833,7 @@ function _sort_and_compress!(x::Vector)
     if length(x) == 0
         return
     end
-    sort!(x, QuickSort, Base.Order.ord(isless, MOI.term_indices, false))
+    sort!(x, InsertionSort, Base.Order.ord(isless, MOI.term_indices, false))
     i = 1
     @inbounds for j in 2:length(x)
         if MOI.term_indices(x[i]) == MOI.term_indices(x[j])

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -833,7 +833,7 @@ function _sort_and_compress!(x::Vector)
     if length(x) == 0
         return
     end
-    sort!(x; by = MOI.term_indices)
+    sort!(x, QuickSort, Base.Order.ord(isless, MOI.term_indices, false))
     i = 1
     @inbounds for j in 2:length(x)
         if MOI.term_indices(x[i]) == MOI.term_indices(x[j])

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -1058,7 +1058,7 @@ function _test_canonicalization(
     @test MOI.Utilities.canonical(g) !== g
     # There are some changes to sorting in Julia v1.9 that now mean sorting
     # allocates.
-    if VERSION < v"1.9"
+    if VERSION < v"1.9.0-DEV"
         @test @allocated(MOI.Utilities.canonicalize!(f)) == 0
     end
     return

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -1058,7 +1058,9 @@ function _test_canonicalization(
     @test MOI.Utilities.canonical(g) !== g
     # There are some changes to sorting in Julia v1.9 that now mean sorting
     # allocates.
-    @test @allocated(MOI.Utilities.canonicalize!(f)) == 0
+    if VERSION < v"1.9"
+        @test @allocated(MOI.Utilities.canonicalize!(f)) == 0
+    end
     return
 end
 

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -1056,11 +1056,7 @@ function _test_canonicalization(
     @test MOI.Utilities.is_canonical(expected)
     @test _isapprox_ordered(MOI.Utilities.canonical(g), g)
     @test MOI.Utilities.canonical(g) !== g
-    # There are some changes to sorting in Julia v1.9 that now mean sorting
-    # allocates.
-    if true # VERSION < v"1.9.0-DEV"
-        @test @allocated(MOI.Utilities.canonicalize!(f)) == 0
-    end
+    @test @allocated(MOI.Utilities.canonicalize!(f)) == 0
     return
 end
 

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -1058,7 +1058,7 @@ function _test_canonicalization(
     @test MOI.Utilities.canonical(g) !== g
     # There are some changes to sorting in Julia v1.9 that now mean sorting
     # allocates.
-    # @test @allocated(MOI.Utilities.canonicalize!(f)) == 0
+    @test @allocated(MOI.Utilities.canonicalize!(f)) == 0
     return
 end
 

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -1058,7 +1058,7 @@ function _test_canonicalization(
     @test MOI.Utilities.canonical(g) !== g
     # There are some changes to sorting in Julia v1.9 that now mean sorting
     # allocates.
-    if VERSION < v"1.9.0-DEV"
+    if true # VERSION < v"1.9.0-DEV"
         @test @allocated(MOI.Utilities.canonicalize!(f)) == 0
     end
     return


### PR DESCRIPTION
Tracking to see if #2017 changed.

But I don't expect it to have. This is a regression introduced by https://github.com/JuliaLang/julia/pull/45222.

Closes #2017 