### PR TITLE
[Utilities] add distance_to_set for SecondOrderCone

### DIFF
--- a/src/Utilities/distance_to_set.jl
+++ b/src/Utilities/distance_to_set.jl
@@ -204,35 +204,13 @@ function distance_to_set(
     # Parikh, N., & Boyd, S. (2014). Proximal algorithms. Foundations and
     # trends in Optimization, page 184, section 6.3.2.
     t, rhs = x[1], LinearAlgebra.norm(@views x[2:end])
+    if t >= rhs
+        return zero(T) # The point is feasible!
+    end
     if rhs <= -t  # Projection to the point (0, [0])
         return LinearAlgebra.norm(x)
-    elseif t >= rhs  # Projection to the point (t, x)
-        return zero(T)
     end
     # Projection to the point (t, x) + 0.5 * (|x|_2 - t, (t/|x|_2 - 1) * x)
-    c = t / rhs - one(T)
-    return sqrt((rhs - t)^2 + sum((c * x[i])^2 for i in 2:length(x))) / 2
-end
+    return sqrt(2) / 2 * abs(t - rhs)
 
-"""
-    distance_to_set(::ProjectionUpperBoundDistance, x, ::MOI.ExponentialCone)
-
-Given `x = (u, v, w)`, this is distance:
-
- * `d`, such that `v * exp(u / v) <= w + d`, if `v > 0`
- * `√(1^2 + d^2)`, such that `1 * exp(u / 1) <= w + d`, if `v <= 0`.
-"""
-function distance_to_set(
-    ::ProjectionUpperBoundDistance,
-    x::AbstractVector{T},
-    set::MOI.ExponentialCone,
-) where {T<:Real}
-    _check_dimension(x, set)
-    u, v, w = x[1], x[2], x[3]
-    if v <= 0
-        # Projection to the point (u, 1, max(w, exp(u)))
-        return sqrt((1 - v)^2 + max(zero(T), exp(u) - w)^2)
-    end
-    # Projection to the point (u, v, max(w, v * exp(u / v)))
-    return max(zero(T), v * exp(u / v) - w)
 end

--- a/src/Utilities/distance_to_set.jl
+++ b/src/Utilities/distance_to_set.jl
@@ -193,3 +193,46 @@ function distance_to_set(
     _check_dimension(x, set)
     return zero(T)
 end
+
+function distance_to_set(
+    ::ProjectionUpperBoundDistance,
+    x::AbstractVector{T},
+    set::MOI.SecondOrderCone,
+) where {T<:Real}
+    _check_dimension(x, set)
+    # Projections come from:
+    # Parikh, N., & Boyd, S. (2014). Proximal algorithms. Foundations and
+    # trends in Optimization, page 184, section 6.3.2.
+    t, rhs = x[1], LinearAlgebra.norm(@views x[2:end])
+    if rhs <= -t  # Projection to the point (0, [0])
+        return LinearAlgebra.norm(x)
+    elseif t >= rhs  # Projection to the point (t, x)
+        return zero(T)
+    end
+    # Projection to the point (t, x) + 0.5 * (|x|_2 - t, (t/|x|_2 - 1) * x)
+    c = t / rhs - one(T)
+    return sqrt((rhs - t)^2 + sum((c * x[i])^2 for i in 2:length(x))) / 2
+end
+
+"""
+    distance_to_set(::ProjectionUpperBoundDistance, x, ::MOI.ExponentialCone)
+
+Given `x = (u, v, w)`, this is distance:
+
+ * `d`, such that `v * exp(u / v) <= w + d`, if `v > 0`
+ * `√(1^2 + d^2)`, such that `1 * exp(u / 1) <= w + d`, if `v <= 0`.
+"""
+function distance_to_set(
+    ::ProjectionUpperBoundDistance,
+    x::AbstractVector{T},
+    set::MOI.ExponentialCone,
+) where {T<:Real}
+    _check_dimension(x, set)
+    u, v, w = x[1], x[2], x[3]
+    if v <= 0
+        # Projection to the point (u, 1, max(w, exp(u)))
+        return sqrt((1 - v)^2 + max(zero(T), exp(u) - w)^2)
+    end
+    # Projection to the point (u, v, max(w, v * exp(u / v)))
+    return max(zero(T), v * exp(u / v) - w)
+end

--- a/src/Utilities/distance_to_set.jl
+++ b/src/Utilities/distance_to_set.jl
@@ -212,5 +212,4 @@ function distance_to_set(
     end
     # Projection to the point (t, x) + 0.5 * (|x|_2 - t, (t/|x|_2 - 1) * x)
     return sqrt(2) / 2 * abs(t - rhs)
-
 end

--- a/test/Utilities/distance_to_set.jl
+++ b/test/Utilities/distance_to_set.jl
@@ -143,20 +143,6 @@ function test_secondordercone()
     return
 end
 
-function test_exponentialcone()
-    @test_throws(
-        DimensionMismatch,
-        MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.ExponentialCone())
-    )
-    set = MOI.ExponentialCone()
-    @test MOI.Utilities.distance_to_set([1, 1, exp(1)], set) ≈ 0.0
-    @test MOI.Utilities.distance_to_set([2, 3, 3], set) ≈ 3 * exp(2 / 3) - 3
-    @test MOI.Utilities.distance_to_set([2, -1, 3], set) ≈
-          sqrt(2^2 + (exp(2) - 3)^2)
-    @test MOI.Utilities.distance_to_set([10.0, 0.01, 0.0], set) ≈ Inf
-    return
-end
-
 end
 
 TestFeasibilityChecker.runtests()

--- a/test/Utilities/distance_to_set.jl
+++ b/test/Utilities/distance_to_set.jl
@@ -8,6 +8,7 @@ module TestFeasibilityChecker
 
 using Test
 
+import LinearAlgebra
 import MathOptInterface
 
 const MOI = MathOptInterface
@@ -124,6 +125,33 @@ function test_zeros()
         MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.Zeros(1))
     )
     @test MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.Zeros(2)) ≈ sqrt(2)
+    return
+end
+
+function test_secondordercone()
+    @test_throws(
+        DimensionMismatch,
+        MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.SecondOrderCone(3))
+    )
+    set = MOI.SecondOrderCone(3)
+    @test MOI.Utilities.distance_to_set([sqrt(2), 1, 1], set) ≈ 0.0
+    @test MOI.Utilities.distance_to_set([-sqrt(2), 1, 1], set) ≈ 2
+    @test MOI.Utilities.distance_to_set([-2, 1, 1], set) ≈ sqrt(6)
+    # According to Boyd, (t, x) = (1, [1, 1]), projects to:
+    d = ((1/2) * (1 + 1 / √2) * [√2, 1, 1]) .- [1, 1, 1]
+    @test MOI.Utilities.distance_to_set([1, 1, 1], set) ≈ LinearAlgebra.norm(d)
+    return
+end
+
+function test_exponentialcone()
+    @test_throws(
+        DimensionMismatch,
+        MOI.Utilities.distance_to_set([-1.0, 1.0], MOI.ExponentialCone())
+    )
+    set = MOI.ExponentialCone()
+    @test MOI.Utilities.distance_to_set([1, 1, exp(1)], set) ≈ 0.0
+    @test MOI.Utilities.distance_to_set([2, 3, 3], set) ≈ 3 * exp(2 / 3) - 3
+    @test MOI.Utilities.distance_to_set([2, -1, 3], set) ≈ sqrt(2^2 + (exp(2) - 3)^2)
     return
 end
 

--- a/test/Utilities/distance_to_set.jl
+++ b/test/Utilities/distance_to_set.jl
@@ -138,7 +138,7 @@ function test_secondordercone()
     @test MOI.Utilities.distance_to_set([-sqrt(2), 1, 1], set) ≈ 2
     @test MOI.Utilities.distance_to_set([-2, 1, 1], set) ≈ sqrt(6)
     # According to Boyd, (t, x) = (1, [1, 1]), projects to:
-    d = ((1/2) * (1 + 1 / √2) * [√2, 1, 1]) .- [1, 1, 1]
+    d = ((1 / 2) * (1 + 1 / √2) * [√2, 1, 1]) .- [1, 1, 1]
     @test MOI.Utilities.distance_to_set([1, 1, 1], set) ≈ LinearAlgebra.norm(d)
     return
 end
@@ -151,7 +151,8 @@ function test_exponentialcone()
     set = MOI.ExponentialCone()
     @test MOI.Utilities.distance_to_set([1, 1, exp(1)], set) ≈ 0.0
     @test MOI.Utilities.distance_to_set([2, 3, 3], set) ≈ 3 * exp(2 / 3) - 3
-    @test MOI.Utilities.distance_to_set([2, -1, 3], set) ≈ sqrt(2^2 + (exp(2) - 3)^2)
+    @test MOI.Utilities.distance_to_set([2, -1, 3], set) ≈
+          sqrt(2^2 + (exp(2) - 3)^2)
     return
 end
 

--- a/test/Utilities/distance_to_set.jl
+++ b/test/Utilities/distance_to_set.jl
@@ -153,6 +153,7 @@ function test_exponentialcone()
     @test MOI.Utilities.distance_to_set([2, 3, 3], set) ≈ 3 * exp(2 / 3) - 3
     @test MOI.Utilities.distance_to_set([2, -1, 3], set) ≈
           sqrt(2^2 + (exp(2) - 3)^2)
+    @test MOI.Utilities.distance_to_set([10.0, 0.01, 0.0], set) ≈ Inf
     return
 end
 


### PR DESCRIPTION
Part of https://github.com/jump-dev/MathOptInterface.jl/issues/2033. 

We'll need to decide what sets we use exact methods for, and what we make up.

Boyd's book is: https://web.stanford.edu/~boyd/papers/pdf/prox_algs.pdf