### PR TITLE
Fix and test that Bridges.final_touch can be called multiple times

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -255,6 +255,8 @@ function runtests(
     model = _bridged_model(Bridge, inner)
     MOI.Utilities.loadfromstring!(model, input)
     final_touch(model)
+    # Should be able to call final_touch multiple times.
+    final_touch(model)
     # Load a non-bridged input model, and check that getters are the same.
     test = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     MOI.Utilities.loadfromstring!(test, input)

--- a/src/Bridges/Constraint/bridges/bin_packing.jl
+++ b/src/Bridges/Constraint/bridges/bin_packing.jl
@@ -59,6 +59,7 @@ struct BinPackingToMILPBridge{
     equal_to::Vector{
         MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
     }
+    bounds::Vector{NTuple{2,T}}
 end
 
 const BinPackingToMILP{T,OT<:MOI.ModelLike} =
@@ -76,6 +77,7 @@ function bridge_constraint(
         MOI.VariableIndex[],
         MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}[],
         MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}[],
+        NTuple{2,T}[],
     )
 end
 
@@ -133,6 +135,7 @@ function MOI.delete(model::MOI.ModelLike, bridge::BinPackingToMILPBridge)
     empty!(bridge.equal_to)
     MOI.delete.(model, bridge.variables)
     empty!(bridge.variables)
+    empty!(bridge.bounds)
     return
 end
 
@@ -232,8 +235,6 @@ function MOI.Bridges.final_touch(
     bridge::BinPackingToMILPBridge{T,F},
     model::MOI.ModelLike,
 ) where {T,F}
-    # Clear any existing reformulations!
-    MOI.delete(model, bridge)
     S = Dict{T,Vector{Tuple{Float64,MOI.VariableIndex}}}()
     scalars = collect(MOI.Utilities.eachscalar(bridge.f))
     bounds = Dict{MOI.VariableIndex,NTuple{2,T}}()
@@ -245,6 +246,21 @@ function MOI.Bridges.final_touch(
                 "Unable to use $(typeof(bridge)) because an element in the " *
                 "function has a non-finite domain: $x",
             )
+        end
+        if length(bridge.bounds) < i
+            # This is the first time calling final_touch
+            push!(bridge.bounds, ret)
+        elseif bridge.bounds[i] == ret
+            # We've called final_touch before, and the bounds match. No need to
+            # reformulate a second time.
+            continue
+        elseif bridge.bounds[i] != ret
+            # There is a stored bound, and the current bounds do not match. This
+            # means the model has been modified since the previous call to
+            # final_touch. We need to delete the bridge and start again.
+            MOI.delete(model, bridge)
+            MOI.Bridges.final_touch(bridge, model)
+            return
         end
         unit_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
         convex_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))

--- a/src/Bridges/Constraint/bridges/count_belongs.jl
+++ b/src/Bridges/Constraint/bridges/count_belongs.jl
@@ -264,7 +264,7 @@ function _unit_expansion(
             # final_touch. We need to delete the bridge and start again.
             MOI.delete(model, bridge)
             MOI.Bridges.final_touch(bridge, model)
-            return
+            break
         end
         unit_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
         convex_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))

--- a/src/Bridges/Constraint/bridges/count_belongs.jl
+++ b/src/Bridges/Constraint/bridges/count_belongs.jl
@@ -59,6 +59,7 @@ mutable struct CountBelongsToMILPBridge{
     equal_to::Vector{
         MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
     }
+    bounds::Vector{NTuple{2,T}}
     function CountBelongsToMILPBridge{T}(
         f::Union{MOI.VectorOfVariables,MOI.VectorAffineFunction{T}},
         s::MOI.CountBelongs,
@@ -68,6 +69,7 @@ mutable struct CountBelongsToMILPBridge{
             s,
             MOI.VariableIndex[],
             MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}[],
+            NTuple{2,T}[],
         )
     end
 end
@@ -139,6 +141,7 @@ function MOI.delete(model::MOI.ModelLike, bridge::CountBelongsToMILPBridge)
         MOI.delete(model, x)
     end
     empty!(bridge.variables)
+    empty!(bridge.bounds)
     return
 end
 
@@ -248,6 +251,21 @@ function _unit_expansion(
                 "non-finite domain: $(f[i])",
             )
         end
+        if length(bridge.bounds) < i
+            # This is the first time calling final_touch
+            push!(bridge.bounds, ret)
+        elseif bridge.bounds[i] == ret
+            # We've called final_touch before, and the bounds match. No need to
+            # reformulate a second time.
+            continue
+        elseif bridge.bounds[i] != ret
+            # There is a stored bound, and the current bounds do not match. This
+            # means the model has been modified since the previous call to
+            # final_touch. We need to delete the bridge and start again.
+            MOI.delete(model, bridge)
+            MOI.Bridges.final_touch(bridge, model)
+            return
+        end
         unit_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
         convex_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
         for xi in ret[1]:ret[2]
@@ -277,9 +295,11 @@ function MOI.Bridges.final_touch(
     bridge::CountBelongsToMILPBridge{T,F},
     model::MOI.ModelLike,
 ) where {T,F}
-    MOI.delete(model, bridge)
     scalars = collect(MOI.Utilities.eachscalar(bridge.f))
     S, ci = _unit_expansion(bridge, model, scalars[2:end])
+    if isempty(S) && isempty(ci)
+        return # Nothing to bridge. We must have already called final_touch.
+    end
     append!(bridge.equal_to, ci)
     for (_, s) in S
         append!(bridge.variables, s)

--- a/src/Bridges/Constraint/bridges/count_distinct.jl
+++ b/src/Bridges/Constraint/bridges/count_distinct.jl
@@ -281,14 +281,14 @@ function MOI.Bridges.final_touch(
                 "in the function has a non-finite domain: $x",
             )
         end
-        if length(bridge.bounds) < i
+        if length(bridge.bounds) < i - 1
             # This is the first time calling final_touch
             push!(bridge.bounds, ret)
-        elseif bridge.bounds[i] == ret
+        elseif bridge.bounds[i-1] == ret
             # We've called final_touch before, and the bounds match. No need to
             # reformulate a second time.
             continue
-        elseif bridge.bounds[i] != ret
+        elseif bridge.bounds[i-1] != ret
             # There is a stored bound, and the current bounds do not match. This
             # means the model has been modified since the previous call to
             # final_touch. We need to delete the bridge and start again.

--- a/src/Bridges/Constraint/bridges/count_distinct.jl
+++ b/src/Bridges/Constraint/bridges/count_distinct.jl
@@ -78,6 +78,7 @@ mutable struct CountDistinctToMILPBridge{
     less_than::Vector{
         MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.LessThan{T}},
     }
+    bounds::Vector{NTuple{2,T}}
     function CountDistinctToMILPBridge{T}(
         f::Union{MOI.VectorOfVariables,MOI.VectorAffineFunction{T}},
     ) where {T}
@@ -86,6 +87,7 @@ mutable struct CountDistinctToMILPBridge{
             MOI.VariableIndex[],
             MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}[],
             MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.LessThan{T}}[],
+            NTuple{2,T}[],
         )
     end
 end
@@ -164,6 +166,7 @@ function MOI.delete(model::MOI.ModelLike, bridge::CountDistinctToMILPBridge)
         MOI.delete(model, x)
     end
     empty!(bridge.variables)
+    empty!(bridge.bounds)
     return
 end
 
@@ -266,8 +269,6 @@ function MOI.Bridges.final_touch(
     bridge::CountDistinctToMILPBridge{T,F},
     model::MOI.ModelLike,
 ) where {T,F}
-    # Clear any existing reformulations!
-    MOI.delete(model, bridge)
     S = Dict{T,Vector{MOI.VariableIndex}}()
     scalars = collect(MOI.Utilities.eachscalar(bridge.f))
     bounds = Dict{MOI.VariableIndex,NTuple{2,T}}()
@@ -279,6 +280,21 @@ function MOI.Bridges.final_touch(
                 "Unable to use CountDistinctToMILPBridge because element $i " *
                 "in the function has a non-finite domain: $x",
             )
+        end
+        if length(bridge.bounds) < i
+            # This is the first time calling final_touch
+            push!(bridge.bounds, ret)
+        elseif bridge.bounds[i] == ret
+            # We've called final_touch before, and the bounds match. No need to
+            # reformulate a second time.
+            continue
+        elseif bridge.bounds[i] != ret
+            # There is a stored bound, and the current bounds do not match. This
+            # means the model has been modified since the previous call to
+            # final_touch. We need to delete the bridge and start again.
+            MOI.delete(model, bridge)
+            MOI.Bridges.final_touch(bridge, model)
+            return
         end
         unit_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
         convex_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
@@ -305,6 +321,9 @@ function MOI.Bridges.final_touch(
             bridge.equal_to,
             MOI.add_constraint(model, convex_f, MOI.EqualTo(one(T))),
         )
+    end
+    if isempty(S)
+        return  # Nothing to bridge. We must have already called final_touch.
     end
     count_terms = MOI.ScalarAffineTerm{T}[]
     # We use a sort so that the model order is deterministic.

--- a/src/Bridges/Constraint/bridges/count_greater_than.jl
+++ b/src/Bridges/Constraint/bridges/count_greater_than.jl
@@ -38,6 +38,7 @@ struct CountGreaterThanToMILPBridge{
     equal_to::Vector{
         MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
     }
+    bounds::Vector{NTuple{2,T}}
 end
 
 const CountGreaterThanToMILP{T,OT<:MOI.ModelLike} =
@@ -55,6 +56,7 @@ function bridge_constraint(
         MOI.VariableIndex[],
         MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}[],
         MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}[],
+        NTuple{2,T}[],
     )
 end
 
@@ -112,6 +114,7 @@ function MOI.delete(model::MOI.ModelLike, bridge::CountGreaterThanToMILPBridge)
     empty!(bridge.equal_to)
     MOI.delete.(model, bridge.variables)
     empty!(bridge.variables)
+    empty!(bridge.bounds)
     return
 end
 
@@ -222,6 +225,7 @@ function _add_unit_expansion(
     S,
     bounds,
     x,
+    i,
 ) where {T,F}
     ret = _get_bounds(bridge, model, bounds, x)
     if ret === nothing
@@ -229,6 +233,21 @@ function _add_unit_expansion(
             "Unable to use $(typeof(bridge)) because an element in the " *
             "function has a non-finite domain: $x",
         )
+    end
+    if length(bridge.bounds) < i
+        # This is the first time calling final_touch
+        push!(bridge.bounds, ret)
+    elseif bridge.bounds[i] == ret
+        # We've called final_touch before, and the bounds match. No need to
+        # reformulate a second time.
+        return
+    elseif bridge.bounds[i] != ret
+        # There is a stored bound, and the current bounds do not match. This
+        # means the model has been modified since the previous call to
+        # final_touch. We need to delete the bridge and start again.
+        MOI.delete(model, bridge)
+        MOI.Bridges.final_touch(bridge, model)
+        return
     end
     unit_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
     convex_f = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], zero(T))
@@ -262,15 +281,13 @@ function MOI.Bridges.final_touch(
     bridge::CountGreaterThanToMILPBridge{T,F},
     model::MOI.ModelLike,
 ) where {T,F}
-    # Clear any existing reformulations!
-    MOI.delete(model, bridge)
     Sx = Dict{T,Vector{MOI.VariableIndex}}()
     Sy = Dict{T,Vector{MOI.VariableIndex}}()
     scalars = collect(MOI.Utilities.eachscalar(bridge.f))
     bounds = Dict{MOI.VariableIndex,NTuple{2,T}}()
-    _add_unit_expansion(bridge, model, Sy, bounds, scalars[2])
+    _add_unit_expansion(bridge, model, Sy, bounds, scalars[2], 1)
     for i in 3:length(scalars)
-        _add_unit_expansion(bridge, model, Sx, bounds, scalars[i])
+        _add_unit_expansion(bridge, model, Sx, bounds, scalars[i], i - 1)
     end
     # We use a sort so that the model order is deterministic.
     for s in sort!(collect(keys(Sy)))

--- a/src/Bridges/Constraint/bridges/count_greater_than.jl
+++ b/src/Bridges/Constraint/bridges/count_greater_than.jl
@@ -255,7 +255,7 @@ function _add_unit_expansion(
         new_var, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
         push!(bridge.variables, new_var)
         if !haskey(S, xi)
-            S[xi] = Tuple{Float64,MOI.VariableIndex}[]
+            S[xi] = Tuple{T,MOI.VariableIndex}[]
         end
         push!(S[xi], new_var)
         push!(unit_f.terms, MOI.ScalarAffineTerm(T(-xi), new_var))

--- a/test/Bridges/Constraint/bin_packing.jl
+++ b/test/Bridges/Constraint/bin_packing.jl
@@ -98,6 +98,22 @@ function test_runtests_VectorAffineFunction()
     return
 end
 
+function test_resolve_with_modified()
+    inner = MOI.Utilities.Model{Int}()
+    model = MOI.Bridges.Constraint.BinPackingToMILP{Int}(inner)
+    x = MOI.add_variables(model, 3)
+    c = MOI.add_constraint.(model, x, MOI.Interval(1, 2))
+    f = MOI.VectorOfVariables(x)
+    MOI.add_constraint(model, f, MOI.BinPacking(3, [1, 2, 3]))
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 3
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 9
+    MOI.set(model, MOI.ConstraintSet(), c[2], MOI.Interval(1, 3))
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 10
+    return
+end
+
 function test_runtests_error_variable()
     inner = MOI.Utilities.Model{Int}()
     model = MOI.Bridges.Constraint.BinPackingToMILP{Int}(inner)

--- a/test/Bridges/Constraint/count_belongs.jl
+++ b/test/Bridges/Constraint/count_belongs.jl
@@ -83,6 +83,22 @@ function test_runtests_VectorAffineFunction()
     return
 end
 
+function test_resolve_with_modified()
+    inner = MOI.Utilities.Model{Int}()
+    model = MOI.Bridges.Constraint.CountBelongsToMILP{Int}(inner)
+    x = MOI.add_variables(model, 3)
+    c = MOI.add_constraint.(model, x, MOI.Interval(1, 2))
+    f = MOI.VectorOfVariables(x)
+    MOI.add_constraint(model, f, MOI.CountBelongs(3, Set([2, 4])))
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 3
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 7
+    MOI.set(model, MOI.ConstraintSet(), c[2], MOI.Interval(1, 3))
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 8
+    return
+end
+
 function test_runtests_error_variable()
     inner = MOI.Utilities.Model{Int}()
     model = MOI.Bridges.Constraint.CountBelongsToMILP{Int}(inner)

--- a/test/Bridges/Constraint/count_distinct.jl
+++ b/test/Bridges/Constraint/count_distinct.jl
@@ -101,6 +101,21 @@ function test_runtests_VectorAffineFunction()
     return
 end
 
+function test_resolve_with_modified()
+    inner = MOI.Utilities.Model{Int}()
+    model = MOI.Bridges.Constraint.CountDistinctToMILP{Int}(inner)
+    x = MOI.add_variables(model, 3)
+    c = MOI.add_constraint.(model, x, MOI.Interval(0, 2))
+    MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.CountDistinct(3))
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 3
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 12
+    MOI.set(model, MOI.ConstraintSet(), c[3], MOI.Interval(0, 1))
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 11
+    return
+end
+
 function test_runtests_error_variable()
     inner = MOI.Utilities.Model{Int}()
     model = MOI.Bridges.Constraint.CountDistinctToMILP{Int}(inner)

--- a/test/Bridges/Constraint/count_distinct_reif.jl
+++ b/test/Bridges/Constraint/count_distinct_reif.jl
@@ -117,6 +117,22 @@ function test_runtests_VectorAffineFunction()
     return
 end
 
+function test_resolve_with_modified()
+    inner = MOI.Utilities.Model{Int}()
+    model = MOI.Bridges.Constraint.ReifiedCountDistinctToMILP{Int}(inner)
+    x = MOI.add_variables(model, 4)
+    c = MOI.add_constraint.(model, x, MOI.Interval(0, 2))
+    f = MOI.VectorOfVariables(x)
+    MOI.add_constraint(model, f, MOI.Reified(MOI.CountDistinct(3)))
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 4
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 17
+    MOI.set(model, MOI.ConstraintSet(), c[3], MOI.Interval(0, 1))
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 16
+    return
+end
+
 function test_runtests_error_variable()
     inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Int}())
     model = MOI.Bridges.Constraint.ReifiedCountDistinctToMILP{Int}(inner)

--- a/test/Bridges/Constraint/count_greater_than.jl
+++ b/test/Bridges/Constraint/count_greater_than.jl
@@ -101,6 +101,21 @@ function test_runtests_VectorAffineFunction()
     return
 end
 
+function test_resolve_with_modified()
+    inner = MOI.Utilities.Model{Int}()
+    model = MOI.Bridges.Constraint.CountGreaterThanToMILP{Int}(inner)
+    x = MOI.add_variables(model, 3)
+    c = MOI.add_constraint.(model, x, MOI.Interval(0, 2))
+    MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.CountGreaterThan(3))
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 3
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 9
+    MOI.set(model, MOI.ConstraintSet(), c[3], MOI.Interval(0, 1))
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 8
+    return
+end
+
 function test_runtests_error_variable()
     inner = MOI.Utilities.Model{Int}()
     model = MOI.Bridges.Constraint.CountGreaterThanToMILP{Int}(inner)


### PR DESCRIPTION
Closes #2088 

So I think the previous implementation was technically correct, if a little slower than need be because it would always reformulate.

Now we cache the bounds and only reformulate if the bounds have changed since the last call.

This fixes the original SCIP issue:
```Julia
julia> using JuMP, SCIP

julia> model = Model(SCIP.Optimizer)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: SCIP

julia> @variable(model, 0 <= s <= 2, Int)
s

julia> @variable(model, n)
n

julia> @constraint(model, s + n <= 3)
s + n ≤ 3.0

julia> @constraint(model, [n, s] in MOI.CountBelongs(2, Set([1])))
[n, s] ∈ MathOptInterface.CountBelongs(2, Set([1]))

julia> optimize!(model)
presolving:
(round 1, fast)       1 del vars, 1 del conss, 0 add conss, 3 chg bounds, 0 chg sides, 0 chg coeffs, 0 upgd conss, 1 impls, 2 clqs
(round 2, fast)       2 del vars, 2 del conss, 0 add conss, 3 chg bounds, 0 chg sides, 0 chg coeffs, 0 upgd conss, 1 impls, 2 clqs
(round 3, fast)       2 del vars, 2 del conss, 0 add conss, 3 chg bounds, 2 chg sides, 1 chg coeffs, 0 upgd conss, 1 impls, 2 clqs
   (0.0s) running MILP presolver
   (0.0s) MILP presolver (2 rounds): 0 aggregations, 3 fixings, 0 bound changes
presolving (4 rounds: 4 fast, 1 medium, 1 exhaustive):
 5 deleted vars, 4 deleted constraints, 0 added constraints, 3 tightened bounds, 0 added holes, 2 changed sides, 1 changed coefficients
 1 implications, 0 cliques
transformed 1/1 original solutions to the transformed problem space
Presolving Time: 0.01

SCIP Status        : problem is solved [optimal solution found]
Solving Time (sec) : 0.01
Solving Nodes      : 0
Primal Bound       : +0.00000000000000e+00 (1 solutions)
Dual Bound         : +0.00000000000000e+00
Gap                : 0.00 %
```

But you can still break SCIP by modifying a variable bound between solves:
```julia
julia> set_lower_bound(s, 1)

julia> optimize!(model)
ERROR: MathOptInterface.DeleteNotAllowed{MathOptInterface.VariableIndex}: Deleting the index MathOptInterface.VariableIndex(3) cannot be performed: Can not delete variable while model contains constraints! You may want to use a `CachingOptimizer` in `AUTOMATIC` mode or you may need to call `reset_optimizer` before doing this operation if the `CachingOptimizer` is in `MANUAL` mode.
Stacktrace:
  [1] delete(o::SCIP.Optimizer, vi::MathOptInterface.VariableIndex)
```