### PR TITLE
Add support for multiple objective functions

### DIFF
--- a/src/Test/test_multiobjective.jl
+++ b/src/Test/test_multiobjective.jl
@@ -1,0 +1,353 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+function test_multiobjective_vector_of_variables(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VariableIndex
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), x[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) == x[i]
+    end
+    return
+end
+
+function test_multiobjective_vector_of_variables_delete(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VariableIndex
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), x[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) == x[i]
+    end
+    MOI.delete(model, x[1])
+    attr = MOI.ObjectiveFunction{F}(1)
+    @test !(attr in MOI.get(model, MOI.ListOfModelAttributesSet()))
+    return
+end
+
+function test_multiobjective_vector_of_variables_delete_vector(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VariableIndex
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), x[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) == x[i]
+    end
+    MOI.delete(model, x)
+    # ObjectiveFunction no longer set because we deleted all the variables!
+    attributes = MOI.get(model, MOI.ListOfModelAttributesSet())
+    @test !(MOI.ObjectiveFunction{F}(1) in attributes)
+    @test !(MOI.ObjectiveFunction{F}(2) in attributes)
+    return
+end
+
+
+
+function test_multiobjective_vector_affine_function(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.ScalarAffineFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    f = [T(1) * x[1], T(2) * x[2] + T(3)]
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), f[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    return
+end
+
+function test_multiobjective_vector_affine_function_modify(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.ScalarAffineFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    f = [T(1) * x[1], T(2) * x[2] + T(3)]
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), f[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    MOI.modify(
+        model,
+        MOI.ObjectiveFunction{F}(1),
+        MOI.ScalarConstantChange(T(4)),
+    )
+    f[1].constant = T(4)
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    return
+end
+
+function test_multiobjective_vector_affine_function_delete(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.ScalarAffineFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    f = [T(1) * x[1], T(2) * x[2] + T(3)]
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), f[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    MOI.delete(model, x[1])
+    g = [zero(F), T(2) * x[2] + T(3)]
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ g[i]
+    end
+    return
+end
+
+function test_multiobjective_vector_affine_function_delete_vector(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.ScalarAffineFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    f = [T(1) * x[1], T(2) * x[2] + T(3)]
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), f[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    MOI.delete(model, x)
+    g = [zero(F), zero(F) + T(3)]
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ g[i]
+    end
+    return
+end
+
+function test_multiobjective_vector_quadratic_function(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.ScalarQuadraticFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    f = T(1) .* x .* x
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), f[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    return
+end
+
+function test_multiobjective_vector_quadratic_function_modify(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.ScalarQuadraticFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    f = T(1) .* x .* x
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), f[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    MOI.modify(
+        model,
+        MOI.ObjectiveFunction{F}(1),
+        MOI.ScalarConstantChange(T(4)),
+    )
+    f[1].constant = T(4)
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    return
+end
+
+function test_multiobjective_vector_quadratic_function_delete(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.ScalarQuadraticFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    f = T(1) .* x .* x
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), f[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    MOI.delete(model, x[1])
+    f[1] = zero(F)
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    return
+end
+
+function test_multiobjective_vector_quadratic_function_delete_vector(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.ScalarQuadraticFunction{T}
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    f = T(1) .* x .* x
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), f[i])
+    end
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    MOI.delete(model, x)
+    f[1] = zero(F)
+    f[2] = zero(F)
+    for i in 1:2
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F
+        @test MOI.get(model, MOI.ObjectiveFunction{F}(i)) ≈ f[i]
+    end
+    return
+end
+
+function test_multiobjective_mixed(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = Any[
+        MOI.VariableIndex,
+        MOI.ScalarAffineFunction{T},
+        MOI.ScalarQuadraticFunction{T},
+    ]
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F[1]}(3))
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F[2]}(3))
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F[3]}(3))
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    f = Any[
+        x[1],
+        T(1) * x[1] + T(2),
+        T(3) * x[1] * x[1] + T(4) * x[2] + T(5)
+    ]
+    for i in 1:3
+        MOI.set(model, MOI.ObjectiveFunction{typeof(f[i])}(i), f[i])
+    end
+    for i in 1:3
+        @test MOI.get(model, MOI.ObjectiveFunctionType(i)) == F[i]
+        @test MOI.get(model, MOI.ObjectiveFunction{F[i]}(i)) ≈ f[i]
+    end
+    MOI.set(model, MOI.ObjectiveFunction{F[2]}(2), nothing)
+    attrs = MOI.get(model, MOI.ListOfModelAttributesSet())
+    @test MOI.ObjectiveSense() in attrs
+    @test MOI.ObjectiveFunction{F[1]}(1) in attrs
+    @test !(MOI.ObjectiveFunction{F[2]}(2) in attrs)
+    @test MOI.ObjectiveFunction{F[3]}(3) in attrs
+    return
+end
+
+function test_multiobjective_solve(
+    model::MOI.ModelLike,
+    config::Config{T},
+) where {T}
+    F = MOI.ScalarAffineFunction{T}
+    @requires _supports(config, MOI.optimize!)
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}(2))
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.add_constraint(model, T(1) * x[1] + x[2], MOI.GreaterThan(T(1)))
+    MOI.add_constraint(model, T(1//2) * x[1] + x[2], MOI.GreaterThan(T(3//4)))
+    MOI.add_constraint(model, x[1], MOI.GreaterThan(T(0)))
+    MOI.add_constraint(model, x[2], MOI.GreaterThan(T(1//4)))
+    f = [T(2) * x[1] + x[2], T(1) * x[1] + T(3) * x[2]]
+    for i in 1:2
+        MOI.set(model, MOI.ObjectiveFunction{F}(i), f[i])
+    end
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+    @test MOI.get(model, MOI.ResultCount()) >= 1
+    for i in 1:MOI.get(model, MOI.ResultCount())
+        @test MOI.get(model, MOI.PrimalStatus(i)) == MOI.FEASIBLE_POINT
+        @test MOI.get(model, MOI.DualStatus(i)) == MOI.NO_SOLUTION
+        sol = MOI.get.(model, MOI.VariablePrimal(i), x)
+        @test sum(sol) >= T(1) - config.atol
+        @test T(1//2) * sol[1] + sol[2] >= T(3//4) - config.atol
+        @test sol[1] >= T(0) - config.atol
+        @test sol[2] >= T(1//4) - config.atol
+        f_val = [T(2) * sol[1] + sol[2], T(1) * sol[1] + T(3) * sol[2]]
+        @test ≈(MOI.get(model, MOI.ObjectiveValue(i, 1)), f_val[1], config)
+        @test ≈(MOI.get(model, MOI.ObjectiveValue(i, 2)), f_val[2], config)
+    end
+    return
+end
+
+function setup_test(
+    ::typeof(test_multiobjective_solve),
+    model::MOIU.MockOptimizer,
+    ::Config{T},
+) where {T}
+    MOIU.set_mock_optimize!(
+        model,
+        (mock::MOIU.MockOptimizer) -> begin
+            MOIU.mock_optimize!(
+                mock,
+                MOI.OPTIMAL,
+                (MOI.FEASIBLE_POINT, T[1//2, 1//2]),
+            )
+        end,
+    )
+    return
+end

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -322,6 +322,18 @@ function MOI.set(
     return
 end
 
+function MOI.set(
+    model::AbstractModel,
+    attr::MOI.ObjectiveFunction{F},
+    ::Nothing,
+) where {F<:MOI.AbstractFunction}
+    if !MOI.supports(model, attr)
+        throw(MOI.UnsupportedAttribute(attr))
+    end
+    MOI.set(model.objective, attr, nothing)
+    return
+end
+
 function MOI.modify(
     model::AbstractModel,
     attr::MOI.ObjectiveFunction,

--- a/src/Utilities/objective_container.jl
+++ b/src/Utilities/objective_container.jl
@@ -4,6 +4,24 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
+mutable struct _ScalarObjective{T}
+    single_variable::Union{Nothing,MOI.VariableIndex}
+    scalar_affine::Union{Nothing,MOI.ScalarAffineFunction{T}}
+    scalar_quadratic::Union{Nothing,MOI.ScalarQuadraticFunction{T}}
+end
+
+function _ScalarObjective(f::MOI.VariableIndex)
+    return _ScalarObjective{Float64}(copy(f), nothing, nothing)
+end
+
+function _ScalarObjective(f::MOI.ScalarAffineFunction{T}) where {T}
+    return _ScalarObjective{T}(nothing, copy(f), nothing)
+end
+
+function _ScalarObjective(f::MOI.ScalarQuadraticFunction{T}) where {T}
+    return _ScalarObjective{T}(nothing, nothing, copy(f))
+end
+
 """
     ObjectiveContainer{T}
 
@@ -13,30 +31,25 @@ Utilities.Model.
 mutable struct ObjectiveContainer{T} <: MOI.ModelLike
     is_sense_set::Bool
     sense::MOI.OptimizationSense
-    is_function_set::Bool
-    single_variable::Union{Nothing,MOI.VariableIndex}
-    scalar_affine::Union{Nothing,MOI.ScalarAffineFunction{T}}
-    scalar_quadratic::Union{Nothing,MOI.ScalarQuadraticFunction{T}}
+    objectives::Dict{Int,_ScalarObjective{T}}
     function ObjectiveContainer{T}() where {T}
-        o = new{T}()
-        MOI.empty!(o)
-        return o
+        return new{T}(
+            false,
+            MOI.FEASIBILITY_SENSE,
+            Dict{Int,_ScalarObjective{T}}(),
+        )
     end
 end
 
 function MOI.empty!(o::ObjectiveContainer{T}) where {T}
     o.is_sense_set = false
     o.sense = MOI.FEASIBILITY_SENSE
-    o.is_function_set = false
-    o.single_variable = nothing
-    o.scalar_affine =
-        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
-    o.scalar_quadratic = nothing
+    empty!(o.objectives)
     return
 end
 
 function MOI.is_empty(o::ObjectiveContainer)
-    return !o.is_sense_set && !o.is_function_set
+    return !o.is_sense_set && isempty(o.objectives)
 end
 
 ###
@@ -61,16 +74,29 @@ end
 ###
 
 function MOI.get(
-    o::ObjectiveContainer{T},
+    o::_ScalarObjective{T},
     ::MOI.ObjectiveFunctionType,
 ) where {T}
-    if o.single_variable !== nothing
+    if o.scalar_affine !== nothing
+        return MOI.ScalarAffineFunction{T}
+    elseif o.single_variable !== nothing
         return MOI.VariableIndex
-    elseif o.scalar_quadratic !== nothing
+    else
+        @assert o.scalar_quadratic !== nothing
         return MOI.ScalarQuadraticFunction{T}
     end
-    @assert o.scalar_affine !== nothing
-    return MOI.ScalarAffineFunction{T}
+end
+
+function MOI.get(
+    o::ObjectiveContainer{T},
+    attr::MOI.ObjectiveFunctionType,
+) where {T}
+    objective = get(o.objectives, attr.objective_index, nothing)
+    if objective === nothing
+        # Default if not set
+        return MOI.ScalarAffineFunction{T}
+    end
+    return MOI.get(objective, attr)
 end
 
 ###
@@ -91,8 +117,8 @@ function MOI.supports(
 end
 
 function MOI.get(
-    o::ObjectiveContainer{T},
-    ::MOI.ObjectiveFunction{F},
+    o::_ScalarObjective{T},
+    attr::MOI.ObjectiveFunction{F},
 ) where {T,F}
     if o.single_variable !== nothing
         return convert(F, o.single_variable)
@@ -103,39 +129,32 @@ function MOI.get(
     return convert(F, o.scalar_affine)
 end
 
+function MOI.get(
+    o::ObjectiveContainer{T},
+    attr::MOI.ObjectiveFunction{F},
+) where {T,F}
+    objective = get(o.objectives, attr.objective_index, nothing)
+    if objective === nothing
+        return zero(MOI.ScalarAffineFunction{T})
+    end
+    return MOI.get(objective, attr)
+end
+
 function MOI.set(
     o::ObjectiveContainer,
-    ::MOI.ObjectiveFunction{MOI.VariableIndex},
-    f::MOI.VariableIndex,
+    attr::MOI.ObjectiveFunction{F},
+    f::F,
+) where {F}
+    o.objectives[attr.objective_index] = _ScalarObjective(f)
+    return
+end
+
+function MOI.set(
+    o::ObjectiveContainer,
+    attr::MOI.ObjectiveFunction,
+    ::Nothing,
 )
-    o.is_function_set = true
-    o.single_variable = copy(f)
-    o.scalar_affine = nothing
-    o.scalar_quadratic = nothing
-    return
-end
-
-function MOI.set(
-    o::ObjectiveContainer{T},
-    ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}},
-    f::MOI.ScalarAffineFunction{T},
-) where {T}
-    o.is_function_set = true
-    o.single_variable = nothing
-    o.scalar_affine = copy(f)
-    o.scalar_quadratic = nothing
-    return
-end
-
-function MOI.set(
-    o::ObjectiveContainer{T},
-    ::MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{T}},
-    f::MOI.ScalarQuadraticFunction{T},
-) where {T}
-    o.is_function_set = true
-    o.single_variable = nothing
-    o.scalar_affine = nothing
-    o.scalar_quadratic = copy(f)
+    delete!(o.objectives, attr.objective_index)
     return
 end
 
@@ -148,9 +167,9 @@ function MOI.get(o::ObjectiveContainer, ::MOI.ListOfModelAttributesSet)
     if o.is_sense_set
         push!(ret, MOI.ObjectiveSense())
     end
-    if o.is_function_set
-        F = MOI.get(o, MOI.ObjectiveFunctionType())
-        push!(ret, MOI.ObjectiveFunction{F}())
+    for objective_index in keys(o.objectives)
+        F = MOI.get(o, MOI.ObjectiveFunctionType(objective_index))
+        push!(ret, MOI.ObjectiveFunction{F}(objective_index))
     end
     return ret
 end
@@ -160,7 +179,7 @@ end
 ###
 
 function MOI.modify(
-    o::ObjectiveContainer,
+    o::_ScalarObjective,
     ::MOI.ObjectiveFunction,
     change::MOI.AbstractFunctionModification,
 )
@@ -170,9 +189,22 @@ function MOI.modify(
         o.scalar_quadratic = modify_function!(o.scalar_quadratic, change)
     else
         @assert o.scalar_affine !== nothing
-        o.is_function_set = true
         o.scalar_affine = modify_function!(o.scalar_affine, change)
     end
+    return
+end
+
+function MOI.modify(
+    o::ObjectiveContainer,
+    attr::MOI.ObjectiveFunction{F},
+    change::MOI.AbstractFunctionModification,
+) where {F<:MOI.AbstractScalarFunction}
+    objective = get(o.objectives, attr.objective_index, nothing)
+    if objective === nothing
+        # If not set, set a default objective.
+        MOI.set(o, attr, zero(F))
+    end
+    MOI.modify(objective, attr, change)
     return
 end
 
@@ -180,15 +212,9 @@ end
 ### MOI.delete
 ###
 
-function MOI.delete(o::ObjectiveContainer, x::MOI.VariableIndex)
+function MOI.delete(o::_ScalarObjective, x::MOI.VariableIndex)
     if o.single_variable !== nothing
-        if x == o.single_variable
-            sense = o.sense
-            MOI.empty!(o)
-            if o.is_sense_set
-                MOI.set(o, MOI.ObjectiveSense(), sense)
-            end
-        end
+        # Handled in the ObjectiveContainer method
     elseif o.scalar_quadratic !== nothing
         o.scalar_quadratic = remove_variable(o.scalar_quadratic, x)
     else
@@ -198,21 +224,45 @@ function MOI.delete(o::ObjectiveContainer, x::MOI.VariableIndex)
     return
 end
 
-function MOI.delete(o::ObjectiveContainer, x::Vector{MOI.VariableIndex})
+function MOI.delete(o::ObjectiveContainer, x::MOI.VariableIndex)
+    to_delete = Int[]
+    for (objective_index, objective) in o.objectives
+        if objective.single_variable === x
+            push!(to_delete, objective_index)
+        else
+            MOI.delete(objective, x)
+        end
+    end
+    for objective_index in to_delete
+        delete!(o.objectives, objective_index)
+    end
+    return
+end
+
+function MOI.delete(o::_ScalarObjective, x::Vector{MOI.VariableIndex})
     keep = v -> !(v in x)
     if o.single_variable !== nothing
-        if o.single_variable in x
-            sense = o.sense
-            MOI.empty!(o)
-            if o.is_sense_set
-                MOI.set(o, MOI.ObjectiveSense(), sense)
-            end
-        end
+        # Handled in the ObjectiveContainer method
     elseif o.scalar_quadratic !== nothing
         o.scalar_quadratic = filter_variables(keep, o.scalar_quadratic)
     else
         @assert o.scalar_affine !== nothing
         o.scalar_affine = filter_variables(keep, o.scalar_affine)
+    end
+    return
+end
+
+function MOI.delete(o::ObjectiveContainer, x::Vector{MOI.VariableIndex})
+    to_delete = Int[]
+    for (objective_index, objective) in o.objectives
+        if objective.single_variable in x
+            push!(to_delete, objective_index)
+        else
+            MOI.delete(objective, x)
+        end
+    end
+    for objective_index in to_delete
+        delete!(o.objectives, objective_index)
     end
     return
 end

--- a/src/Utilities/results.jl
+++ b/src/Utilities/results.jl
@@ -24,8 +24,8 @@ the `ObjectiveFunction` value.
 """
 function get_fallback(model::MOI.ModelLike, attr::MOI.ObjectiveValue)
     MOI.check_result_index_bounds(model, attr)
-    F = MOI.get(model, MOI.ObjectiveFunctionType())
-    f = MOI.get(model, MOI.ObjectiveFunction{F}())
+    F = MOI.get(model, MOI.ObjectiveFunctionType(attr.objective_index))
+    f = MOI.get(model, MOI.ObjectiveFunction{F}(attr.objective_index))
     obj = eval_variables(
         vi -> MOI.get(model, MOI.VariablePrimal(attr.result_index), vi),
         f,

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1183,9 +1183,11 @@ function type and `S` is a set type indicating that the attribute
 struct ListOfConstraintTypesPresent <: AbstractModelAttribute end
 
 """
-    ObjectiveFunction{F<:AbstractScalarFunction}()
+    ObjectiveFunction{F}(
+        objective_index::Int = 1,
+    ) where {F<:AbstractScalarFunction}
 
-A model attribute for the objective function which has a type
+A model attribute for the objective function `objective_index`, which has a type
 `F<:AbstractScalarFunction`.
 
 `F` should be guaranteed to be equivalent but not necessarily identical to the
@@ -1196,33 +1198,44 @@ e.g., the objective function is quadratic and `F` is
 `ScalarAffineFunction{Float64}` or it has non-integer coefficient and `F` is
 `ScalarAffineFunction{Int}`.
 """
-struct ObjectiveFunction{F<:AbstractScalarFunction} <: AbstractModelAttribute end
+struct ObjectiveFunction{F<:AbstractScalarFunction} <: AbstractModelAttribute
+    objective_index::Int
+    function ObjectiveFunction{F}(
+        objective_index::Int = 1,
+    ) where {F<:AbstractScalarFunction}
+        return new{F}(objective_index)
+    end
+end
 
 attribute_value_type(::ObjectiveFunction{F}) where {F} = F
 
 """
-    ObjectiveFunctionType()
+    ObjectiveFunctionType(objective_index::Int = 1)
 
-A model attribute for the type `F` of the objective function set using the
-[`ObjectiveFunction{F}`](@ref) attribute.
+A model attribute for the type `F` of the objective function `objective_index`
+set using the [`ObjectiveFunction{F}`](@ref) attribute.
 
 ## Examples
 
 In the following code, `attr` should be equal to `MOI.VariableIndex`:
 ```julia
 x = MOI.add_variable(model)
-MOI.set(model, MOI.ObjectiveFunction{MOI.VariableIndex}(), x)
-attr = MOI.get(model, MOI.ObjectiveFunctionType())
+MOI.set(model, MOI.ObjectiveFunction{MOI.VariableIndex}(1), x)
+attr = MOI.get(model, MOI.ObjectiveFunctionType(1))
 ```
 """
-struct ObjectiveFunctionType <: AbstractModelAttribute end
+struct ObjectiveFunctionType <: AbstractModelAttribute
+    objective_index::Int
+    ObjectiveFunctionType(objective_index::Int = 1) = new(objective_index)
+end
 
 attribute_value_type(::ObjectiveFunctionType) = Type{<:AbstractFunction}
 
 """
-    ObjectiveValue(result_index::Int = 1)
+    ObjectiveValue(result_index::Int = 1, objective_index::Int = 1)
 
-A model attribute for the objective value of the primal solution `result_index`.
+A model attribute for the objective value of the primal solution `result_index`
+and objective `objective_index`.
 
 If the solver does not have a primal value for the objective because the
 `result_index` is beyond the available solutions (whose number is indicated by
@@ -1236,7 +1249,10 @@ See [`ResultCount`](@ref) for information on how the results are ordered.
 """
 struct ObjectiveValue <: AbstractModelAttribute
     result_index::Int
-    ObjectiveValue(result_index::Int = 1) = new(result_index)
+    objective_index::Int
+    function ObjectiveValue(result_index::Int = 1, objective_index::Int = 1)
+        return new(result_index, objective_index)
+    end
 end
 
 """
@@ -1261,11 +1277,14 @@ struct DualObjectiveValue <: AbstractModelAttribute
 end
 
 """
-    ObjectiveBound()
+    ObjectiveBound(objective_index::Int = 1)
 
 A model attribute for the best known bound on the optimal objective value.
 """
-struct ObjectiveBound <: AbstractModelAttribute end
+struct ObjectiveBound <: AbstractModelAttribute
+    objective_index::Int
+    ObjectiveBound(objective_index::Int = 1) = new(objective_index)
+end
 
 """
     RelativeGap()


### PR DESCRIPTION
An alternative to #2070

Instead of adding vector-valued objectives, this PR adds
```Julia
struct ObjectiveFunction{F<:AbstractScalarFunction} <: AbstractModelAttribute
    objective_index::Int
    function ObjectiveFunction{F}(
        objective_index::Int = 1,
    ) where {F<:AbstractScalarFunction}
        return new{F}(objective_index)
    end
end
```

This has a number of implications:

 * Other attributes like `ObjectiveValue` need an index
 * Most solver's current implementation of `supports(::Optimizer, ::MOI.ObjectiveFunction{F})` will be incorrect, because they must **also** check the value of the `objective_index` field, that is, every solver will currently lie and tell JuMP that they support multiobjective optimization.
 * We probably need a way to delete individual objectives, otherwise if you want to drop from 3 to 2 objectives, you'll need to set `FEASIBILITY_SENSE`
 * The objective bridging system needs to be rewritten to support multiple objectives
 * We support multiple objectives but only a single objective sense

Still TODOs:

 - [ ] Setting `FEASIBILITY_SENSE` erases all objectives
 - [ ] Bridges
 - [ ] Introduce an `ObjectiveIndex` object instead of using integers?