### PR TITLE
[Bridges] Use is_coefficient_type

### DIFF
--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -81,24 +81,10 @@ function supports_objective_function(
 end
 
 function supports_objective_function(
-    ::Type{<:SlackBridge},
-    ::Type{<:MOI.AbstractScalarFunction},
-)
-    return true
-end
-
-function supports_objective_function(
-    ::Type{<:SlackBridge},
-    ::Type{<:MOI.ScalarAffineFunction{<:Complex}},
-)
-    return false
-end
-
-function supports_objective_function(
-    ::Type{<:SlackBridge},
-    ::Type{<:MOI.ScalarQuadraticFunction{<:Complex}},
-)
-    return false
+    ::Type{<:SlackBridge{T}},
+    ::Type{F},
+) where {T,F<:<:MOI.AbstractScalarFunction}
+    return MOI.Utilities.is_coefficient_type(F, T)
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:SlackBridge})

--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -83,7 +83,7 @@ end
 function supports_objective_function(
     ::Type{<:SlackBridge{T}},
     ::Type{F},
-) where {T,F<:<:MOI.AbstractScalarFunction}
+) where {T,F<:MOI.AbstractScalarFunction}
     return MOI.Utilities.is_coefficient_type(F, T)
 end
 


### PR DESCRIPTION
The bridge will fail with the error given in https://github.com/jump-dev/MathOptInterface.jl/issues/2035 whenever the function type is different from `T` so this should fix all these cases, not only the `Complex` case.