### PR TITLE
[Utilities] revert to QuickSort

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -833,7 +833,7 @@ function _sort_and_compress!(x::Vector)
     if length(x) == 0
         return
     end
-    sort!(x, InsertionSort, Base.Order.ord(isless, MOI.term_indices, false))
+    sort!(x, QuickSort, Base.Order.ord(isless, MOI.term_indices, false))
     i = 1
     @inbounds for j in 2:length(x)
         if MOI.term_indices(x[i]) == MOI.term_indices(x[j])

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -1056,7 +1056,11 @@ function _test_canonicalization(
     @test MOI.Utilities.is_canonical(expected)
     @test _isapprox_ordered(MOI.Utilities.canonical(g), g)
     @test MOI.Utilities.canonical(g) !== g
-    @test @allocated(MOI.Utilities.canonicalize!(f)) == 0
+    # There are some changes to sorting in Julia v1.9 that now mean sorting
+    # allocates.
+    if VERSION < v"1.9.0-DEV"
+        @test @allocated(MOI.Utilities.canonicalize!(f)) == 0
+    end
     return
 end
 


### PR DESCRIPTION
I've gone back and forward on this: https://github.com/jump-dev/MathOptInterface.jl/pull/2034

But there are cases where the scaling behavior of InsertionSort rules it out. So let's just incur the allocations and be done with it.