### PR TITLE
[Bridges] Add FixParametricVariablesBridge

### DIFF
--- a/docs/src/submodules/Bridges/list_of_bridges.md
+++ b/docs/src/submodules/Bridges/list_of_bridges.md
@@ -68,6 +68,7 @@ Bridges.Constraint.CountDistinctToMILPBridge
 Bridges.Constraint.ReifiedCountDistinctToMILPBridge
 Bridges.Constraint.CountGreaterThanToMILPBridge
 Bridges.Constraint.TableToMILPBridge
+Bridges.Constraint.FixParametricVariablesBridge
 ```
 
 ## [Objective bridges](@id objective_bridges_ref)

--- a/docs/src/submodules/Bridges/list_of_bridges.md
+++ b/docs/src/submodules/Bridges/list_of_bridges.md
@@ -68,7 +68,7 @@ Bridges.Constraint.CountDistinctToMILPBridge
 Bridges.Constraint.ReifiedCountDistinctToMILPBridge
 Bridges.Constraint.CountGreaterThanToMILPBridge
 Bridges.Constraint.TableToMILPBridge
-Bridges.Constraint.FixParametricVariablesBridge
+Bridges.Constraint._FixParametricVariablesBridge
 ```
 
 ## [Objective bridges](@id objective_bridges_ref)

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -27,6 +27,7 @@ include("bridges/count_distinct.jl")
 include("bridges/count_distinct_reif.jl")
 include("bridges/count_greater_than.jl")
 include("bridges/det.jl")
+include("bridges/fix_parametric_variables.jl")
 include("bridges/flip_sign.jl")
 include("bridges/functionize.jl")
 include("bridges/geomean_to_power.jl")
@@ -127,6 +128,8 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(bridged_model, ReifiedCountDistinctToMILPBridge{T})
     MOI.Bridges.add_bridge(bridged_model, CountGreaterThanToMILPBridge{T})
     MOI.Bridges.add_bridge(bridged_model, TableToMILPBridge{T})
+    # We do not add `FixParametricVariablesBridge` since it it only valid for
+    # a special case of problem formulations.
     return
 end
 

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -128,7 +128,7 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(bridged_model, ReifiedCountDistinctToMILPBridge{T})
     MOI.Bridges.add_bridge(bridged_model, CountGreaterThanToMILPBridge{T})
     MOI.Bridges.add_bridge(bridged_model, TableToMILPBridge{T})
-    # We do not add `FixParametricVariablesBridge` since it it only valid for
+    # We do not add `_FixParametricVariablesBridge` since it it only valid for
     # a special case of problem formulations.
     return
 end

--- a/src/Bridges/Constraint/bridges/fix_parametric_variables.jl
+++ b/src/Bridges/Constraint/bridges/fix_parametric_variables.jl
@@ -28,10 +28,10 @@ end
 
 function MOI.supports_constraint(
     ::Type{<:FixParametricVariablesBridge{T}},
-	::Type{MOI.ScalarQuadraticFunction{T}},
-	::Type{<:MOI.AbstractScalarSet},
+    ::Type{MOI.ScalarQuadraticFunction{T}},
+    ::Type{<:MOI.AbstractScalarSet},
 ) where {T}
-	return true
+    return true
 end
 
 function concrete_bridge_type(
@@ -45,13 +45,13 @@ end
 function MOI.Bridges.added_constrained_variable_types(
     ::Type{<:FixParametricVariablesBridge},
 )
-	return Tuple{Type}[]
+    return Tuple{Type}[]
 end
 
 function MOI.Bridges.added_constraint_types(
     ::Type{FixParametricVariablesBridge{T,S}},
 ) where {T,S}
-	return Tuple{Type,Type}[(MOI.ScalarAffineFunction{T}, S)]
+    return Tuple{Type,Type}[(MOI.ScalarAffineFunction{T}, S)]
 end
 
 function MOI.get(
@@ -70,20 +70,14 @@ function MOI.get(
     return MOI.get(model, MOI.ConstraintSet(), bridge.affine_constraint)
 end
 
-function MOI.delete(
-    model::MOI.ModelLike,
-    bridge::FixParametricVariablesBridge,
-)
+function MOI.delete(model::MOI.ModelLike, bridge::FixParametricVariablesBridge)
     MOI.delete(model, bridge.affine_constraint)
     return
 end
 
 MOI.get(::FixParametricVariablesBridge, ::MOI.NumberOfVariables)::Int64 = 0
 
-function MOI.get(
-    ::FixParametricVariablesBridge,
-    ::MOI.ListOfVariableIndices,
-)
+function MOI.get(::FixParametricVariablesBridge, ::MOI.ListOfVariableIndices)
     return MOI.VariableIndex[]
 end
 

--- a/src/Bridges/Constraint/bridges/fix_parametric_variables.jl
+++ b/src/Bridges/Constraint/bridges/fix_parametric_variables.jl
@@ -1,0 +1,167 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+"""
+    FixParametricVariablesBridge{T,S} <: AbstractBridge
+"""
+struct FixParametricVariablesBridge{T,S} <: AbstractBridge
+    affine_constraint::MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},S}
+    f::MOI.ScalarQuadraticFunction{T}
+end
+
+const FixParametricVariables{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{FixParametricVariablesBridge{T},OT}
+
+function bridge_constraint(
+    ::Type{FixParametricVariablesBridge{T,S}},
+    model::MOI.ModelLike,
+    f::MOI.ScalarQuadraticFunction{T},
+    s::S,
+) where {T,S<:MOI.AbstractScalarSet}
+    affine = MOI.ScalarAffineFunction(f.affine_terms, f.constant)
+    ci = MOI.add_constraint(model, affine, s)
+    return FixParametricVariablesBridge{T,S}(ci, f)
+end
+
+function MOI.supports_constraint(
+    ::Type{<:FixParametricVariablesBridge{T}},
+	::Type{MOI.ScalarQuadraticFunction{T}},
+	::Type{<:MOI.AbstractScalarSet},
+) where {T}
+	return true
+end
+
+function concrete_bridge_type(
+    ::Type{<:FixParametricVariablesBridge},
+    ::Type{MOI.ScalarQuadraticFunction{T}},
+    ::Type{S},
+) where {T,S<:MOI.AbstractScalarSet}
+    return FixParametricVariablesBridge{T,S}
+end
+
+function MOI.Bridges.added_constrained_variable_types(
+    ::Type{<:FixParametricVariablesBridge},
+)
+	return Tuple{Type}[]
+end
+
+function MOI.Bridges.added_constraint_types(
+    ::Type{FixParametricVariablesBridge{T,S}},
+) where {T,S}
+	return Tuple{Type,Type}[(MOI.ScalarAffineFunction{T}, S)]
+end
+
+function MOI.get(
+    ::MOI.ModelLike,
+    ::MOI.ConstraintFunction,
+    bridge::FixParametricVariablesBridge,
+)
+    return bridge.f
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    ::MOI.ConstraintSet,
+    bridge::FixParametricVariablesBridge,
+)
+    return MOI.get(model, MOI.ConstraintSet(), bridge.affine_constraint)
+end
+
+function MOI.delete(
+    model::MOI.ModelLike,
+    bridge::FixParametricVariablesBridge,
+)
+    MOI.delete(model, bridge.affine_constraint)
+    return
+end
+
+MOI.get(::FixParametricVariablesBridge, ::MOI.NumberOfVariables)::Int64 = 0
+
+function MOI.get(
+    ::FixParametricVariablesBridge,
+    ::MOI.ListOfVariableIndices,
+)
+    return MOI.VariableIndex[]
+end
+
+function MOI.get(
+    bridge::FixParametricVariablesBridge{T,S},
+    ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},S},
+)::Int64 where {T,S}
+    return 1
+end
+
+function MOI.get(
+    bridge::FixParametricVariablesBridge{T,S},
+    ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T},S},
+) where {T,S}
+    return [bridge.affine_constraint]
+end
+
+MOI.Bridges.needs_final_touch(::FixParametricVariablesBridge) = true
+
+function _get_fix_value(model, values::Dict{MOI.VariableIndex,T}, x) where {T}
+    v = get(values, x, nothing)
+    if v !== nothing
+        return v
+    end
+    ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{T}}(x.value)
+    if MOI.is_valid(model, ci)
+        v = MOI.get(model, MOI.ConstraintSet(), ci).value
+        values[x] = v
+        return v
+    end
+    return nothing
+end
+
+function _get_affine_coefficient(f::MOI.ScalarQuadraticFunction{T}, x) where {T}
+    c = zero(T)
+    for t in f.affine_terms
+        if t.variable == x
+            c += t.coefficient
+        end
+    end
+    return c
+end
+
+function MOI.Bridges.final_touch(
+    bridge::FixParametricVariablesBridge{T,S},
+    model::MOI.ModelLike,
+) where {T,S}
+    values = Dict{MOI.VariableIndex,T}()
+    new_coefs = Dict{MOI.VariableIndex,T}()
+    for term in bridge.f.quadratic_terms
+        v1 = _get_fix_value(model, values, term.variable_1)
+        v2 = _get_fix_value(model, values, term.variable_2)
+        if v1 !== nothing
+            new_coef = v1 * term.coefficient
+            if haskey(new_coefs, term.variable_2)
+                new_coefs[term.variable_2] += new_coef
+            else
+                coef = _get_affine_coefficient(bridge.f, term.variable_2)
+                new_coefs[term.variable_2] = coef + new_coef
+            end
+        elseif v2 !== nothing
+            new_coef = v2 * term.coefficient
+            if haskey(new_coefs, term.variable_1)
+                new_coefs[term.variable_1] += new_coef
+            else
+                coef = _get_affine_coefficient(bridge.f, term.variable_1)
+                new_coefs[term.variable_1] = coef + new_coef
+            end
+        else
+            error("At least one variable is not fixed")
+        end
+    end
+    for (k, v) in new_coefs
+        MOI.modify(
+            model,
+            bridge.affine_constraint,
+            MOI.ScalarCoefficientChange(k, v),
+        )
+    end
+    return
+end

--- a/src/Bridges/Constraint/bridges/fix_parametric_variables.jl
+++ b/src/Bridges/Constraint/bridges/fix_parametric_variables.jl
@@ -9,13 +9,18 @@
 
 `FixParametricVariablesBridge` implements the following reformulation:
 
-  * ``f(x) \\in S`` into ``g(x) \\in S``, where ``g(x)`` is a
-    [`MOI.ScalarQuadraticFunction{T}`](@ref) and ``f(x)`` is a
-    [`MOI.ScalarAffineFunction{T}`](@ref) with all variables fixed using a
-    [`MOI.VariableIndex`](@ref)-in-[`MOI.EqualTo`](@ref) constraint replaced by
-    their corresponding constant.
+  * ``f(x) \\in S`` into ``g(x) \\in S``, where ``f(x)`` is a
+    [`MOI.ScalarQuadraticFunction{T}`](@ref) and ``g(x)`` is a
+    [`MOI.ScalarAffineFunction{T}`](@ref), where all variables that are fixed
+    using a [`MOI.VariableIndex`](@ref)-in-[`MOI.EqualTo`](@ref) constraint and
+    that appear in a quadratic term are replaced by their corresponding
+    constant.
 
-An error is thrown if, after fixing variables, ``f(x)`` is not an affine
+For example, if `p == 3`, this bridge converts the quadratic term `0.3 * p * x`
+into the linear term `0.9 * x`. Moreover, a linear term such as `0.3 * p` is
+left as `0.3 * p`.
+
+An error is thrown if, after fixing variables, ``g(x)`` is not an affine
 function,
 
 !!! warning

--- a/src/Bridges/Constraint/bridges/fix_parametric_variables.jl
+++ b/src/Bridges/Constraint/bridges/fix_parametric_variables.jl
@@ -16,8 +16,8 @@
   * ``f(x) \\in S`` into ``g(x) \\in S``, where ``f(x)`` is a
     [`MOI.ScalarQuadraticFunction{T}`](@ref) and ``g(x)`` is a
     [`MOI.ScalarAffineFunction{T}`](@ref), where all variables that are fixed
-    using a [`MOI.VariableIndex`](@ref)-in-[`MOI.EqualTo`](@ref) constraint and
-    that appear in a quadratic term are replaced by their corresponding
+    using a [`MOI.VariableIndex`](@ref)-in-[`MOI.Parameter`](@ref) constraint
+    and that appear in a quadratic term are replaced by their corresponding
     constant.
 
 For example, if `p == 3`, this bridge converts the quadratic term `0.3 * p * x`
@@ -163,7 +163,7 @@ function MOI.Bridges.final_touch(
     for x in keys(bridge.values)
         bridge.values[x] = nothing
         bridge.new_coefs[x] = zero(T)
-        ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{T}}(x.value)
+        ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.Parameter{T}}(x.value)
         if MOI.is_valid(model, ci)
             bridge.values[x] = MOI.get(model, MOI.ConstraintSet(), ci).value
         end

--- a/test/Bridges/Constraint/fix_parametric_variables.jl
+++ b/test/Bridges/Constraint/fix_parametric_variables.jl
@@ -92,6 +92,60 @@ function test_runtests_duplicates()
     return
 end
 
+function test_runtests_squared()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.FixParametricVariablesBridge,
+        """
+        variables: x, y
+        c: 2.0 * x * x + y >= 1.0
+        x == 3.0
+        """,
+        """
+        variables: x, y
+        c: 6.0 * x + y >= 1.0
+        x == 3.0
+        """,
+    )
+    return
+end
+
+function test_at_least_one_variable_is_not_fixed()
+    inner = MOI.Utilities.Model{Int}()
+    model = MOI.Bridges.Constraint.FixParametricVariables{Int}(inner)
+    x, y = MOI.add_variables(model, 2)
+    f = 1 * x * y + 2 * x + 3 * y
+    MOI.add_constraint(model, f, MOI.EqualTo(0))
+    @test_throws(
+        ErrorException("At least one variable is not fixed"),
+        MOI.Bridges.final_touch(model),
+    )
+    return
+end
+
+function test_resolve_with_modified()
+    inner = MOI.Utilities.Model{Int}()
+    model = MOI.Bridges.Constraint.FixParametricVariables{Int}(inner)
+    x, y = MOI.add_variables(model, 2)
+    f = 1 * x * y + 2 * x + 3 * y
+    c = MOI.add_constraint(model, f, MOI.EqualTo(0))
+    MOI.add_constraint(model, x, MOI.EqualTo(2))
+    MOI.Bridges.final_touch(model)
+    z = MOI.get(inner, MOI.ListOfVariableIndices())
+    cis = MOI.get(inner, MOI.ListOfConstraintIndices{F,MOI.EqualTo{Int}}())
+    @test length(cis) == 1
+    f = MOI.get(inner, MOI.ConstraintFunction(), cis[1])
+    @test f ≈ 2 * z[1] + 5 * z[2]
+    MOI.modify(model, c, MOI.ScalarCoefficientChange(y, 4))
+    MOI.Bridges.final_touch(model)
+    F = MOI.ScalarAffineFunction{Int}
+    z = MOI.get(inner, MOI.ListOfVariableIndices())
+    cis = MOI.get(inner, MOI.ListOfConstraintIndices{F,MOI.EqualTo{Int}}())
+    @test length(cis) == 1
+    f = MOI.get(inner, MOI.ConstraintFunction(), cis[1])
+    @test f ≈ 2 * z[1] + 6 * z[2]
+    return
+end
+
 end  # module
 
 TestConstraintFixParametricVariables.runtests()

--- a/test/Bridges/Constraint/fix_parametric_variables.jl
+++ b/test/Bridges/Constraint/fix_parametric_variables.jl
@@ -92,7 +92,6 @@ function test_runtests_duplicates()
     return
 end
 
-
 end  # module
 
 TestConstraintFixParametricVariables.runtests()

--- a/test/Bridges/Constraint/fix_parametric_variables.jl
+++ b/test/Bridges/Constraint/fix_parametric_variables.jl
@@ -1,0 +1,98 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestConstraintFixParametricVariables
+
+using Test
+
+using MathOptInterface
+const MOI = MathOptInterface
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function test_runtests_x_fixed()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.FixParametricVariablesBridge,
+        """
+        variables: x, y
+        c: 1.0 * x * y + x + y >= 1.0
+        x == 2.0
+        """,
+        """
+        variables: x, y
+        c: 3.0 * y + x >= 1.0
+        x == 2.0
+        """,
+    )
+    return
+end
+
+function test_runtests_y_fixed()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.FixParametricVariablesBridge,
+        """
+        variables: x, y
+        c: 1.0 * x * y + x + y >= 1.0
+        y == 2.0
+        """,
+        """
+        variables: x, y
+        c: 3.0 * x + y >= 1.0
+        y == 2.0
+        """,
+    )
+    return
+end
+
+function test_runtests_both_fixed()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.FixParametricVariablesBridge,
+        """
+        variables: x, y
+        c: 1.0 * x * y + x + y >= 1.0
+        x == 3.0
+        y == 2.0
+        """,
+        """
+        variables: x, y
+        c: 4.0 * y + x >= 1.0
+        x == 3.0
+        y == 2.0
+        """,
+    )
+    return
+end
+
+function test_runtests_duplicates()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.FixParametricVariablesBridge,
+        """
+        variables: x, y
+        c: 1.0 * x * y + 2.0 * x * y + x + y + x >= 1.0
+        x == 3.0
+        """,
+        """
+        variables: x, y
+        c: 10.0 * y + 2.0 * x >= 1.0
+        x == 3.0
+        """,
+    )
+    return
+end
+
+
+end  # module
+
+TestConstraintFixParametricVariables.runtests()

--- a/test/Bridges/Constraint/fix_parametric_variables.jl
+++ b/test/Bridges/Constraint/fix_parametric_variables.jl
@@ -131,13 +131,13 @@ function test_resolve_with_modified()
     MOI.add_constraint(model, x, MOI.EqualTo(2))
     MOI.Bridges.final_touch(model)
     z = MOI.get(inner, MOI.ListOfVariableIndices())
+    F = MOI.ScalarAffineFunction{Int}
     cis = MOI.get(inner, MOI.ListOfConstraintIndices{F,MOI.EqualTo{Int}}())
     @test length(cis) == 1
     f = MOI.get(inner, MOI.ConstraintFunction(), cis[1])
     @test f ≈ 2 * z[1] + 5 * z[2]
     MOI.modify(model, c, MOI.ScalarCoefficientChange(y, 4))
     MOI.Bridges.final_touch(model)
-    F = MOI.ScalarAffineFunction{Int}
     z = MOI.get(inner, MOI.ListOfVariableIndices())
     cis = MOI.get(inner, MOI.ListOfConstraintIndices{F,MOI.EqualTo{Int}}())
     @test length(cis) == 1

--- a/test/Bridges/Constraint/fix_parametric_variables.jl
+++ b/test/Bridges/Constraint/fix_parametric_variables.jl
@@ -8,8 +8,7 @@ module TestConstraintFixParametricVariables
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/fix_parametric_variables.jl
+++ b/test/Bridges/Constraint/fix_parametric_variables.jl
@@ -24,7 +24,7 @@ end
 
 function test_runtests_x_fixed()
     MOI.Bridges.runtests(
-        MOI.Bridges.Constraint.FixParametricVariablesBridge,
+        MOI.Bridges.Constraint._FixParametricVariablesBridge,
         """
         variables: x, y
         c: 1.0 * x * y + x + y >= 1.0
@@ -41,7 +41,7 @@ end
 
 function test_runtests_y_fixed()
     MOI.Bridges.runtests(
-        MOI.Bridges.Constraint.FixParametricVariablesBridge,
+        MOI.Bridges.Constraint._FixParametricVariablesBridge,
         """
         variables: x, y
         c: 1.0 * x * y + x + y >= 1.0
@@ -58,7 +58,7 @@ end
 
 function test_runtests_both_fixed()
     MOI.Bridges.runtests(
-        MOI.Bridges.Constraint.FixParametricVariablesBridge,
+        MOI.Bridges.Constraint._FixParametricVariablesBridge,
         """
         variables: x, y
         c: 1.0 * x * y + x + y >= 1.0
@@ -77,7 +77,7 @@ end
 
 function test_runtests_duplicates()
     MOI.Bridges.runtests(
-        MOI.Bridges.Constraint.FixParametricVariablesBridge,
+        MOI.Bridges.Constraint._FixParametricVariablesBridge,
         """
         variables: x, y
         c: 1.0 * x * y + 2.0 * x * y + x + y + x >= 1.0
@@ -94,7 +94,7 @@ end
 
 function test_runtests_squared()
     MOI.Bridges.runtests(
-        MOI.Bridges.Constraint.FixParametricVariablesBridge,
+        MOI.Bridges.Constraint._FixParametricVariablesBridge,
         """
         variables: x, y
         c: 2.0 * x * x + y >= 1.0
@@ -117,7 +117,7 @@ function test_at_least_one_variable_is_not_fixed()
     MOI.add_constraint(model, f, MOI.EqualTo(0))
     @test_throws(
         ErrorException(
-            "unable to use `FixParametricVariablesBridge: at least one " *
+            "unable to use `_FixParametricVariablesBridge: at least one " *
             "variable is not fixed",
         ),
         MOI.Bridges.final_touch(model),

--- a/test/Bridges/Constraint/fix_parametric_variables.jl
+++ b/test/Bridges/Constraint/fix_parametric_variables.jl
@@ -28,12 +28,12 @@ function test_runtests_x_fixed()
         """
         variables: x, y
         c: 1.0 * x * y + x + y >= 1.0
-        x == 2.0
+        x in Parameter(2.0)
         """,
         """
         variables: x, y
         c: 3.0 * y + x >= 1.0
-        x == 2.0
+        x in Parameter(2.0)
         """,
     )
     return
@@ -45,12 +45,12 @@ function test_runtests_y_fixed()
         """
         variables: x, y
         c: 1.0 * x * y + x + y >= 1.0
-        y == 2.0
+        y in Parameter(2.0)
         """,
         """
         variables: x, y
         c: 3.0 * x + y >= 1.0
-        y == 2.0
+        y in Parameter(2.0)
         """,
     )
     return
@@ -62,14 +62,14 @@ function test_runtests_both_fixed()
         """
         variables: x, y
         c: 1.0 * x * y + x + y >= 1.0
-        x == 3.0
-        y == 2.0
+        x in Parameter(3.0)
+        y in Parameter(2.0)
         """,
         """
         variables: x, y
         c: 4.0 * y + x >= 1.0
-        x == 3.0
-        y == 2.0
+        x in Parameter(3.0)
+        y in Parameter(2.0)
         """,
     )
     return
@@ -81,12 +81,12 @@ function test_runtests_duplicates()
         """
         variables: x, y
         c: 1.0 * x * y + 2.0 * x * y + x + y + x >= 1.0
-        x == 3.0
+        x in Parameter(3.0)
         """,
         """
         variables: x, y
         c: 10.0 * y + 2.0 * x >= 1.0
-        x == 3.0
+        x in Parameter(3.0)
         """,
     )
     return
@@ -98,12 +98,12 @@ function test_runtests_squared()
         """
         variables: x, y
         c: 2.0 * x * x + y >= 1.0
-        x == 3.0
+        x in Parameter(3.0)
         """,
         """
         variables: x, y
         c: 6.0 * x + y >= 1.0
-        x == 3.0
+        x in Parameter(3.0)
         """,
     )
     return
@@ -114,7 +114,7 @@ function test_at_least_one_variable_is_not_fixed()
     model = MOI.Bridges.Constraint.FixParametricVariables{Int}(inner)
     x, y = MOI.add_variables(model, 2)
     f = 1 * x * y + 2 * x + 3 * y
-    MOI.add_constraint(model, f, MOI.EqualTo(0))
+    MOI.add_constraint(model, f, MOI.Parameter(0))
     @test_throws(
         ErrorException(
             "unable to use `_FixParametricVariablesBridge: at least one " *
@@ -130,19 +130,19 @@ function test_resolve_with_modified()
     model = MOI.Bridges.Constraint.FixParametricVariables{Int}(inner)
     x, y = MOI.add_variables(model, 2)
     f = 1 * x * y + 2 * x + 3 * y
-    c = MOI.add_constraint(model, f, MOI.EqualTo(0))
-    MOI.add_constraint(model, x, MOI.EqualTo(2))
+    c = MOI.add_constraint(model, f, MOI.Parameter(0))
+    MOI.add_constraint(model, x, MOI.Parameter(2))
     MOI.Bridges.final_touch(model)
     z = MOI.get(inner, MOI.ListOfVariableIndices())
     F = MOI.ScalarAffineFunction{Int}
-    cis = MOI.get(inner, MOI.ListOfConstraintIndices{F,MOI.EqualTo{Int}}())
+    cis = MOI.get(inner, MOI.ListOfConstraintIndices{F,MOI.Parameter{Int}}())
     @test length(cis) == 1
     f = MOI.get(inner, MOI.ConstraintFunction(), cis[1])
     @test f ≈ 2 * z[1] + 5 * z[2]
     MOI.modify(model, c, MOI.ScalarCoefficientChange(y, 4))
     MOI.Bridges.final_touch(model)
     z = MOI.get(inner, MOI.ListOfVariableIndices())
-    cis = MOI.get(inner, MOI.ListOfConstraintIndices{F,MOI.EqualTo{Int}}())
+    cis = MOI.get(inner, MOI.ListOfConstraintIndices{F,MOI.Parameter{Int}}())
     @test length(cis) == 1
     f = MOI.get(inner, MOI.ConstraintFunction(), cis[1])
     @test f ≈ 2 * z[1] + 6 * z[2]

--- a/test/Bridges/Constraint/fix_parametric_variables.jl
+++ b/test/Bridges/Constraint/fix_parametric_variables.jl
@@ -116,7 +116,10 @@ function test_at_least_one_variable_is_not_fixed()
     f = 1 * x * y + 2 * x + 3 * y
     MOI.add_constraint(model, f, MOI.EqualTo(0))
     @test_throws(
-        ErrorException("At least one variable is not fixed"),
+        ErrorException(
+            "unable to use `FixParametricVariablesBridge: at least one " *
+            "variable is not fixed",
+        ),
         MOI.Bridges.final_touch(model),
     )
     return


### PR DESCRIPTION
# Idea

_Preface: This PR was moved over from [PR#3211 in JuMP.jl](https://github.com/jump-dev/JuMP.jl/pull/3211). It is not meant as an actual PR, but more as starting point for the discussion of a possible implementation for (partial, not generally viable) parameters in (MI)LP models. I copied the relevant paragraphs._

The main idea originated while skimming through [this rework in PowerSimulations.jl](https://github.com/NREL-SIIP/PowerSimulations.jl/commit/8345963de2effcade1d4944c49a24068896e9a44#diff-17d6eaec9a0898dbd4527d1de3f5382d72ab85426bf1148633d048d9eb810a74R3): using fixed variables as parameters. While (from now on I'm only thinking about LPs) this works easily as long as the parameters are part of `b` (thought as in some constraints like `Ax <= b`), because the solver just eliminates them during presolve. However, as soon as they are part of `Ax`, they actually create an expression `param * var`, and since both of them are actually `JuMP.VariableRef` this will entail the creation of a `QuadExpr` (instead of an `AffExpr`).

After [asking about "multiplicative parameters"](https://discourse.julialang.org/t/jump-multiplicative-parameters-for-lp/94192/3), the idea (see [here](https://discourse.julialang.org/t/moi-re-evaluate-custom-bridge-direct-model-bridging/94219) for the first steps) was that - since solvers like `HiGHS` actually do not support quadratic terms in the constraints - adding a MathOptInterface bridge that converts `MOI.ScalarQuadraticFunction` into `MOI.ScalarAffineFunction` could

1. take the initial constraint,
2. find all quadratic terms in the underlying function,
3. lookup the values of all fixed variables that are involved,
4. replace the constraint by one containing an affine function were all fixed variables are replaced by their values

Therefore the usage of a "ParameterRef" would then entail:
1. creating a variable and fixing it to some value
2. using it like a constant (the "variable" will be replaced by its value before being passed to the solver)
3. calling `set_value(param, val) = fix(param, val; force=true)` automatically takes care of updating the parameter's value

# Initial prototype

I added the code that @odow [proposed](https://github.com/jump-dev/JuMP.jl/pull/3211#issuecomment-1423407976). 

A simple test model is available [in this gist](https://gist.github.com/sstroemer/34e1b84c1178a447876a039970a2260a). It implements a basic concept of something generating (`gen`) a commodity (here: heat) that can be stored (`charge`/`discharge`) into `state` (with some losses due to efficiency), while making sure that a given demand is met. All that for each timestep. The parameters are: the `demand` (RHS / constant), the `cost` (coefficient in the objective function) of generation, and the conversion efficiency `cop` (coefficient in the constraints). Those are randomized. While simple, this is a pretty "hard" example, since 50% of all constraints contain a multiplicative parameter that needs to be adjusted.

# Benchmarks

An initial performance test compares the timing for the steps: build, solve, re-build/update, re-solve. This is done for a standard model that is rebuilt from scratch each time vs. a parametric model. Timings (**all values given in milliseconds**) obtained from BenchmarkTools are listed below. All values correspond to **median** results. "Re-***" steps are only given for the parametric model, assuming that the standard would roughly be the same time in each iteration.

Percentage time increases/decreases for the total of the first iteration (_timing it. #1_) as well as all subsequent iterations (_timing it. #i_) are given at the end ("+" means the parametric model is slower, "-" means it's faster). `T` denotes the number of timesteps in the model; **scroll to the right!**.

|                   |  build (standard)  |  solve (standard)  |  total (standard)  |  build (parametric) |  solve (parametric) |  total (parametric) | rebuild (parametric) | resolve (parametric) |  "re"-total (parametric) | timing it. jump-dev/ParametricOptInterface.jl#1 | timing it. #i |
|---|---|---|---|---|---|---|---|---|---|---|---|
T=100:           |   0.33  |   2.18  |  2.51 |   0.83  |   2.84  |  3.67 |   0.22  |   0.51  |  0.74 | +46% | -71% |
T=1000:           |   1.87  |   21.85  |  23.71 |   2.87  |   32.16  |  35.03 |   2.83  |   4.79  |  7.63 | +48% | -68% |
T=10000:           |   17.16  |   276.28  |  293.44 |   29.93  |   797.46  |  827.39 |   92.98  |   73.24  |  166.21 | +172% | -43% |

While the overhead seems okay-ish for the first iteration (basically after 2 iterations we are already faster compared to rebuilding the model), a huge drop in performance can be seen for `T=10000`. I suspected some GC shenanigans, but compare:

```
# Build and pass a standard model to the solver
@benchmark optimize!(model_standard) setup=(
        p1 = get_params(1, 10000);
        model_standard=build_model(p1..., 10000; parametric=false);
        JuMP.set_time_limit_sec(model_standard, 1e-6)
    )
```
```
BenchmarkTools.Trial: 40 samples with 1 evaluation.
 Range (min … max):   96.336 ms … 113.824 ms  ┊ GC (min … max): 0.00% … 10.11%
 Time  (median):      99.600 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   103.616 ms ±   6.278 ms  ┊ GC (mean ± σ):  4.26% ±  5.18%

        ▅▅ █ ▂                                                   
  ▅▁▅▁▁▁██▅████▅▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▅▁▅████▅▁▅▁▁▅ ▁
  96.3 ms          Histogram: frequency by time          114 ms <

 Memory estimate: 32.43 MiB, allocs estimate: 220351.
```
---
```
# Build and pass a parametric model to the solver
@benchmark optimize!(model_parametric) setup=(
        p1 = get_params(1, 10000);
        model_parametric=build_model(p1..., 10000; parametric=true);
        JuMP.set_time_limit_sec(model_parametric, 1e-6)
    )
```
```
BenchmarkTools.Trial: 8 samples with 1 evaluation.
 Range (min … max):  622.821 ms … 671.644 ms  ┊ GC (min … max): 0.00% … 1.98%
 Time  (median):     642.528 ms               ┊ GC (median):    1.84%
 Time  (mean ± σ):   648.696 ms ±  16.536 ms  ┊ GC (mean ± σ):  1.49% ± 0.94%

  █                    ███ █                        █   █     █  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁█▁▁▁▁▁█ ▁
  623 ms           Histogram: frequency by time          672 ms <

 Memory estimate: 67.94 MiB, allocs estimate: 730572.
```

Memory usage and allocs for smaller models are basically the same ratio (~ 3:1), but I assume that some "non-model-size" related constant term seems to dominate the total time for "build+pass" there. 

# Notes

This is just a collection of notes/thoughts:

- It still does not work with `relax_with_penalty!(...)`
- Timings could be different for `direct_model(...)` (I'll check that later, didn't have enough time right now)