### PR TITLE
[Utilities] add distance_to_set

### DIFF
--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -213,6 +213,14 @@ Utilities.is_diagonal_vectorized_index
 Utilities.side_dimension_for_vectorized_dimension
 ```
 
+## Function utilities
+
+The following utilities are available for sets:
+
+```@docs
+Utilities.distance_to_set
+```
+
 ## DoubleDicts
 
 ```@docs

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -219,7 +219,7 @@ The following utilities are available for sets:
 
 ```@docs
 Utilities.AbstractDistance
-Utilities.DefaultDistance
+Utilities.ProjectionUpperBoundDistance
 Utilities.distance_to_set
 Utilities.set_dot
 ```

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -213,12 +213,13 @@ Utilities.is_diagonal_vectorized_index
 Utilities.side_dimension_for_vectorized_dimension
 ```
 
-## Function utilities
+## Set utilities
 
 The following utilities are available for sets:
 
 ```@docs
 Utilities.distance_to_set
+Utilities.set_dot
 ```
 
 ## DoubleDicts

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -218,6 +218,8 @@ Utilities.side_dimension_for_vectorized_dimension
 The following utilities are available for sets:
 
 ```@docs
+Utilities.AbstractDistance
+Utilities.DefaultDistance
 Utilities.distance_to_set
 Utilities.set_dot
 ```

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -80,6 +80,8 @@ include("print.jl")
 
 include("lazy_iterators.jl")
 
+include("distance_to_set.jl")
+
 include("precompile.jl")
 _precompile_()
 

--- a/src/Utilities/distance_to_set.jl
+++ b/src/Utilities/distance_to_set.jl
@@ -13,7 +13,7 @@ An abstract type used to enabble dispatch of
 abstract type AbstractDistance end
 
 """
-    DefaultDistance() <: AbstractDistance
+    ProjectionUpperBoundDistance() <: AbstractDistance
 
 An upper bound on the minimum distance between `point` and the closest
 feasible point in `set`.
@@ -47,17 +47,17 @@ If the distance is not the smallest upper bound, the docstring of the
 appropriate `distance_to_set` method _must_ describe the way that the distance
 is computed.
 """
-struct DefaultDistance <: AbstractDistance end
+struct ProjectionUpperBoundDistance <: AbstractDistance end
 
 """
     distance_to_set(
-        [d::AbstractDistance = DefaultDistance()],]
+        [d::AbstractDistance = ProjectionUpperBoundDistance()],]
         point::T,
         set::MOI.AbstractScalarSet,
     ) where {T}
 
     distance_to_set(
-        [d::AbstractDistance = DefaultDistance(),]
+        [d::AbstractDistance = ProjectionUpperBoundDistance(),]
         point::AbstractVector{T},
         set::MOI.AbstractVectorSet,
     ) where {T}
@@ -65,9 +65,11 @@ struct DefaultDistance <: AbstractDistance end
 Compute the distance between `point` and `set` using the distance metric `d`. If
 `point` is in the set `set`, this function _must_ return `zero(T)`.
 
-If `d` is omitted, the default distance is [`Utilities.DefaultDistance`](@ref).
+If `d` is omitted, the default distance is [`Utilities.ProjectionUpperBoundDistance`](@ref).
 """
-distance_to_set(point, set) = distance_to_set(DefaultDistance(), point, set)
+function distance_to_set(point, set)
+    return distance_to_set(ProjectionUpperBoundDistance(), point, set)
+end
 
 function distance_to_set(d::AbstractDistance, ::Any, set::MOI.AbstractSet)
     return error(
@@ -81,7 +83,7 @@ end
 ###
 
 function distance_to_set(
-    ::DefaultDistance,
+    ::ProjectionUpperBoundDistance,
     x::T,
     set::MOI.LessThan{T},
 ) where {T<:Real}
@@ -89,7 +91,7 @@ function distance_to_set(
 end
 
 function distance_to_set(
-    ::DefaultDistance,
+    ::ProjectionUpperBoundDistance,
     x::T,
     set::MOI.GreaterThan{T},
 ) where {T<:Real}
@@ -97,7 +99,7 @@ function distance_to_set(
 end
 
 function distance_to_set(
-    ::DefaultDistance,
+    ::ProjectionUpperBoundDistance,
     x::T,
     set::MOI.EqualTo{T},
 ) where {T<:Number}
@@ -105,23 +107,31 @@ function distance_to_set(
 end
 
 function distance_to_set(
-    ::DefaultDistance,
+    ::ProjectionUpperBoundDistance,
     x::T,
     set::MOI.Interval{T},
 ) where {T<:Real}
     return max(x - set.upper, set.lower - x, zero(T))
 end
 
-function distance_to_set(::DefaultDistance, x::T, ::MOI.ZeroOne) where {T<:Real}
+function distance_to_set(
+    ::ProjectionUpperBoundDistance,
+    x::T,
+    ::MOI.ZeroOne,
+) where {T<:Real}
     return min(abs(x - zero(T)), abs(x - one(T)))
 end
 
-function distance_to_set(::DefaultDistance, x::T, ::MOI.Integer) where {T<:Real}
+function distance_to_set(
+    ::ProjectionUpperBoundDistance,
+    x::T,
+    ::MOI.Integer,
+) where {T<:Real}
     return abs(x - round(x))
 end
 
 function distance_to_set(
-    ::DefaultDistance,
+    ::ProjectionUpperBoundDistance,
     x::T,
     set::MOI.Semicontinuous{T},
 ) where {T<:Real}
@@ -129,7 +139,7 @@ function distance_to_set(
 end
 
 function distance_to_set(
-    ::DefaultDistance,
+    ::ProjectionUpperBoundDistance,
     x::T,
     set::MOI.Semiinteger{T},
 ) where {T<:Real}
@@ -149,7 +159,7 @@ function _check_dimension(v::AbstractVector, s)
 end
 
 function distance_to_set(
-    ::DefaultDistance,
+    ::ProjectionUpperBoundDistance,
     x::AbstractVector{T},
     set::MOI.Nonnegatives,
 ) where {T<:Real}
@@ -158,7 +168,7 @@ function distance_to_set(
 end
 
 function distance_to_set(
-    ::DefaultDistance,
+    ::ProjectionUpperBoundDistance,
     x::AbstractVector{T},
     set::MOI.Nonpositives,
 ) where {T<:Real}
@@ -167,7 +177,7 @@ function distance_to_set(
 end
 
 function distance_to_set(
-    ::DefaultDistance,
+    ::ProjectionUpperBoundDistance,
     x::AbstractVector{T},
     set::MOI.Zeros,
 ) where {T<:Number}
@@ -176,7 +186,7 @@ function distance_to_set(
 end
 
 function distance_to_set(
-    ::DefaultDistance,
+    ::ProjectionUpperBoundDistance,
     x::AbstractVector{T},
     set::MOI.Reals,
 ) where {T<:Real}

--- a/src/Utilities/distance_to_set.jl
+++ b/src/Utilities/distance_to_set.jl
@@ -11,12 +11,35 @@
         set::MOI.AbstractVectorSet,
     ) where {T}
 
-Compute an upper bound on the Euclidean distance between `point` and the closest
+Compute an upper bound on the minimum distance between `point` and the closest
 feasible point in `set`. If `point` is in the set `set`, this function _must_
 return `zero(T)`.
 
-In most cases, this function should return the smallest upper bound, but it may
-return a larger value if the smallest upper bound is expensive to compute.
+## Definition of distance
+
+The minimum distance is computed as
+```math
+d(x, \\mathcal{K}) = \\min\\_{y \\in \\mathcal{K}} || x - y ||
+```
+where ``x`` is `point` and ``\\mathcal{K}`` is `set`. The norm is computed as
+```math
+||x|| = \\sqrt{\\texttt{set\\_dot}(x, x, \\mathcal{K})}
+```
+where ``\\texttt{set\\_dot}`` is [`Utilities.set_dot`](@ref).
+
+In the default case, where the set does not have a specialized method for
+[`Utilities.set_dot`](@ref), the norm is equivalent to the Euclidean norm
+``||x|| = \\sqrt{\\sum x_i^2}``.
+
+## Why an upper bound?
+
+In most cases, `distance_to_set` should return the smallest upper bound, but it
+may return a larger value if the smallest upper bound is expensive to compute.
+
+For example, given an epigraph from of a conic set, ``(t, x) \\in \\mathcal{K}``,
+it may be simpler to return ``\\delta`` such that
+``(t + \\delta, x) \\in \\mathcal{K}``, rather than computing the nearest
+projection onto ``\\mathcal{K}``.
 """
 function distance_to_set(::Any, set::MOI.AbstractSet)
     return error(

--- a/src/Utilities/distance_to_set.jl
+++ b/src/Utilities/distance_to_set.jl
@@ -17,15 +17,15 @@ return `zero(T)`.
 
 ## Definition of distance
 
-The minimum distance is computed as
+The minimum distance is computed as:
 ```math
-d(x, \\mathcal{K}) = \\min\\_{y \\in \\mathcal{K}} || x - y ||
+d(x, \\mathcal{K}) = \\min_{y \\in \\mathcal{K}} || x - y ||
 ```
-where ``x`` is `point` and ``\\mathcal{K}`` is `set`. The norm is computed as
+where ``x`` is `point` and ``\\mathcal{K}`` is `set`. The norm is computed as:
 ```math
-||x|| = \\sqrt{\\texttt{set\\_dot}(x, x, \\mathcal{K})}
+||x|| = \\sqrt{\\texttt{set_dot}(x, x, \\mathcal{K})}
 ```
-where ``\\texttt{set\\_dot}`` is [`Utilities.set_dot`](@ref).
+where ``\\texttt{set_dot}`` is [`Utilities.set_dot`](@ref).
 
 In the default case, where the set does not have a specialized method for
 [`Utilities.set_dot`](@ref), the norm is equivalent to the Euclidean norm

--- a/src/Utilities/distance_to_set.jl
+++ b/src/Utilities/distance_to_set.jl
@@ -89,18 +89,12 @@ function distance_to_set(
     return LinearAlgebra.norm(max(xi, zero(T)) for xi in x)
 end
 
-function distance_to_set(
-    x::AbstractVector{T},
-    set::MOI.Zeros,
-) where {T<:Number}
+function distance_to_set(x::AbstractVector{T}, set::MOI.Zeros) where {T<:Number}
     _check_dimension(x, set)
     return LinearAlgebra.norm(x)
 end
 
-function distance_to_set(
-    x::AbstractVector{T},
-    set::MOI.Reals,
-) where {T<:Real}
+function distance_to_set(x::AbstractVector{T}, set::MOI.Reals) where {T<:Real}
     _check_dimension(x, set)
     return zero(T)
 end

--- a/src/Utilities/distance_to_set.jl
+++ b/src/Utilities/distance_to_set.jl
@@ -1,0 +1,106 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+"""
+    distance_to_set(point::T, set::MOI.AbstractScalarSet) where {T}
+    distance_to_set(
+        point::AbstractVector{T},
+        set::MOI.AbstractVectorSet,
+    ) where {T}
+
+Compute an upper bound on the Euclidean distance between `point` and the closest
+feasible point in `set`. If `point` is in the set `set`, this function _must_
+return `zero(T)`.
+
+In most cases, this function should return the smallest upper bound, but it may
+return a larger value if the smallest upper bound is expensive to compute.
+"""
+function distance_to_set(::Any, set::MOI.AbstractSet)
+    return error(
+        "distance_to_set for set type $(typeof(set)) has not been " *
+        "implemented yet.",
+    )
+end
+
+###
+### MOI.AbstractScalarSets
+###
+
+function distance_to_set(x::T, set::MOI.LessThan{T}) where {T<:Real}
+    return max(x - set.upper, zero(T))
+end
+
+function distance_to_set(x::T, set::MOI.GreaterThan{T}) where {T<:Real}
+    return max(set.lower - x, zero(T))
+end
+
+function distance_to_set(x::T, set::MOI.EqualTo{T}) where {T<:Number}
+    return abs(set.value - x)
+end
+
+function distance_to_set(x::T, set::MOI.Interval{T}) where {T<:Real}
+    return max(x - set.upper, set.lower - x, zero(T))
+end
+
+function distance_to_set(x::T, ::MOI.ZeroOne) where {T<:Real}
+    return min(abs(x - zero(T)), abs(x - one(T)))
+end
+
+function distance_to_set(x::T, ::MOI.Integer) where {T<:Real}
+    return abs(x - round(x))
+end
+
+function distance_to_set(x::T, set::MOI.Semicontinuous{T}) where {T<:Real}
+    return min(max(x - set.upper, set.lower - x, zero(T)), abs(x))
+end
+
+function distance_to_set(x::T, set::MOI.Semiinteger{T}) where {T<:Real}
+    d = max(ceil(set.lower) - x, x - floor(set.upper), abs(x - round(x)))
+    return min(d, abs(x))
+end
+
+###
+### MOI.AbstractVectorSets
+###
+
+function _check_dimension(v::AbstractVector, s)
+    if length(v) != MOI.dimension(s)
+        throw(DimensionMismatch("Mismatch between value and set"))
+    end
+    return
+end
+
+function distance_to_set(
+    x::AbstractVector{T},
+    set::MOI.Nonnegatives,
+) where {T<:Real}
+    _check_dimension(x, set)
+    return LinearAlgebra.norm(max(-xi, zero(T)) for xi in x)
+end
+
+function distance_to_set(
+    x::AbstractVector{T},
+    set::MOI.Nonpositives,
+) where {T<:Real}
+    _check_dimension(x, set)
+    return LinearAlgebra.norm(max(xi, zero(T)) for xi in x)
+end
+
+function distance_to_set(
+    x::AbstractVector{T},
+    set::MOI.Zeros,
+) where {T<:Number}
+    _check_dimension(x, set)
+    return LinearAlgebra.norm(x)
+end
+
+function distance_to_set(
+    x::AbstractVector{T},
+    set::MOI.Reals,
+) where {T<:Real}
+    _check_dimension(x, set)
+    return zero(T)
+end

--- a/src/Utilities/distance_to_set.jl
+++ b/src/Utilities/distance_to_set.jl
@@ -23,9 +23,9 @@ d(x, \\mathcal{K}) = \\min_{y \\in \\mathcal{K}} || x - y ||
 ```
 where ``x`` is `point` and ``\\mathcal{K}`` is `set`. The norm is computed as:
 ```math
-||x|| = \\sqrt{\\texttt{set_dot}(x, x, \\mathcal{K})}
+||x|| = \\sqrt{f(x, x, \\mathcal{K})}
 ```
-where ``\\texttt{set_dot}`` is [`Utilities.set_dot`](@ref).
+where ``f`` is [`Utilities.set_dot`](@ref).
 
 In the default case, where the set does not have a specialized method for
 [`Utilities.set_dot`](@ref), the norm is equivalent to the Euclidean norm
@@ -36,10 +36,13 @@ In the default case, where the set does not have a specialized method for
 In most cases, `distance_to_set` should return the smallest upper bound, but it
 may return a larger value if the smallest upper bound is expensive to compute.
 
-For example, given an epigraph from of a conic set, ``(t, x) \\in \\mathcal{K}``,
-it may be simpler to return ``\\delta`` such that
-``(t + \\delta, x) \\in \\mathcal{K}``, rather than computing the nearest
-projection onto ``\\mathcal{K}``.
+For example, given an epigraph from of a conic set, ``\\{(t, x) | f(x) \\le t\\}``,
+it may be simpler to return ``\\delta`` such that ``f(x) \\le t + \\delta``,
+rather than computing the nearest projection onto the set.
+
+If the distance is not the smallest upper bound, the docstring of the
+appropriate `distance_to_set` method _must_ describe the way that the distance
+is computed.
 """
 function distance_to_set(::Any, set::MOI.AbstractSet)
     return error(

--- a/test/Utilities/distance_to_set.jl
+++ b/test/Utilities/distance_to_set.jl
@@ -1,0 +1,132 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestFeasibilityChecker
+
+using Test
+
+import MathOptInterface
+
+const MOI = MathOptInterface
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function test_unsupported()
+    @test_throws(
+        ErrorException,
+        MOI.Utilities.distance_to_set([1.0, 1.0], MOI.Complements(2)),
+    )
+    return
+end
+
+function test_lessthan()
+    @test MOI.Utilities.distance_to_set(1.0, MOI.LessThan(2.0)) ≈ 0.0
+    @test MOI.Utilities.distance_to_set(1.0, MOI.LessThan(0.5)) ≈ 0.5
+    return
+end
+
+function test_greaterthan()
+    @test MOI.Utilities.distance_to_set(1.0, MOI.GreaterThan(2.0)) ≈ 1.0
+    @test MOI.Utilities.distance_to_set(1.0, MOI.GreaterThan(0.5)) ≈ 0.0
+    return
+end
+
+function test_equalto()
+    @test MOI.Utilities.distance_to_set(1.0, MOI.EqualTo(2.0)) ≈ 1.0
+    @test MOI.Utilities.distance_to_set(1.0, MOI.EqualTo(0.5)) ≈ 0.5
+    return
+end
+
+function test_interval()
+    @test MOI.Utilities.distance_to_set(1.0, MOI.Interval(1.0, 2.0)) ≈ 0.0
+    @test MOI.Utilities.distance_to_set(0.5, MOI.Interval(1.0, 2.0)) ≈ 0.5
+    @test MOI.Utilities.distance_to_set(2.75, MOI.Interval(1.0, 2.0)) ≈ 0.75
+    return
+end
+
+function test_zeroone()
+    @test MOI.Utilities.distance_to_set(0.6, MOI.ZeroOne()) ≈ 0.4
+    @test MOI.Utilities.distance_to_set(-0.01, MOI.ZeroOne()) ≈ 0.01
+    @test MOI.Utilities.distance_to_set(1.01, MOI.ZeroOne()) ≈ 0.01
+    return
+end
+
+function test_integer()
+    @test MOI.Utilities.distance_to_set(0.6, MOI.Integer()) ≈ 0.4
+    @test MOI.Utilities.distance_to_set(3.1, MOI.Integer()) ≈ 0.1
+    @test MOI.Utilities.distance_to_set(-0.01, MOI.Integer()) ≈ 0.01
+    @test MOI.Utilities.distance_to_set(1.01, MOI.Integer()) ≈ 0.01
+    return
+end
+
+function test_semicontinuous()
+    s = MOI.Semicontinuous(2.0, 4.0)
+    @test MOI.Utilities.distance_to_set(-2.0, s) ≈ 2.0
+    @test MOI.Utilities.distance_to_set(0.5, s) ≈ 0.5
+    @test MOI.Utilities.distance_to_set(1.9, s) ≈ 0.1
+    @test MOI.Utilities.distance_to_set(2.1, s) ≈ 0.0
+    @test MOI.Utilities.distance_to_set(4.1, s) ≈ 0.1
+    return
+end
+
+function test_semiintger()
+    s = MOI.Semiinteger(1.9, 4.0)
+    @test MOI.Utilities.distance_to_set(-2.0, s) ≈ 2.0
+    @test MOI.Utilities.distance_to_set(0.5, s) ≈ 0.5
+    @test MOI.Utilities.distance_to_set(1.9, s) ≈ 0.1
+    @test MOI.Utilities.distance_to_set(2.1, s) ≈ 0.1
+    @test MOI.Utilities.distance_to_set(4.1, s) ≈ 0.1
+    return
+end
+
+function test_nonnegatives()
+    @test_throws(
+        DimensionMismatch,
+        MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.Nonnegatives(1))
+    )
+    @test MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.Nonnegatives(2)) ≈ 1.0
+    return
+end
+
+function test_nonpositives()
+    @test_throws(
+        DimensionMismatch,
+        MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.Nonpositives(1))
+    )
+    @test MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.Nonpositives(2)) ≈ 1.0
+    return
+end
+
+function test_reals()
+    @test_throws(
+        DimensionMismatch,
+        MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.Reals(1))
+    )
+    @test MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.Reals(2)) ≈ 0.0
+    return
+end
+
+function test_zeros()
+    @test_throws(
+        DimensionMismatch,
+        MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.Zeros(1))
+    )
+    @test MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.Zeros(2)) ≈ sqrt(2)
+    return
+end
+
+end
+
+TestFeasibilityChecker.runtests()


### PR DESCRIPTION
Docs: https://jump.dev/MathOptInterface.jl/previews/PR2048/submodules/Utilities/reference/#Set-utilities

Reviving the ghost of https://github.com/jump-dev/MathOptInterface.jl/pull/1023

These definitions have been working fine in JuMP, and providing a public API will let external packages add new definitions (even if it's piracy). x-ref #2033.

The up-for-debate topic is the fact, after some thinking, I called it an upper bound on the Euclidean distance. I think this resolves the debate of which distance to use, and how to define it for various sets.

It's _always_ the Euclidean distance between the point and the set, it just might not be the smallest distance. It will be `0` if the point is within the set.

That'd let us define:
```julia
function distance_to_set(
    point::AbstractVector{T},
    set::MOI.ExponentialCone,
) where {T<:Real}
    _check_dimension(point, set)
    x, y, z = point
    # y * e^(x / y) <= z, y > 0
    if y <= 0
        return sqrt((y + eps(T))^2 + min(0, z)^2)
    end
    return max(0.0, y * exp(x / y) - z)
end
```

with tests like
```Julia
function test_exponentialcone()
    @test_throws(
        DimensionMismatch,
        MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.ExponentialCone())
    )
    for (x, d) in [
        [1.0, 1.0, 1.0] => exp(1) - 1.0,
        [1.0, 1.0, 2.0] => exp(1) - 2.0,
        [1.0, 1.0, exp(1)] => 0.0,
        [1.0, 1.0, exp(1) + 0.1] => 0.0,
        [2.0, 0.5, 0.5 * exp(2 / 0.5)] => 0.0,
        [2.0, 0.0, 1.0] => eps(Float64),
        [2.0, -1.0, 1.0] => 1 + eps(Float64),
    ]
        @test MOI.Utilities.distance_to_set(x, MOI.ExponentialCone()) ≈ d
    end
    return
end
```