### PR TITLE
Add checks for test_nonlinear_invalid

### DIFF
--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -1089,7 +1089,7 @@ function test_nonlinear_invalid(
     @requires T == Float64
     @requires MOI.supports(model, MOI.NLPBlock())
     @requires _supports(config, MOI.optimize!)
-    MOI.add_variable(model)
+    x = MOI.add_variable(model)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     MOI.set(
         model,
@@ -1098,6 +1098,14 @@ function test_nonlinear_invalid(
     )
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.INVALID_MODEL
+    @test MOI.get(model, MOI.ResultCount()) == 0
+    @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
+    attr = MOI.VariablePrimal()
+    err = MOI.ResultIndexBoundsError(attr, 0)
+    @test_throws err MOI.get(model, attr, x)
+    if _supports(config, MOI.ConstraintDual)
+        @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
+    end
     return
 end
 

--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -1089,7 +1089,7 @@ function test_nonlinear_invalid(
     @requires T == Float64
     @requires MOI.supports(model, MOI.NLPBlock())
     @requires _supports(config, MOI.optimize!)
-    x = MOI.add_variable(model)
+    _ = MOI.add_variable(model)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     MOI.set(
         model,
@@ -1098,14 +1098,9 @@ function test_nonlinear_invalid(
     )
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.INVALID_MODEL
-    @test MOI.get(model, MOI.ResultCount()) == 0
     @test MOI.get(model, MOI.PrimalStatus()) == MOI.NO_SOLUTION
-    attr = MOI.VariablePrimal()
-    err = MOI.ResultIndexBoundsError(attr, 0)
-    @test_throws err MOI.get(model, attr, x)
-    if _supports(config, MOI.ConstraintDual)
-        @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
-    end
+    @test MOI.get(model, MOI.DualStatus()) == MOI.NO_SOLUTION
+    @test MOI.get(model, MOI.ResultCount()) == 0
     return
 end
 


### PR DESCRIPTION
When the model is invalid, it might be a common mistake from the user to not check the termination status and directly look at the solution. It might also be a common mistake of the solver to not clear the solution. When both sides make the mistake, it leads to confusion. This test makes sure that the solver clears the solution to avoid that situation.
This is the case for instance for https://github.com/jump-dev/PolyJuMP.jl/pull/80 where an MOI layer convert NL constraints to polynomial. I needed to add a few methods to make sure that the layer also catches the result getters in case there was an invalid model.