### PR TITLE
Add support for vector-valued objective functions

### DIFF
--- a/docs/src/submodules/Bridges/list_of_bridges.md
+++ b/docs/src/submodules/Bridges/list_of_bridges.md
@@ -78,6 +78,7 @@ These bridges are subtypes of [`Bridges.Objective.AbstractBridge`](@ref).
 Bridges.Objective.FunctionizeBridge
 Bridges.Objective.QuadratizeBridge
 Bridges.Objective.SlackBridge
+Bridges.Objective.VectorSlackBridge
 ```
 
 ## [Variable bridges](@id variable_bridges_ref)

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -341,7 +341,7 @@ function _general_bridge_tests(bridge::B) where {B<:AbstractBridge}
         MOI.get(bridge, MOI.NumberOfVariables())
     )
     if B <: Objective.AbstractBridge
-        Test.@test set_objective_function_type(B) <: MOI.AbstractScalarFunction
+        Test.@test set_objective_function_type(B) <: MOI.AbstractFunction
     end
     return
 end

--- a/src/Bridges/Constraint/single_bridge_optimizer.jl
+++ b/src/Bridges/Constraint/single_bridge_optimizer.jl
@@ -122,7 +122,7 @@ end
 
 function MOI.Bridges.is_bridged(
     ::SingleBridgeOptimizer,
-    ::Type{<:MOI.AbstractScalarFunction},
+    ::Type{<:MOI.AbstractFunction},
 )
     return false
 end

--- a/src/Bridges/Objective/Objective.jl
+++ b/src/Bridges/Objective/Objective.jl
@@ -17,6 +17,7 @@ include("single_bridge_optimizer.jl")
 include("bridges/functionize.jl")
 include("bridges/quadratize.jl")
 include("bridges/slack.jl")
+include("bridges/vector_slack.jl")
 
 """
     add_all_bridges(model, ::Type{T}) where {T}
@@ -29,6 +30,7 @@ function add_all_bridges(model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(model, FunctionizeBridge{T})
     MOI.Bridges.add_bridge(model, QuadratizeBridge{T})
     MOI.Bridges.add_bridge(model, SlackBridge{T})
+    MOI.Bridges.add_bridge(model, VectorSlackBridge{T})
     return
 end
 

--- a/src/Bridges/Objective/bridge.jl
+++ b/src/Bridges/Objective/bridge.jl
@@ -23,7 +23,7 @@ abstract type AbstractBridge <: MOI.Bridges.AbstractBridge end
 """
     supports_objective_function(
         BT::Type{<:MOI.Bridges.Objective.AbstractBridge},
-        F::Type{<:MOI.AbstractScalarFunction},
+        F::Type{<:MOI.AbstractFunction},
     )::Bool
 
 Return a `Bool` indicating whether the bridges of type `BT` support bridging
@@ -37,7 +37,7 @@ objective functions of type `F`.
 """
 function supports_objective_function(
     ::Type{<:AbstractBridge},
-    ::Type{<:MOI.AbstractScalarFunction},
+    ::Type{<:MOI.AbstractFunction},
 )
     return false
 end
@@ -45,7 +45,7 @@ end
 """
     concrete_bridge_type(
         BT::Type{<:MOI.Bridges.Objective.AbstractBridge},
-        F::Type{<:MOI.AbstractScalarFunction},
+        F::Type{<:MOI.AbstractFunction},
     )::Type
 
 Return the concrete type of the bridge supporting objective functions of type
@@ -56,14 +56,14 @@ This function can only be called if `MOI.supports_objective_function(BT, F)` is
 """
 function concrete_bridge_type(
     ::Type{BT},
-    ::Type{<:MOI.AbstractScalarFunction},
+    ::Type{<:MOI.AbstractFunction},
 ) where {BT}
     return BT
 end
 
 function concrete_bridge_type(
     b::MOI.Bridges.AbstractBridgeOptimizer,
-    F::Type{<:MOI.AbstractScalarFunction},
+    F::Type{<:MOI.AbstractFunction},
 )
     return concrete_bridge_type(MOI.Bridges.bridge_type(b, F), F)
 end
@@ -72,7 +72,7 @@ end
     bridge_objective(
         BT::Type{<:MOI.Bridges.Objective.AbstractBridge},
         model::MOI.ModelLike,
-        func::MOI.AbstractScalarFunction,
+        func::MOI.AbstractFunction,
     )::BT
 
 Bridge the objective function `func` using bridge `BT` to `model` and returns
@@ -86,7 +86,7 @@ a bridge object of type `BT`.
 function bridge_objective(
     ::Type{<:AbstractBridge},
     ::MOI.ModelLike,
-    func::MOI.AbstractScalarFunction,
+    func::MOI.AbstractFunction,
 )
     return throw(
         MOI.UnsupportedAttribute(MOI.ObjectiveFunction{typeof(func)}()),

--- a/src/Bridges/Objective/bridges/vector_slack.jl
+++ b/src/Bridges/Objective/bridges/vector_slack.jl
@@ -1,0 +1,173 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+"""
+    VectorSlackBridge{T,F,G}
+
+`VectorSlackBridge` implements the following reformulations:
+
+ * ``\\min\\{f(x)\\}`` into ``\\min\\{y\\;|\\; y - f(x) \\in \\mathbb{R}_+ \\}``
+ * ``\\max\\{f(x)\\}`` into ``\\max\\{y\\;|\\; f(x) - y \\in \\mathbb{R}_+ \\}``
+
+where `F` is the type of `f(x) - y`, `G` is the type of `f(x)`, and `T` is the
+coefficient type of `f(x)`.
+
+## Source node
+
+`VectorSlackBridge` supports:
+
+ * [`MOI.ObjectiveFunction{G}`](@ref)
+
+## Target nodes
+
+`VectorSlackBridge` creates:
+
+ * One variable node: [`MOI.VectorOfVariables`](@ref) in [`MOI.Reals`](@ref)
+ * One objective node: [`MOI.ObjectiveFunction{MOI.VectorOfVariables}`](@ref)
+ * One constraint node: `F`-in-[`MOI.Nonnegatives`](@ref)
+
+!!! warning
+    When using this bridge, changing the optimization sense is not supported.
+    Set the sense to `MOI.FEASIBILITY_SENSE` first to delete the bridge, then
+    set [`MOI.ObjectiveSense`](@ref) and re-add the objective.
+"""
+struct VectorSlackBridge{
+    T,
+    F<:MOI.AbstractVectorFunction,
+    G<:MOI.AbstractVectorFunction,
+} <: AbstractBridge
+    slack::MOI.VectorOfVariables
+    constraint::MOI.ConstraintIndex{F,MOI.Nonnegatives}
+end
+
+const VectorSlack{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{VectorSlackBridge{T},OT}
+
+function bridge_objective(
+    ::Type{VectorSlackBridge{T,F,G}},
+    model::MOI.ModelLike,
+    func::G,
+) where {T,F,G<:MOI.AbstractVectorFunction}
+    dim = MOI.output_dimension(func)
+    slack = MOI.VectorOfVariables(MOI.add_variables(model, dim))
+    MOI.set(model, MOI.ObjectiveFunction{MOI.VectorOfVariables}(), slack)
+    sense = MOI.get(model, MOI.ObjectiveSense())
+    if sense == MOI.FEASIBILITY_SENSE
+        error(
+            "Set `MOI.ObjectiveSense` before `MOI.ObjectiveFunction` when",
+            " using `MOI.Bridges.Objective.VectorSlackBridge`.",
+        )
+    end
+    f = if sense == MOI.MIN_SENSE
+        MOI.Utilities.operate(-, T, slack, func)
+    elseif sense == MOI.MAX_SENSE
+        MOI.Utilities.operate(-, T, func, slack)
+    end
+    set = MOI.Nonnegatives(dim)
+    ci = MOI.add_constraint(model, f, set)
+    return VectorSlackBridge{T,F,G}(slack, ci)
+end
+
+function supports_objective_function(
+    ::Type{<:VectorSlackBridge{T}},
+    ::Type{MOI.VectorOfVariables},
+) where {T}
+    return false
+end
+
+function supports_objective_function(
+    ::Type{<:VectorSlackBridge{T}},
+    ::Type{F},
+) where {T,F<:MOI.AbstractVectorFunction}
+    return MOI.Utilities.is_coefficient_type(F, T)
+end
+
+function MOI.Bridges.added_constrained_variable_types(
+    ::Type{<:VectorSlackBridge},
+)
+    return Tuple{Type}[]
+end
+
+function MOI.Bridges.added_constraint_types(
+    ::Type{<:VectorSlackBridge{T,F}},
+) where {T,F}
+    return Tuple{Type,Type}[(F, MOI.Nonnegatives)]
+end
+
+function MOI.Bridges.set_objective_function_type(::Type{<:VectorSlackBridge})
+    return MOI.VectorOfVariables
+end
+
+function concrete_bridge_type(
+    ::Type{<:VectorSlackBridge{T}},
+    G::Type{<:MOI.AbstractVectorFunction},
+) where {T}
+    F = MOI.Utilities.promote_operation(-, T, G, MOI.VectorOfVariables)
+    return VectorSlackBridge{T,F,G}
+end
+
+function MOI.get(bridge::VectorSlackBridge, ::MOI.NumberOfVariables)::Int64
+    return MOI.output_dimension(bridge.slack)
+end
+
+function MOI.get(bridge::VectorSlackBridge, ::MOI.ListOfVariableIndices)
+    return copy(bridge.slack.variables)
+end
+
+function MOI.get(
+    bridge::VectorSlackBridge{T,F},
+    ::MOI.NumberOfConstraints{F,MOI.Nonnegatives},
+)::Int64 where {T,F}
+    return 1
+end
+
+function MOI.get(
+    bridge::VectorSlackBridge{T,F},
+    ::MOI.ListOfConstraintIndices{F,MOI.Nonnegatives},
+) where {T,F}
+    return [bridge.constraint]
+end
+
+function MOI.delete(model::MOI.ModelLike, bridge::VectorSlackBridge)
+    MOI.delete(model, bridge.constraint)
+    MOI.delete(model, bridge.slack.variables)
+    return
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr_g::MOI.Bridges.ObjectiveFunctionValue{G},
+    bridge::VectorSlackBridge{T,F,G},
+) where {T,F,G}
+    N = attr_g.result_index
+    attr_f = MOI.Bridges.ObjectiveFunctionValue{MOI.VectorOfVariables}(N)
+    y_val = MOI.get(model, attr_f)
+    con_primal = MOI.get(model, MOI.ConstraintPrimal(), bridge.constraint)
+    sense = MOI.get(model, MOI.ObjectiveSense())
+    if sense == MOI.MIN_SENSE
+        # con_primal = y - func => func = y - con_primal
+        return y_val - con_primal
+    else
+        @assert sense == MOI.MAX_SENSE
+        # con_primal = func - y => func = con_primal + y
+        return con_primal + y_val
+    end
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    ::MOI.ObjectiveFunction{G},
+    bridge::VectorSlackBridge{T,F,G},
+) where {T,F,G<:MOI.AbstractVectorFunction}
+    con_f = MOI.get(model, MOI.ConstraintFunction(), bridge.constraint)
+    if MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
+        # con_f = y - func so we need to negate it. Nothing to do in the
+        # MAX_SENSE case.
+        con_f = MOI.Utilities.operate(-, T, con_f)
+    end
+    g = MOI.Utilities.remove_variable(con_f, bridge.slack.variables)
+    return MOI.Utilities.convert_approx(G, g)
+end

--- a/src/Bridges/Objective/map.jl
+++ b/src/Bridges/Objective/map.jl
@@ -12,7 +12,7 @@ bridging that type of objective function.
 """
 mutable struct Map <: AbstractDict{MOI.ObjectiveFunction,AbstractBridge}
     bridges::Dict{MOI.ObjectiveFunction,AbstractBridge}
-    function_type::Union{Nothing,Type{<:MOI.AbstractScalarFunction}}
+    function_type::Union{Nothing,Type{<:MOI.AbstractFunction}}
 end
 
 Map() = Map(Dict{MOI.ObjectiveFunction,AbstractBridge}(), nothing)
@@ -74,7 +74,7 @@ end
         map::Map,
         bridge::AbstractBridge,
         ::F,
-    ) where {F<:MOI.AbstractScalarFunction}
+    ) where {F<:MOI.AbstractFunction}
 
 Stores the mapping `attr => bridge` where `attr` is
 `MOI.ObjectiveFunction{F}()` and set [`function_type`](@ref) to `F`.
@@ -83,7 +83,7 @@ function add_key_for_bridge(
     map::Map,
     bridge::AbstractBridge,
     ::F,
-) where {F<:MOI.AbstractScalarFunction}
+) where {F<:MOI.AbstractFunction}
     attr = MOI.ObjectiveFunction{F}()
     map.function_type = F
     map.bridges[attr] = bridge

--- a/src/Bridges/Objective/single_bridge_optimizer.jl
+++ b/src/Bridges/Objective/single_bridge_optimizer.jl
@@ -94,21 +94,21 @@ end
 
 function MOI.Bridges.supports_bridging_objective_function(
     ::SingleBridgeOptimizer{BT},
-    F::Type{<:MOI.AbstractScalarFunction},
+    F::Type{<:MOI.AbstractFunction},
 ) where {BT}
     return supports_objective_function(BT, F)
 end
 
 function MOI.Bridges.is_bridged(
     bridge::SingleBridgeOptimizer,
-    F::Type{<:MOI.AbstractScalarFunction},
+    F::Type{<:MOI.AbstractFunction},
 )
     return MOI.Bridges.supports_bridging_objective_function(bridge, F)
 end
 
 function MOI.Bridges.bridge_type(
     ::SingleBridgeOptimizer{BT},
-    ::Type{<:MOI.AbstractScalarFunction},
+    ::Type{<:MOI.AbstractFunction},
 ) where {BT}
     return BT
 end

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -234,7 +234,7 @@ function added_constraint_types end
 """
     set_objective_function_type(
         BT::Type{<:Objective.AbstractBridge},
-    )::Type{<:MOI.AbstractScalarFunction}
+    )::Type{<:MOI.AbstractFunction}
 
 Return the type of objective function that bridges of concrete type `BT`
 set.

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -218,7 +218,7 @@ end
 """
     supports_bridging_objective_function(
         b::AbstractBridgeOptimizer,
-        F::Type{<:MOI.AbstractScalarFunction},
+        F::Type{<:MOI.AbstractFunction},
     )::Bool
 
 Return a `Bool` indicating whether `b` supports bridging objective functions of
@@ -226,7 +226,7 @@ type `F`.
 """
 function supports_bridging_objective_function(
     ::AbstractBridgeOptimizer,
-    ::Type{<:MOI.AbstractScalarFunction},
+    ::Type{<:MOI.AbstractFunction},
 )
     return false
 end
@@ -965,14 +965,14 @@ function MOI.supports(
 end
 
 """
-    struct ObjectiveFunctionValue{F<:MOI.AbstractScalarFunction} end
+    struct ObjectiveFunctionValue{F<:MOI.AbstractFunction} end
 
 Attribute for the value of the objective function of type `F`. If the objective
 of the objective function does not depend on `F`, the type `F` determines
 whether the computation is redirected to an objective bridge or to the
 underlying model.
 """
-struct ObjectiveFunctionValue{F<:MOI.AbstractScalarFunction}
+struct ObjectiveFunctionValue{F<:MOI.AbstractFunction}
     result_index::Int
 end
 
@@ -985,7 +985,7 @@ end
 function MOI.get(
     b::AbstractBridgeOptimizer,
     attr::ObjectiveFunctionValue{F},
-) where {F<:MOI.AbstractScalarFunction} # Need `<:` to avoid ambiguity
+) where {F<:MOI.AbstractFunction} # Need `<:` to avoid ambiguity
     obj_attr = MOI.ObjectiveFunction{F}()
     if is_bridged(b, obj_attr)
         return MOI.get(recursive_model(b), attr, bridge(b, obj_attr))
@@ -1046,7 +1046,7 @@ end
 function MOI.set(
     b::AbstractBridgeOptimizer,
     attr::MOI.ObjectiveFunction,
-    func::MOI.AbstractScalarFunction,
+    func::MOI.AbstractFunction,
 )
     if is_objective_bridged(b)
         # Clear objective function by setting sense to `MOI.FEASIBILITY_SENSE`

--- a/src/Bridges/debug.jl
+++ b/src/Bridges/debug.jl
@@ -493,7 +493,7 @@ end
 
 function debug(
     b::LazyBridgeOptimizer,
-    F::Type{<:MOI.AbstractScalarFunction};
+    F::Type{<:MOI.AbstractFunction};
     io::IO = Base.stdout,
 )
     MOI.Utilities.print_with_acronym(io, "Objective function of type `$F` is")

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -407,10 +407,7 @@ function is_bridged(
     return !MOI.supports_constraint(b.model, F, S)
 end
 
-function is_bridged(
-    b::LazyBridgeOptimizer,
-    F::Type{<:MOI.AbstractFunction},
-)
+function is_bridged(b::LazyBridgeOptimizer, F::Type{<:MOI.AbstractFunction})
     return !MOI.supports(b.model, MOI.ObjectiveFunction{F}())
 end
 
@@ -498,10 +495,7 @@ function bridge_type(
     return new_bt::Type
 end
 
-function bridge_type(
-    b::LazyBridgeOptimizer,
-    F::Type{<:MOI.AbstractFunction},
-)
+function bridge_type(b::LazyBridgeOptimizer, F::Type{<:MOI.AbstractFunction})
     bt = get(b.cached_bridge_type, (F,), nothing)
     if bt !== nothing
         return bt::Type

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -298,7 +298,7 @@ end
 
 Return the `ObjectiveNode` associated with constraint `F` in `b`.
 """
-function node(b::LazyBridgeOptimizer, F::Type{<:MOI.AbstractScalarFunction})
+function node(b::LazyBridgeOptimizer, F::Type{<:MOI.AbstractFunction})
     # If we support the objective function, the node is 0.
     if MOI.supports(b.model, MOI.ObjectiveFunction{F}())
         return ObjectiveNode(0)
@@ -409,7 +409,7 @@ end
 
 function is_bridged(
     b::LazyBridgeOptimizer,
-    F::Type{<:MOI.AbstractScalarFunction},
+    F::Type{<:MOI.AbstractFunction},
 )
     return !MOI.supports(b.model, MOI.ObjectiveFunction{F}())
 end
@@ -455,7 +455,7 @@ end
 
 function supports_bridging_objective_function(
     b::LazyBridgeOptimizer,
-    F::Type{<:MOI.AbstractScalarFunction},
+    F::Type{<:MOI.AbstractFunction},
 )
     return !iszero(bridge_index(b, F))
 end
@@ -500,7 +500,7 @@ end
 
 function bridge_type(
     b::LazyBridgeOptimizer,
-    F::Type{<:MOI.AbstractScalarFunction},
+    F::Type{<:MOI.AbstractFunction},
 )
     bt = get(b.cached_bridge_type, (F,), nothing)
     if bt !== nothing

--- a/src/Test/test_multiobjective.jl
+++ b/src/Test/test_multiobjective.jl
@@ -1,0 +1,186 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+function test_multiobjective_vector_of_variables(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorOfVariables
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.VectorOfVariables(x)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) == f
+    return
+end
+
+function test_multiobjective_vector_of_variables_delete(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorOfVariables
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.VectorOfVariables(x)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) == f
+    MOI.delete(model, x[1])
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ==
+          MOI.VectorOfVariables([x[2]])
+    return
+end
+
+function test_multiobjective_vector_of_variables_delete_all(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorOfVariables
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.VectorOfVariables(x)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) == f
+    MOI.delete(model, x[1])
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ==
+          MOI.VectorOfVariables([x[2]])
+    MOI.delete(model, x[2])
+    # ObjectiveFunction no longer set because we deleted all the variables!
+    attributes = MOI.get(model, MOI.ListOfModelAttributesSet())
+    @test !(MOI.ObjectiveFunction{F}() in attributes)
+    return
+end
+
+function test_multiobjective_vector_of_variables_delete_vector(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorOfVariables
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.VectorOfVariables(x)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) == f
+    attributes = MOI.get(model, MOI.ListOfModelAttributesSet())
+    @test MOI.ObjectiveFunction{F}() in attributes
+    MOI.delete(model, x)
+    # ObjectiveFunction no longer set because we deleted all the variables!
+    attributes = MOI.get(model, MOI.ListOfModelAttributesSet())
+    @test !(MOI.ObjectiveFunction{F}() in attributes)
+    return
+end
+
+function test_multiobjective_vector_affine_function(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorAffineFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.Utilities.operate(vcat, T, T(1) * x[1], T(2) * x[2] + T(3))
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    return
+end
+
+function test_multiobjective_vector_affine_function_delete(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorAffineFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.Utilities.operate(vcat, T, T(1) * x[1], T(2) * x[2] + T(3))
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    MOI.delete(model, x[1])
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈
+          MOI.Utilities.operate(vcat, T, T(0), T(2) * x[2] + T(3))
+    return
+end
+
+function test_multiobjective_vector_affine_function_delete_vector(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorAffineFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.Utilities.operate(vcat, T, T(1) * x[1], T(2) * x[2] + T(3))
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    MOI.delete(model, x)
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈
+          MOI.VectorAffineFunction{T}(MOI.VectorAffieTerm{T}[], T[0, 3])
+    return
+end
+
+function test_multiobjective_vector_quadratic_function(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorQuadraticFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.Utilities.operate(vcat, T, (T(1) .* x .* x)...)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    return
+end
+
+function test_multiobjective_vector_quadratic_function_delete(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorQuadraticFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.Utilities.operate(vcat, T, (T(1) .* x .* x)...)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    MOI.delete(model, x[1])
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈
+          MOI.Utilities.operate(vcat, T, T(0), T(1) * x[2] * x[2])
+    return
+end
+
+function test_multiobjective_vector_quadratic_function_delete_vector(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorQuadraticFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.Utilities.operate(vcat, T, (T(1) .* x .* x)...)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    MOI.delete(model, x)
+    new_f = MOI.VectorQuadraticFunction{T}(
+        MOI.VectorQuadraticTerm{T}[],
+        MOI.VectorAffineTerm{T}[],
+        zeros(T, 2)
+    )
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ new_f
+    return
+end

--- a/src/Test/test_multiobjective.jl
+++ b/src/Test/test_multiobjective.jl
@@ -126,7 +126,7 @@ function test_multiobjective_vector_affine_function_delete_vector(
     @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
     MOI.delete(model, x)
     @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈
-          MOI.VectorAffineFunction{T}(MOI.VectorAffieTerm{T}[], T[0, 3])
+          MOI.VectorAffineFunction{T}(MOI.VectorAffineTerm{T}[], T[0, 3])
     return
 end
 
@@ -179,7 +179,7 @@ function test_multiobjective_vector_quadratic_function_delete_vector(
     new_f = MOI.VectorQuadraticFunction{T}(
         MOI.VectorQuadraticTerm{T}[],
         MOI.VectorAffineTerm{T}[],
-        zeros(T, 2)
+        zeros(T, 2),
     )
     @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ new_f
     return

--- a/src/Test/test_multiobjective.jl
+++ b/src/Test/test_multiobjective.jl
@@ -94,6 +94,28 @@ function test_multiobjective_vector_affine_function(
     return
 end
 
+function test_multiobjective_vector_affine_function_modify(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorAffineFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.Utilities.operate(vcat, T, T(1) * x[1], T(2) * x[2] + T(3))
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    MOI.modify(
+        model,
+        MOI.ObjectiveFunction{F}(),
+        MOI.VectorConstantChange(T[4, 5]),
+    )
+    f.constants .= T[4, 5]
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    return
+end
+
 function test_multiobjective_vector_affine_function_delete(
     model::MOI.ModelLike,
     ::Config{T},
@@ -141,6 +163,28 @@ function test_multiobjective_vector_quadratic_function(
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{F}(), f)
     @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    return
+end
+
+function test_multiobjective_vector_quadratic_function_modify(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorQuadraticFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    f = MOI.Utilities.operate(vcat, T, (T(1) .* x .* x)...)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    MOI.modify(
+        model,
+        MOI.ObjectiveFunction{F}(),
+        MOI.VectorConstantChange(T[4, 5]),
+    )
+    f.constants .= T[4, 5]
     @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
     return
 end

--- a/src/Utilities/objective_container.jl
+++ b/src/Utilities/objective_container.jl
@@ -79,7 +79,7 @@ function MOI.get(
         return MOI.VectorOfVariables
     elseif o.vector_affine !== nothing
         return MOI.VectorAffineFunction{T}
-    else o.vector_quadratic !== nothing
+    elseif o.vector_quadratic !== nothing
         return MOI.VectorQuadraticFunction{T}
     end
     # The default if no objective is set.
@@ -133,6 +133,7 @@ function _empty_keeping_sense(o::ObjectiveContainer)
     o.sense, o.is_sense_set = sense, is_sense_set
     return
 end
+
 function MOI.set(
     o::ObjectiveContainer,
     ::MOI.ObjectiveFunction{MOI.VariableIndex},

--- a/src/Utilities/objective_container.jl
+++ b/src/Utilities/objective_container.jl
@@ -221,10 +221,10 @@ end
 ###
 
 function MOI.modify(
-    o::ObjectiveContainer,
+    o::ObjectiveContainer{T},
     ::MOI.ObjectiveFunction,
     change::MOI.AbstractFunctionModification,
-)
+) where {T}
     if o.single_variable !== nothing
         o.single_variable = modify_function!(o.single_variable, change)
     elseif o.scalar_affine !== nothing

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1196,7 +1196,7 @@ e.g., the objective function is quadratic and `F` is
 `ScalarAffineFunction{Float64}` or it has non-integer coefficient and `F` is
 `ScalarAffineFunction{Int}`.
 """
-struct ObjectiveFunction{F<:AbstractScalarFunction} <: AbstractModelAttribute end
+struct ObjectiveFunction{F<:AbstractFunction} <: AbstractModelAttribute end
 
 attribute_value_type(::ObjectiveFunction{F}) where {F} = F
 

--- a/test/Bridges/Objective/vector_slack.jl
+++ b/test/Bridges/Objective/vector_slack.jl
@@ -75,6 +75,30 @@ function test_runtests()
         MOI.Bridges.Objective.VectorSlackBridge,
         """
         variables: x
+        maxobjective: [1.0 * x, -1.1 * x]
+        """,
+        """
+        variables: x, y
+        maxobjective: [x, y]
+        [-1.0 * y + -1.1 * x] in Nonnegatives(1)
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Objective.VectorSlackBridge,
+        """
+        variables: x
+        minobjective: [-1.1 * x, 1.0 * x]
+        """,
+        """
+        variables: x, y
+        minobjective: [y, x]
+        [1.0 * y + 1.1 * x] in Nonnegatives(1)
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Objective.VectorSlackBridge,
+        """
+        variables: x
         maxobjective: [x]
         """,
         """

--- a/test/Bridges/Objective/vector_slack.jl
+++ b/test/Bridges/Objective/vector_slack.jl
@@ -71,6 +71,57 @@ function test_runtests()
         [-1.0 * y + 1.1 * x + 2.2, -1.0 * z + -1.0 * x] in Nonnegatives(2)
         """,
     )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Objective.VectorSlackBridge,
+        """
+        variables: x
+        maxobjective: [x]
+        """,
+        """
+        variables: x
+        maxobjective: [x]
+        """,
+    )
+    return
+end
+
+function test_objective_sense_before_function()
+    inner = MOI.Utilities.MockOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+    )
+    model = MOI.Bridges.Objective.VectorSlack{Float64}(inner)
+    x = MOI.add_variable(model)
+    f = MOI.Utilities.operate(vcat, Float64, 1.0 * x, 1.0 * x)
+    err = ErrorException(
+        "Set `MOI.ObjectiveSense` before `MOI.ObjectiveFunction` when using " *
+        "`MOI.Bridges.Objective.VectorSlackBridge`.",
+    )
+    @test_throws err MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+    return
+end
+
+function test_objective_function_value()
+    for sense in ("min", "max")
+        inner = MOI.Utilities.MockOptimizer(
+            MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+        )
+        model = MOI.Bridges.Objective.VectorSlack{Float64}(inner)
+        MOI.Utilities.loadfromstring!(
+            model,
+            """
+            variables: x
+            $(sense)objective: [1.1 * x + 2.2, -1.0 * x]
+            """,
+        )
+        MOI.Utilities.set_mock_optimize!(
+            inner,
+            mock -> MOI.Utilities.mock_optimize!(mock, [3.0, 5.6, -3.0]),
+        )
+        MOI.optimize!(model)
+        # Test that we get 5.5 here, not 5.6 as set for the slack variable. This
+        # ensures we return the value of the f(x) objective, not the `y` slack.
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ [5.5, -3.0]
+    end
     return
 end
 

--- a/test/Bridges/Objective/vector_slack.jl
+++ b/test/Bridges/Objective/vector_slack.jl
@@ -1,0 +1,79 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestObjectiveVectorSlack
+
+using Test
+
+using MathOptInterface
+const MOI = MathOptInterface
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function test_runtests()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Objective.VectorSlackBridge,
+        """
+        variables: x
+        minobjective: [1.1 * x + 2.2]
+        """,
+        """
+        variables: x, y
+        minobjective: [y]
+        [1.0 * y + -1.1 * x + -2.2] in Nonnegatives(1)
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Objective.VectorSlackBridge,
+        """
+        variables: x
+        maxobjective: [1.1 * x + 2.2]
+        """,
+        """
+        variables: x, y
+        maxobjective: [y]
+        [-1.0 * y + 1.1 * x + 2.2] in Nonnegatives(1)
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Objective.VectorSlackBridge,
+        """
+        variables: x
+        minobjective: [1.1 * x + 2.2, -1.0 * x]
+        """,
+        """
+        variables: x, y, z
+        minobjective: [y, z]
+        [1.0 * y + -1.1 * x + -2.2, 1.0 * z + 1.0 * x] in Nonnegatives(2)
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Objective.VectorSlackBridge,
+        """
+        variables: x
+        maxobjective: [1.1 * x + 2.2, -1.0 * x]
+        """,
+        """
+        variables: x, y, z
+        maxobjective: [y, z]
+        [-1.0 * y + 1.1 * x + 2.2, -1.0 * z + -1.0 * x] in Nonnegatives(2)
+        """,
+    )
+    return
+end
+
+end  # module
+
+TestObjectiveVectorSlack.runtests()


### PR DESCRIPTION
This is a re-hash of https://github.com/jump-dev/MathOptInterface.jl/pull/968

The last PR lost steam because of the discussion in https://github.com/jump-dev/JuMP.jl/issues/2099

My sense is that this is still the right API approach at the MOI-level, but that it's the wrong approach at the JuMP level. I'm working on a PR to JuMP: https://github.com/jump-dev/JuMP.jl/pull/3176, <s>so let's hold off comments until things are working fully and we can discuss the full API, rather than the pros and cons of treating multi-criteria as vector optimization.</s>

I have a proof-of-concept solver at https://github.com/odow/MOO.jl and a PR for Gurobi is https://github.com/jump-dev/Gurobi.jl/pull/497.

## Alternative approaches

Instead of having a vector-valued objective, we could instead add a vector of scalar objectives.

The start to PR implementing that is https://github.com/jump-dev/MathOptInterface.jl/pull/2086.

Closes #2086 