### PR TITLE
Remove special iterators from CleverDict

### DIFF
--- a/src/Utilities/CleverDicts.jl
+++ b/src/Utilities/CleverDicts.jl
@@ -148,13 +148,6 @@ function Base.haskey(c::CleverDict{K}, key::K) where {K}
     return haskey(c.dict, key)
 end
 
-function Base.keys(c::CleverDict{K}) where {K}
-    if _is_dense(c)
-        return K[_inverse_hash(c, i) for i in 1:length(c.vector)]
-    end
-    return collect(keys(c.dict))
-end
-
 function Base.get(c::CleverDict, key, default)
     if _is_dense(c)
         if !haskey(c, key)
@@ -315,8 +308,6 @@ function Base.resize!(c::CleverDict{K,V}, n) where {K,V}
     end
     return
 end
-
-Base.values(d::CleverDict) = _is_dense(d) ? d.vector : values(d.dict)
 
 # TODO `map!(f, values(dict::AbstractDict))` requires Julia 1.2 or later,
 #      use `map_values` once we drop Julia 1.1 and earlier.

--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -154,7 +154,7 @@ function MOI.get(
     v::VectorOfConstraints{F,S},
     ::MOI.ListOfConstraintIndices{F,S},
 ) where {F,S}
-    return keys(v.constraints)
+    return collect(keys(v.constraints))
 end
 
 function MOI.modify(


### PR DESCRIPTION
These were no help at all, on the contrary.

Before:
```
julia> main()
typeof(keys(d)) = Vector{MathOptInterface.VariableIndex}
  0.361756 seconds (2 allocations: 762.939 MiB, 19.29% gc time)
  0.064835 seconds
```
After:
```
julia> main()
typeof(keys(d)) = Base.KeySet{MathOptInterface.VariableIndex, MathOptInterface.Utilities.CleverDicts.CleverDict{MathOptInterface.VariableIndex, Int64, typeof(MathOptInterface.Utilities.CleverDicts.key_to_index), typeof(MathOptInterface.Utilities.CleverDicts.index_to_key)}}
  0.032200 seconds
  0.062263 seconds
```
Code:
```julia

using MathOptInterface

const CleverDicts = MathOptInterface.Utilities.CleverDicts

function build(N::Int)
    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex, Int}()
    for i in 1:N
        CleverDicts.add_item(d, i)
    end
    return d
end

function test2_k(d, N)
    val = 0
    for k in keys(d)
        val += k.value
    end
    @assert val == N*(N+1)/ 2 #sum(1:N)
end

function test2_v(d, N)
    val = 0
    for v in values(d)
        val += v
    end
    @assert val == N*(N+1)/ 2 #sum(1:N)
end

function main()
    N = 100_000_000
    d = build(N)

    @show typeof(keys(d))

    @time test2_k(d, N)
    @time test2_v(d, N)

end

main()
```