### PR TITLE
[FileFormats.LP] fix reading "Integer" section

### DIFF
--- a/src/FileFormats/LP/LP.jl
+++ b/src/FileFormats/LP/LP.jl
@@ -430,6 +430,8 @@ const _KEYWORDS = Dict(
     "gen" => _KW_INTEGER,
     "general" => _KW_INTEGER,
     "generals" => _KW_INTEGER,
+    "integer" => _KW_INTEGER,
+    "integers" => _KW_INTEGER,
     # _KW_BINARY
     "bin" => _KW_BINARY,
     "binary" => _KW_BINARY,

--- a/test/FileFormats/LP/LP.jl
+++ b/test/FileFormats/LP/LP.jl
@@ -247,6 +247,22 @@ function test_free_variables_reading()
     return
 end
 
+function test_integer_variables_reading()
+    for case in ["general", "GeneRalS", "Integer", "InTegeRs"]
+        io = IOBuffer()
+        write(io, "Minimize\nobj: x\nsubject to\n$case\nx\nEnd")
+        seekstart(io)
+        model = MOI.FileFormats.LP.Model()
+        read!(io, model)
+        out = IOBuffer()
+        write(out, model)
+        seekstart(out)
+        file = read(out, String)
+        @test occursin("General\nx\nEnd", file)
+    end
+    return
+end
+
 function test_quadratic_objective_diag()
     model = LP.Model()
     MOI.Utilities.loadfromstring!(


### PR DESCRIPTION
Closes https://github.com/jump-dev/MathOptInterface.jl/issues/2075

I hate the LP file. No one has a standard. Even though it makes more sense than `Generals`, it's not documented by solvers that they support reading it.

From Gurobi:

> Valid keywords for variable type headers are: binary, binaries, bin, general, generals, gen