### PR TITLE
[Nonlinear] fix situations in which the result of ^ is Complex

### DIFF
--- a/src/FileFormats/NL/NL.jl
+++ b/src/FileFormats/NL/NL.jl
@@ -7,6 +7,8 @@
 module NL
 
 import MathOptInterface
+import NaNMath
+
 const MOI = MathOptInterface
 
 include("NLExpr.jl")

--- a/src/FileFormats/NL/NLExpr.jl
+++ b/src/FileFormats/NL/NLExpr.jl
@@ -500,5 +500,15 @@ function _evaluate(
     for n in 1:N
         args[n], head_i = _evaluate(terms[head_i], terms, x, head_i)
     end
+    # A few special cases to work-around domain issues and other mistakes.
+    if f === ifelse
+        # ifelse requires ::Bool as the first argument, not ::Float64.
+        @assert N == 3
+        return ifelse(Bool(args[1]), args[2], args[3]), head_i
+    elseif f === ^
+        return NaNMath.pow(args...), head_i
+    elseif f === log
+        return NaNMath.log(args...), head_i
+    end
     return is_nary ? f(args) : f(args...), head_i
 end

--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -301,7 +301,7 @@ function _forward_eval_ϵ(
                         partials_storage_ϵ[ix1] = zero_ϵ
                     else
                         partials_storage_ϵ[ix1] = ForwardDiff.partials(
-                            exponent_gnum * base_gnum^(exponent_gnum - 1),
+                            exponent_gnum * pow(base_gnum, exponent_gnum - 1),
                         )
                     end
                     result_gnum = ForwardDiff.Dual{TAG}(

--- a/test/FileFormats/NL/NL.jl
+++ b/test/FileFormats/NL/NL.jl
@@ -824,6 +824,17 @@ function test_eval_binary_specialcases()
     end
 end
 
+function test_evaluate_domain_error()
+    x = MOI.VariableIndex(1)
+    expr = NL._NLExpr(:(ifelse($x > 0, log($x), 0.0)))
+    @test NL._evaluate(expr, Dict(x => 1.1)) == log(1.1)
+    @test NL._evaluate(expr, Dict(x => 0.0)) == 0.0
+    expr = NL._NLExpr(:(ifelse($x > 0, $x^1.5, -(-$x)^1.5)))
+    @test NL._evaluate(expr, Dict(x => 1.1)) ≈ 1.1^1.5
+    @test NL._evaluate(expr, Dict(x => -1.1)) ≈ -(1.1^1.5)
+    return
+end
+
 """
     test_issue_79()
 

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -808,6 +808,18 @@ function test_evaluate_comparison()
     return
 end
 
+function test_evaluate_domain_error()
+    model = Nonlinear.Model()
+    x = MOI.VariableIndex(1)
+    ex = Nonlinear.add_expression(model, :(ifelse($x > 0, log($x), 0.0)))
+    @test Nonlinear.evaluate(Dict(x => 1.1), model, ex) == log(1.1)
+    @test Nonlinear.evaluate(Dict(x => 0.0), model, ex) == 0.0
+    ex = Nonlinear.add_expression(model, :(ifelse($x > 0, $x^1.5, (-$x)^1.5)))
+    @test Nonlinear.evaluate(Dict(x => 1.1), model, ex) ≈ 1.1^1.5
+    @test Nonlinear.evaluate(Dict(x => -1.1), model, ex) ≈ -(1.1^1.5)
+    return
+end
+
 function test_evaluate_logic()
     model = Nonlinear.Model()
     x = MOI.VariableIndex(1)

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -948,6 +948,19 @@ function test_max_operator()
     return
 end
 
+function test_pow_complex_result()
+    r = Nonlinear.OperatorRegistry()
+    x = [-1.0, 1.5]
+    @test isnan(Nonlinear.eval_multivariate_function(r, :^, x))
+    g = zeros(2)
+    Nonlinear.eval_multivariate_gradient(r, :^, g, x)
+    @test all(isnan, g)
+    H = LinearAlgebra.LowerTriangular(zeros(2, 2))
+    Nonlinear.eval_multivariate_hessian(r, :^, H, x)
+    @test all(iszero, H)
+    return
+end
+
 end
 
 TestNonlinear.runtests()

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -970,6 +970,7 @@ function test_pow_complex_result()
     H = LinearAlgebra.LowerTriangular(zeros(2, 2))
     Nonlinear.eval_multivariate_hessian(r, :^, H, x)
     @test all(iszero, H)
+    @test Nonlinear.eval_multivariate_function(r, :^, Int[-2, 3]) == -8
     return
 end
 

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -814,7 +814,7 @@ function test_evaluate_domain_error()
     ex = Nonlinear.add_expression(model, :(ifelse($x > 0, log($x), 0.0)))
     @test Nonlinear.evaluate(Dict(x => 1.1), model, ex) == log(1.1)
     @test Nonlinear.evaluate(Dict(x => 0.0), model, ex) == 0.0
-    ex = Nonlinear.add_expression(model, :(ifelse($x > 0, $x^1.5, (-$x)^1.5)))
+    ex = Nonlinear.add_expression(model, :(ifelse($x > 0, $x^1.5, -(-$x)^1.5)))
     @test Nonlinear.evaluate(Dict(x => 1.1), model, ex) ≈ 1.1^1.5
     @test Nonlinear.evaluate(Dict(x => -1.1), model, ex) ≈ -(1.1^1.5)
     return

--- a/test/Nonlinear/ReverseAD.jl
+++ b/test/Nonlinear/ReverseAD.jl
@@ -988,6 +988,24 @@ function test_jacobians_and_jacvec_with_subexpressions()
     return
 end
 
+function test_pow_complex_result()
+    x = MOI.VariableIndex(1)
+    model = Nonlinear.Model()
+    Nonlinear.set_objective(model, :(ifelse($x > 0, $x^1.5, -(-$x)^1.5)))
+    evaluator = Nonlinear.Evaluator(model, Nonlinear.SparseReverseMode(), [x])
+    MOI.initialize(evaluator, [:Grad, :Jac, :Hess])
+    x = [-2.0]
+    @test MOI.eval_objective(evaluator, x) ≈ -(2^1.5)
+    g = [NaN]
+    MOI.eval_objective_gradient(evaluator, g, x)
+    @test g ≈ [1.5 * 2.0^0.5]
+    @test MOI.hessian_lagrangian_structure(evaluator) == [(1, 1)]
+    H = [NaN]
+    MOI.eval_hessian_lagrangian(evaluator, H, x, 1.5, Float64[])
+    @test H ≈ 1.5 .* [-0.5 * 1.5 / sqrt(2.0)]
+    return
+end
+
 end  # module
 
 TestReverseAD.runtests()


### PR DESCRIPTION
Part of #1996 

This now works, where previously it errored.

```julia
julia> using JuMP, Ipopt

julia> p = 1.5
1.5

julia> model = Model(Ipopt.Optimizer)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: Ipopt

julia> @variable(model, -10 <= x <= 10, start = 1.0)
x

julia> @NLobjective(model, Min, ifelse(x > 0, x^p, -(-x)^p))

julia> optimize!(model)

******************************************************************************
This program contains Ipopt, a library for large-scale nonlinear optimization.
 Ipopt is released as open source code under the Eclipse Public License (EPL).
         For more information visit https://github.com/coin-or/Ipopt
******************************************************************************

This is Ipopt version 3.14.4, running with linear solver MUMPS 5.4.1.

Number of nonzeros in equality constraint Jacobian...:        0
Number of nonzeros in inequality constraint Jacobian.:        0
Number of nonzeros in Lagrangian Hessian.............:        1

Total number of variables............................:        1
                     variables with only lower bounds:        0
                variables with lower and upper bounds:        1
                     variables with only upper bounds:        0
Total number of equality constraints.................:        0
Total number of inequality constraints...............:        0
        inequality constraints with only lower bounds:        0
   inequality constraints with lower and upper bounds:        0
        inequality constraints with only upper bounds:        0

iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  1.0000000e+00 0.00e+00 1.50e+00  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1 -4.3911148e-01 0.00e+00 8.71e-01  -1.0 1.58e+00    -  8.50e-01 1.00e+00f  1
   2 -3.1176893e+01 0.00e+00 4.24e+00  -1.0 2.60e+01   0.0 3.94e-01 3.59e-01f  1
   3 -3.1397342e+01 0.00e+00 1.70e-01  -1.0 7.60e-01    -  1.00e+00 6.14e-02f  2
   4 -3.1595906e+01 0.00e+00 1.05e-05  -1.7 4.19e-02    -  1.00e+00 1.00e+00f  1
   5 -3.1622629e+01 0.00e+00 1.88e-07  -3.8 5.63e-03    -  1.00e+00 1.00e+00f  1
   6 -3.1622775e+01 0.00e+00 5.67e-12  -5.7 3.09e-05    -  1.00e+00 1.00e+00f  1
   7 -3.1622777e+01 0.00e+00 1.65e-16  -8.6 3.88e-07    -  1.00e+00 1.00e+00f  1

Number of Iterations....: 7

                                   (scaled)                 (unscaled)
Objective...............:  -3.1622777073519540e+01   -3.1622777073519540e+01
Dual infeasibility......:   1.6540384261438127e-16    1.6540384261438127e-16
Constraint violation....:   0.0000000000000000e+00    0.0000000000000000e+00
Variable bound violation:   9.9471709091858429e-08    9.9471709091858429e-08
Complementarity.........:   2.5059009350611344e-09    2.5059009350611344e-09
Overall NLP error.......:   2.5059009350611344e-09    2.5059009350611344e-09


Number of objective function evaluations             = 13
Number of objective gradient evaluations             = 8
Number of equality constraint evaluations            = 0
Number of inequality constraint evaluations          = 0
Number of equality constraint Jacobian evaluations   = 0
Number of inequality constraint Jacobian evaluations = 0
Number of Lagrangian Hessian evaluations             = 7
Total seconds in IPOPT                               = 1.423

EXIT: Optimal Solution Found.

julia> solution_summary(model)
* Solver : Ipopt

* Status
  Termination status : LOCALLY_SOLVED
  Primal status      : FEASIBLE_POINT
  Dual status        : FEASIBLE_POINT
  Message from the solver:
  "Solve_Succeeded"

* Candidate solution
  Objective value      : -3.16228e+01

* Work counters
  Solve time (sec)   : 1.58024e+00
```