### PR TITLE
Use import MathOptInterface as MOI

### DIFF
--- a/docs/src/background/duality.md
+++ b/docs/src/background/duality.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/background/infeasibility_certificates.md
+++ b/docs/src/background/infeasibility_certificates.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/background/naming_conventions.md
+++ b/docs/src/background/naming_conventions.md
@@ -1,21 +1,20 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```
 
 # Naming conventions
 
-MOI follows several conventions for naming functions and structures. These 
+MOI follows several conventions for naming functions and structures. These
 should also be followed by packages extending MOI.
 
 ## Sets
 
-Sets encode the structure of constraints. Their names should follow the 
-following conventions: 
+Sets encode the structure of constraints. Their names should follow the
+following conventions:
 
 * Abstract types in the set hierarchy should begin with `Abstract` and end in
   `Set`, e.g., [`AbstractScalarSet`](@ref), [`AbstractVectorSet`](@ref).
@@ -26,10 +25,10 @@ following conventions:
 * Matrix-valued conic sets should provide two representations: `ConeSquare` and
   `ConeTriangle`, e.g., [`RootDetConeTriangle`](@ref) and
   [`RootDetConeSquare`](@ref). See [Matrix cones](@ref) for more details.
-* Scalar sets should be singular, not plural, e.g., [`Integer`](@ref), not 
+* Scalar sets should be singular, not plural, e.g., [`Integer`](@ref), not
   `Integers`.
-* As much as possible, the names should follow established conventions in the 
-  domain where this set is used: for instance, convex sets should have names 
-  close to those of [CVX](http://web.cvxr.com/cvx/doc/), and 
-  constraint-programming sets should follow 
+* As much as possible, the names should follow established conventions in the
+  domain where this set is used: for instance, convex sets should have names
+  close to those of [CVX](http://web.cvxr.com/cvx/doc/), and
+  constraint-programming sets should follow
   [MiniZinc](https://www.minizinc.org/doc-latest/en/)'s constraints.

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```
@@ -29,8 +28,7 @@ section for more details.
     MOI does not export functions, but for brevity we often omit qualifying
     names with the MOI module. Best practice is to have
     ```julia
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
     ```
     and prefix all MOI methods with `MOI.` in user code. If a name is also
     available in base Julia, we always explicitly use the module prefix, for

--- a/docs/src/manual/modification.md
+++ b/docs/src/manual/modification.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/manual/standard_form.md
+++ b/docs/src/manual/standard_form.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/reference/callbacks.md
+++ b/docs/src/reference/callbacks.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/reference/constraints.md
+++ b/docs/src/reference/constraints.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/reference/errors.md
+++ b/docs/src/reference/errors.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/reference/modification.md
+++ b/docs/src/reference/modification.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/reference/nonlinear.md
+++ b/docs/src/reference/nonlinear.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/reference/variables.md
+++ b/docs/src/reference/variables.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/Benchmarks/overview.md
+++ b/docs/src/submodules/Benchmarks/overview.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```
@@ -17,9 +16,7 @@ benchmark suite as follows:
 
 ```julia
 using SolverPackage  # Replace with your choice of solver.
-
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 suite = MOI.Benchmarks.suite() do
     SolverPackage.Optimizer()
@@ -36,9 +33,8 @@ Second, after making changes to the package, re-run the benchmark suite and
 compare to the prior saved results:
 
 ```julia
-using SolverPackage, MathOptInterface
-
-const MOI = MathOptInterface
+using SolverPackage
+import MathOptInterface as MOI
 
 suite = MOI.Benchmarks.suite() do
     SolverPackage.Optimizer()

--- a/docs/src/submodules/Benchmarks/reference.md
+++ b/docs/src/submodules/Benchmarks/reference.md
@@ -2,14 +2,6 @@
 CurrentModule = MathOptInterface
 DocTestSetup = quote
     import MathOptInterface as MOI
-
-    # For compatibility with both Julia 1.0.5 and 1.5.2
-    # Upon the Julia LTS version becoming 1.6, these imports could be dropped,
-    # and all ScalarAffineTerm and VariableIndex instances in doctests below
-    # could be replaced with MOI.ScalarAffineTerm and MOI.VariableIndex
-    # Check discussion at PR 1184: https://github.com/jump-dev/MathOptInterface.jl/pull/1184#discussion_r515300914
-    import MathOptInterface.ScalarAffineTerm
-    import MathOptInterface.VariableIndex
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/Benchmarks/reference.md
+++ b/docs/src/submodules/Benchmarks/reference.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 
     # For compatibility with both Julia 1.0.5 and 1.5.2
     # Upon the Julia LTS version becoming 1.6, these imports could be dropped,

--- a/docs/src/submodules/Bridges/list_of_bridges.md
+++ b/docs/src/submodules/Bridges/list_of_bridges.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/Bridges/overview.md
+++ b/docs/src/submodules/Bridges/overview.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/Bridges/reference.md
+++ b/docs/src/submodules/Bridges/reference.md
@@ -2,14 +2,6 @@
 CurrentModule = MathOptInterface
 DocTestSetup = quote
     import MathOptInterface as MOI
-
-    # For compatibility with both Julia 1.0.5 and 1.5.2
-    # Upon the Julia LTS version becoming 1.6, these imports could be dropped,
-    # and all ScalarAffineTerm and VariableIndex instances in doctests below
-    # could be replaced with MOI.ScalarAffineTerm and MOI.VariableIndex
-    # Check discussion at PR 1184: https://github.com/jump-dev/MathOptInterface.jl/pull/1184#discussion_r515300914
-    import MathOptInterface.ScalarAffineTerm
-    import MathOptInterface.VariableIndex
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/Bridges/reference.md
+++ b/docs/src/submodules/Bridges/reference.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 
     # For compatibility with both Julia 1.0.5 and 1.5.2
     # Upon the Julia LTS version becoming 1.6, these imports could be dropped,

--- a/docs/src/submodules/FileFormats/overview.md
+++ b/docs/src/submodules/FileFormats/overview.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/FileFormats/reference.md
+++ b/docs/src/submodules/FileFormats/reference.md
@@ -2,14 +2,6 @@
 CurrentModule = MathOptInterface
 DocTestSetup = quote
     import MathOptInterface as MOI
-
-    # For compatibility with both Julia 1.0.5 and 1.5.2
-    # Upon the Julia LTS version becoming 1.6, these imports could be dropped,
-    # and all ScalarAffineTerm and VariableIndex instances in doctests below
-    # could be replaced with MOI.ScalarAffineTerm and MOI.VariableIndex
-    # Check discussion at PR 1184: https://github.com/jump-dev/MathOptInterface.jl/pull/1184#discussion_r515300914
-    import MathOptInterface.ScalarAffineTerm
-    import MathOptInterface.VariableIndex
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/FileFormats/reference.md
+++ b/docs/src/submodules/FileFormats/reference.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 
     # For compatibility with both Julia 1.0.5 and 1.5.2
     # Upon the Julia LTS version becoming 1.6, these imports could be dropped,

--- a/docs/src/submodules/Nonlinear/overview.md
+++ b/docs/src/submodules/Nonlinear/overview.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```
@@ -365,8 +364,7 @@ julia> MOI.set(model, MOI.NLPBlock(), block);
 Putting everything together, you can create a nonlinear optimization problem in
 MathOptInterface as follows:
 ```@example
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function build_model(
     model::MOI.ModelLike;

--- a/docs/src/submodules/Nonlinear/overview.md
+++ b/docs/src/submodules/Nonlinear/overview.md
@@ -37,7 +37,7 @@ best dealt with by other components of MathOptInterface.
 The core element of the `Nonlinear` submodule is
 [`Nonlinear.Model`](@ref):
 ```jldoctest nonlinear_developer
-julia> const Nonlinear = MathOptInterface.Nonlinear;
+julia> const Nonlinear = MOI.Nonlinear;
 
 julia> model = Nonlinear.Model()
 A Nonlinear.Model with:

--- a/docs/src/submodules/Nonlinear/reference.md
+++ b/docs/src/submodules/Nonlinear/reference.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/Test/overview.md
+++ b/docs/src/submodules/Test/overview.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```
@@ -27,10 +26,9 @@ The skeleton below can be used for the wrapper test file of a solver named
 module TestFooBar
 
 import FooBar
-using MathOptInterface
 using Test
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 const OPTIMIZER = MOI.instantiate(
     MOI.OptimizerWithAttributes(FooBar.Optimizer, MOI.Silent() => true),

--- a/docs/src/submodules/Test/reference.md
+++ b/docs/src/submodules/Test/reference.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/Utilities/overview.md
+++ b/docs/src/submodules/Utilities/overview.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -2,14 +2,6 @@
 CurrentModule = MathOptInterface
 DocTestSetup = quote
     import MathOptInterface as MOI
-
-    # For compatibility with both Julia 1.0.5 and 1.5.2
-    # Upon the Julia LTS version becoming 1.6, these imports could be dropped,
-    # and all ScalarAffineTerm and VariableIndex instances in doctests below
-    # could be replaced with MOI.ScalarAffineTerm and MOI.VariableIndex
-    # Check discussion at PR 1184: https://github.com/jump-dev/MathOptInterface.jl/pull/1184#discussion_r515300914
-    import MathOptInterface.ScalarAffineTerm
-    import MathOptInterface.VariableIndex
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/submodules/Utilities/reference.md
+++ b/docs/src/submodules/Utilities/reference.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 
     # For compatibility with both Julia 1.0.5 and 1.5.2
     # Upon the Julia LTS version becoming 1.6, these imports could be dropped,

--- a/docs/src/tutorials/bridging_constraint.md
+++ b/docs/src/tutorials/bridging_constraint.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/docs/src/tutorials/example.md
+++ b/docs/src/tutorials/example.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```
@@ -23,8 +22,7 @@ s.t. \; & w^\top x \le C \\
 
 Load the MathOptInterface module and define the shorthand `MOI`:
 ```julia
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 ```
 
 As an optimizer, we choose GLPK:

--- a/docs/src/tutorials/implementing.md
+++ b/docs/src/tutorials/implementing.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```
@@ -236,8 +235,7 @@ By convention, these optimizers should not be exported and should be named
 `PackageName.Optimizer`.
 
 ```julia
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 struct Optimizer <: MOI.AbstractOptimizer
     # Fields go here

--- a/docs/src/tutorials/latency.md
+++ b/docs/src/tutorials/latency.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```
@@ -179,8 +178,8 @@ tracks progress on reducing latency in MathOptInterface.
 
 A useful script is the following (replace GLPK as needed):
 ```julia
-using MathOptInterface, GLPK
-const MOI = MathOptInterface
+import GLPK
+import MathOptInterface as MOI
 
 function example_diet(optimizer, bridge)
     category_data = [

--- a/docs/src/tutorials/manipulating_expressions.md
+++ b/docs/src/tutorials/manipulating_expressions.md
@@ -1,8 +1,7 @@
 ```@meta
 CurrentModule = MathOptInterface
 DocTestSetup = quote
-    using MathOptInterface
-    const MOI = MathOptInterface
+    import MathOptInterface as MOI
 end
 DocTestFilters = [r"MathOptInterface|MOI"]
 ```

--- a/perf/bellman_ford.jl
+++ b/perf/bellman_ford.jl
@@ -5,10 +5,8 @@
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
 using BenchmarkTools
-using MathOptInterface
-const MOI = MathOptInterface
-const MOIU = MOI.Utilities
-const MOIB = MOI.Bridges
+import MathOptInterface as MOI
+import MathOptInterface.Utilities as MOIU
 
 # Model similar to SDPA format, it gives a good example because it does not
 # support a lot hence need a lot of bridges
@@ -25,17 +23,17 @@ MOI.supports(::SDPAModel, ::MOI.ObjectiveFunction{MOI.VariableIndex}) = false
 
 function interval_constraint()
     model = SDPAModel{Float64}()
-    bridged = MOIB.full_bridge_optimizer(model, Float64)
+    bridged = MOI.Bridges.full_bridge_optimizer(model, Float64)
     F = MOI.ScalarAffineFunction{Float64}
     S = MOI.Interval{Float64}
-    MOIB.bridge_index(bridged, F, S)
+    MOI.Bridges.bridge_index(bridged, F, S)
     display(@benchmark begin
-        MOIB._reset_bridge_graph($bridged)
-        MOIB.node($bridged, $F, $S)
+        MOI.Bridges._reset_bridge_graph($bridged)
+        MOI.Bridges.node($bridged, $F, $S)
     end)
     display(@benchmark begin
-        MOIB._reset_bridge_graph($bridged)
-        MOIB.bridge_index($bridged, $F, $S)
+        MOI.Bridges._reset_bridge_graph($bridged)
+        MOI.Bridges.bridge_index($bridged, $F, $S)
     end)
 end
 
@@ -43,16 +41,16 @@ interval_constraint()
 
 function quadratic_objective()
     model = SDPAModel{Float64}()
-    bridged = MOIB.full_bridge_optimizer(model, Float64)
+    bridged = MOI.Bridges.full_bridge_optimizer(model, Float64)
     F = MOI.ScalarQuadraticFunction{Float64}
-    MOIB.bridge_index(bridged, F)
+    MOI.Bridges.bridge_index(bridged, F)
     display(@benchmark begin
-        MOIB._reset_bridge_graph($bridged)
-        MOIB.node($bridged, $F)
+        MOI.Bridges._reset_bridge_graph($bridged)
+        MOI.Bridges.node($bridged, $F)
     end)
     display(@benchmark begin
-        MOIB._reset_bridge_graph($bridged)
-        MOIB.bridge_index($bridged, $F)
+        MOI.Bridges._reset_bridge_graph($bridged)
+        MOI.Bridges.bridge_index($bridged, $F)
     end)
 end
 

--- a/perf/cachingoptimizer.jl
+++ b/perf/cachingoptimizer.jl
@@ -9,9 +9,8 @@
 #     https://github.com/jump-dev/MathOptInterface.jl/pull/390
 
 using BenchmarkTools
-using MathOptInterface
-const MOI = MathOptInterface
-const MOIU = MOI.Utilities
+import MathOptInterface as MOI
+import MathOptInterface.Utilities as MOIU
 
 @MOIU.model Model () (MOI.Interval,) () () () (MOI.ScalarAffineFunction,) () ()
 optimizer = MOIU.MockOptimizer(Model{Float64}())

--- a/perf/time_to_first_solve/script.jl
+++ b/perf/time_to_first_solve/script.jl
@@ -4,10 +4,9 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-using MathOptInterface
-import GLPK
 import Clp
-const MOI = MathOptInterface
+import GLPK
+import MathOptInterface as MOI
 
 function example_diet(optimizer, bridge)
     category_data = [

--- a/src/Benchmarks/Benchmarks.jl
+++ b/src/Benchmarks/Benchmarks.jl
@@ -6,9 +6,10 @@
 
 module Benchmarks
 
-using BenchmarkTools, MathOptInterface
+using BenchmarkTools
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
+
 const BENCHMARKS = Dict{String,Function}()
 
 """

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -88,7 +88,7 @@ package-specific functions or sets to be used if the non-standard bridges
 are not added. Therefore, you are recommended to use
 `model = MOI.instantiate(Package.Optimizer; with_bridge_type = T)` instead of
 `model = MOI.instantiate(Package.Optimizer)`. See
-[`MathOptInterface.instantiate`](@ref).
+[`MOI.instantiate`](@ref).
 
 ## Examples
 

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -6,12 +6,10 @@
 
 module Bridges
 
-import MathOptInterface
+import MathOptInterface as MOI
 import OrderedCollections: OrderedDict
 import Printf
 import Test
-
-const MOI = MathOptInterface
 
 include("bridge.jl")
 include("set_map.jl")
@@ -34,7 +32,7 @@ coefficient type `T`, as well as the bridges in the list returned by the
 
 ## Example
 
-```jldoctest; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=:(import MathOptInterface as MOI)
 julia> model = MOI.Utilities.Model{Float64}();
 
 julia> bridged_model = MOI.Bridges.full_bridge_optimizer(model, Float64);
@@ -229,7 +227,7 @@ Run a series of tests that check the correctness of `Bridge`.
 
 ## Example
 
-```jldoctest; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=:(import MathOptInterface as MOI)
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.ZeroOneBridge,
            \"\"\"

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -7,12 +7,10 @@
 module Constraint
 
 import LinearAlgebra
-import MutableArithmetics
-import MathOptInterface
+import MutableArithmetics as MA
+import MathOptInterface as MOI
 import OrderedCollections: OrderedDict, OrderedSet
 import SparseArrays
-
-const MOI = MathOptInterface
 
 include("bridge.jl")
 include("map.jl")

--- a/src/Bridges/Constraint/bridge.jl
+++ b/src/Bridges/Constraint/bridge.jl
@@ -61,7 +61,7 @@ The [`SplitIntervalBridge`](@ref) bridges a [`MOI.VariableIndex`](@ref)-in-[`MOI
 constraint into a [`MOI.VariableIndex`](@ref)-in-[`MOI.GreaterThan`](@ref) and a
 [`MOI.VariableIndex`](@ref)-in-[`MOI.LessThan`](@ref) constraint.
 
-```jldoctest; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=:(import MathOptInterface as MOI)
 julia> MOI.Bridges.Constraint.concrete_bridge_type(
            MOI.Bridges.Constraint.SplitIntervalBridge{Float64},
            MOI.VariableIndex,

--- a/src/Bridges/Constraint/bridges/split_complex_equalto.jl
+++ b/src/Bridges/Constraint/bridges/split_complex_equalto.jl
@@ -88,7 +88,7 @@ function concrete_bridge_type(
     G::Type{<:MOI.Utilities.TypedLike},
     ::Type{<:MOI.EqualTo},
 ) where {T}
-    F = MutableArithmetics.promote_operation(imag, G)
+    F = MA.promote_operation(imag, G)
     return SplitComplexEqualToBridge{T,F,G}
 end
 

--- a/src/Bridges/Constraint/bridges/split_complex_zeros.jl
+++ b/src/Bridges/Constraint/bridges/split_complex_zeros.jl
@@ -105,7 +105,7 @@ function concrete_bridge_type(
     G::Type{<:MOI.Utilities.TypedLike},
     ::Type{MOI.Zeros},
 ) where {T}
-    F = MutableArithmetics.promote_operation(imag, G)
+    F = MA.promote_operation(imag, G)
     return SplitComplexZerosBridge{T,F,G}
 end
 

--- a/src/Bridges/Constraint/map.jl
+++ b/src/Bridges/Constraint/map.jl
@@ -219,7 +219,7 @@ end
 """
     variable_constraints(map::Map, vi::MOI.VariableIndex)
 
-Return the list of all keys corresponding to [`MathOptInterface.VariableIndex`](@ref)
+Return the list of all keys corresponding to [`MOI.VariableIndex`](@ref)
 constraints on the variable `vi`.
 """
 function variable_constraints(map::Map, vi::MOI.VariableIndex)
@@ -236,7 +236,7 @@ end
     vector_of_variables_constraints(map::Map)
 
 Return the list of all keys that correspond to
-[`MathOptInterface.VectorOfVariables`](@ref) constraints.
+[`MOI.VectorOfVariables`](@ref) constraints.
 """
 function vector_of_variables_constraints(map::Map)
     return MOI.Utilities.LazyMap{MOI.ConstraintIndex{MOI.VectorOfVariables}}(

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -15,18 +15,18 @@ into `F`-in-`S1` by mapping the function through `A`.
 
 The linear map `A` is described by;
 
- * [`MathOptInterface.Bridges.map_set`](@ref)
- * [`MathOptInterface.Bridges.map_function`](@ref).
+ * [`MOI.Bridges.map_set`](@ref)
+ * [`MOI.Bridges.map_function`](@ref).
 
 Implementing a method for these two functions is sufficient to bridge
 constraints. However, in order for the getters and setters of attributes such as
 dual solutions and starting values to work as well, a method for the following
 functions must be implemented:
 
- * [`MathOptInterface.Bridges.inverse_map_set`](@ref)
- * [`MathOptInterface.Bridges.inverse_map_function`](@ref)
- * [`MathOptInterface.Bridges.adjoint_map_function`](@ref)
- * [`MathOptInterface.Bridges.inverse_adjoint_map_function`](@ref)
+ * [`MOI.Bridges.inverse_map_set`](@ref)
+ * [`MOI.Bridges.inverse_map_function`](@ref)
+ * [`MOI.Bridges.adjoint_map_function`](@ref)
+ * [`MOI.Bridges.inverse_adjoint_map_function`](@ref)
 
 See the docstrings of each function to see which feature would be missing if it
 was not implemented for a given bridge.

--- a/src/Bridges/Constraint/single_bridge_optimizer.jl
+++ b/src/Bridges/Constraint/single_bridge_optimizer.jl
@@ -10,7 +10,7 @@
 Return `AbstractBridgeOptimizer` that always bridges any objective function
 supported by the bridge `BT`.
 
-This is in contrast with the [`MathOptInterface.Bridges.LazyBridgeOptimizer`](@ref),
+This is in contrast with the [`MOI.Bridges.LazyBridgeOptimizer`](@ref),
 which only bridges the objective function if it is supported by the bridge `BT`
 and unsupported by `model`.
 

--- a/src/Bridges/Constraint/single_bridge_optimizer.jl
+++ b/src/Bridges/Constraint/single_bridge_optimizer.jl
@@ -16,7 +16,7 @@ and unsupported by `model`.
 
 ## Example
 
-```jldoctest con_singlebridgeoptimizer; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest con_singlebridgeoptimizer; setup=:(import MathOptInterface as MOI)
 julia> struct MyNewBridge{T} <: MOI.Bridges.Constraint.AbstractBridge end
 
 julia> bridge = MOI.Bridges.Constraint.SingleBridgeOptimizer{MyNewBridge{Float64}}(

--- a/src/Bridges/Objective/Objective.jl
+++ b/src/Bridges/Objective/Objective.jl
@@ -6,9 +6,7 @@
 
 module Objective
 
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 include("bridge.jl")
 include("map.jl")

--- a/src/Bridges/Objective/single_bridge_optimizer.jl
+++ b/src/Bridges/Objective/single_bridge_optimizer.jl
@@ -16,7 +16,7 @@ and unsupported by `model`.
 
 ## Example
 
-```jldoctest obj_singlebridgeoptimizer; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest obj_singlebridgeoptimizer; setup=:(import MathOptInterface as MOI)
 julia> struct MyNewBridge{T} <: MOI.Bridges.Objective.AbstractBridge end
 
 julia> bridge = MOI.Bridges.Objective.SingleBridgeOptimizer{MyNewBridge{Float64}}(

--- a/src/Bridges/Objective/single_bridge_optimizer.jl
+++ b/src/Bridges/Objective/single_bridge_optimizer.jl
@@ -10,7 +10,7 @@
 Return `AbstractBridgeOptimizer` that always bridges any objective function
 supported by the bridge `BT`.
 
-This is in contrast with the [`MathOptInterface.Bridges.LazyBridgeOptimizer`](@ref),
+This is in contrast with the [`MOI.Bridges.LazyBridgeOptimizer`](@ref),
 which only bridges the objective function if it is supported by the bridge `BT`
 and unsupported by `model`.
 

--- a/src/Bridges/Variable/Variable.jl
+++ b/src/Bridges/Variable/Variable.jl
@@ -6,9 +6,7 @@
 
 module Variable
 
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 include("bridge.jl")
 include("map.jl")

--- a/src/Bridges/Variable/bridge.jl
+++ b/src/Bridges/Variable/bridge.jl
@@ -39,7 +39,7 @@ solver.
 
 ## Example
 
-```jldoctest; setup=(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=(import MathOptInterface as MOI)
 julia> MOI.Bridges.Variable.supports_constrained_variable(
            MOI.Bridges.Variable.NonposToNonnegBridge{Float64},
            MOI.Nonpositives,
@@ -77,7 +77,7 @@ As a variable in [`MathOptInterface.GreaterThan`](@ref) is bridged into
 variables in [`MathOptInterface.Nonnegatives`](@ref) by the
 [`VectorizeBridge`](@ref):
 
-```jldoctest; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=:(import MathOptInterface as MOI)
 julia> MOI.Bridges.Variable.concrete_bridge_type(
            MOI.Bridges.Variable.VectorizeBridge{Float64},
            MOI.GreaterThan{Float64},

--- a/src/Bridges/Variable/bridge.jl
+++ b/src/Bridges/Variable/bridge.jl
@@ -73,8 +73,8 @@ is `true`.
 
 ## Examples
 
-As a variable in [`MathOptInterface.GreaterThan`](@ref) is bridged into
-variables in [`MathOptInterface.Nonnegatives`](@ref) by the
+As a variable in [`MOI.GreaterThan`](@ref) is bridged into
+variables in [`MOI.Nonnegatives`](@ref) by the
 [`VectorizeBridge`](@ref):
 
 ```jldoctest; setup=:(import MathOptInterface as MOI)

--- a/src/Bridges/Variable/map.jl
+++ b/src/Bridges/Variable/map.jl
@@ -290,7 +290,7 @@ end
 Return a `Bool` indicating whether any bridge was added yet. Note that it
 returns `false` even if all bridges were deleted while `isempty` would return
 `true`. It is computed in `O(1)` while `isempty` needs `O(n)` hence it is used
-by [`MathOptInterface.Bridges.AbstractBridgeOptimizer`](@ref) to shortcut
+by [`MOI.Bridges.AbstractBridgeOptimizer`](@ref) to shortcut
 operations in case variable bridges are not used.
 """
 has_bridges(map::Map) = !isempty(map.info)
@@ -521,7 +521,7 @@ end
     EmptyMap <: AbstractDict{MOI.VariableIndex, AbstractBridge}
 
 Empty version of [`Map`](@ref). It is used by
-[`MathOptInterface.Bridges.Constraint.SingleBridgeOptimizer`](@ref) as it does
+[`MOI.Bridges.Constraint.SingleBridgeOptimizer`](@ref) as it does
 not bridge any variable.
 """
 struct EmptyMap <: AbstractDict{MOI.VariableIndex,AbstractBridge} end

--- a/src/Bridges/Variable/set_map.jl
+++ b/src/Bridges/Variable/set_map.jl
@@ -15,18 +15,18 @@ in `S2` into the image through `A` of constrained variables in `S1`.
 
 The linear map `A` is described by:
 
- * [`MathOptInterface.Bridges.map_set`](@ref)
- * [`MathOptInterface.Bridges.map_function`](@ref)
+ * [`MOI.Bridges.map_set`](@ref)
+ * [`MOI.Bridges.map_function`](@ref)
 
 Implementing a method for these two functions is sufficient to bridge
 constrained variables. However, in order for the getters and setters of
 attributes such as dual solutions and starting values to work as well, a method
 for the following functions must be implemented:
 
- * [`MathOptInterface.Bridges.inverse_map_set`](@ref)
- * [`MathOptInterface.Bridges.inverse_map_function`](@ref)
- * [`MathOptInterface.Bridges.adjoint_map_function`](@ref)
- * [`MathOptInterface.Bridges.inverse_adjoint_map_function`](@ref).
+ * [`MOI.Bridges.inverse_map_set`](@ref)
+ * [`MOI.Bridges.inverse_map_function`](@ref)
+ * [`MOI.Bridges.adjoint_map_function`](@ref)
+ * [`MOI.Bridges.inverse_adjoint_map_function`](@ref).
 
 See the docstrings of each function to see which feature would be missing if it
 was not implemented for a given bridge.

--- a/src/Bridges/Variable/single_bridge_optimizer.jl
+++ b/src/Bridges/Variable/single_bridge_optimizer.jl
@@ -21,7 +21,7 @@ by the bridge `BT` and unsupported by `model`.
 
 ## Example
 
-```jldoctest var_singlebridgeoptimizer; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest var_singlebridgeoptimizer; setup=:(import MathOptInterface as MOI)
 julia> struct MyNewBridge{T} <: MOI.Bridges.Variable.AbstractBridge end
 
 julia> bridge = MOI.Bridges.Variable.SingleBridgeOptimizer{MyNewBridge{Float64}}(

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -8,7 +8,7 @@
     abstract type AbstractBridge end
 
 An abstract type representing a bridged constraint or variable in a
-[`MathOptInterface.Bridges.AbstractBridgeOptimizer`](@ref).
+[`MOI.Bridges.AbstractBridgeOptimizer`](@ref).
 
 All bridges must implement:
 
@@ -25,8 +25,8 @@ docstrings for details.
 In addition, all subtypes may optionally implement the following constraint
 attributes with the bridge in place of the constraint index:
 
- * [`MathOptInterface.ConstraintDual`](@ref)
- * [`MathOptInterface.ConstraintPrimal`](@ref)
+ * [`MOI.ConstraintDual`](@ref)
+ * [`MOI.ConstraintPrimal`](@ref)
 """
 abstract type AbstractBridge end
 

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -196,7 +196,7 @@ type `BT` add.
 
 ## Example
 
-```jldoctest; setup=(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=(import MathOptInterface as MOI)
 julia> MOI.Bridges.added_constrained_variable_types(
            MOI.Bridges.Variable.NonposToNonnegBridge{Float64},
        )
@@ -220,7 +220,7 @@ add.
 
 ## Example
 
-```jldoctest; setup=(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=(import MathOptInterface as MOI)
 julia> MOI.Bridges.added_constraint_types(
            MOI.Bridges.Constraint.ZeroOneBridge{Float64},
        )
@@ -245,7 +245,7 @@ set.
 
 ## Example
 
-```jldoctest; setup=(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=(import MathOptInterface as MOI)
 julia> MOI.Bridges.set_objective_function_type(
            MOI.Bridges.Objective.FunctionizeBridge{Float64},
        )

--- a/src/Bridges/lazy_bridge_optimizer.jl
+++ b/src/Bridges/lazy_bridge_optimizer.jl
@@ -24,7 +24,7 @@ and [`full_bridge_optimizer`](@ref).
 
 ## Example
 
-```jldoctest; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=:(import MathOptInterface as MOI)
 julia> model = MOI.Bridges.LazyBridgeOptimizer(MOI.Utilities.Model{Float64}())
 MOIB.LazyBridgeOptimizer{MOIU.Model{Float64}}
 with 0 variable bridges

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -10,7 +10,7 @@
 Return the image of `set` through the linear map `A` defined in
 [`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
 used for bridging the constraint and setting
-the [`MathOptInterface.ConstraintSet`](@ref).
+the [`MOI.ConstraintSet`](@ref).
 """
 function map_set end
 
@@ -19,7 +19,7 @@ function map_set end
 
 Return the preimage of `set` through the linear map `A` defined in
 [`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
-used for getting the [`MathOptInterface.ConstraintSet`](@ref).
+used for getting the [`MOI.ConstraintSet`](@ref).
 """
 function inverse_map_set end
 
@@ -28,19 +28,19 @@ function inverse_map_set end
 
 Return the image of `func` through the linear map `A` defined in
 [`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
-used for getting the [`MathOptInterface.ConstraintPrimal`](@ref) of variable
+used for getting the [`MOI.ConstraintPrimal`](@ref) of variable
 bridges. For constraint bridges, this is used for bridging the constraint,
-setting the [`MathOptInterface.ConstraintFunction`](@ref) and
-[`MathOptInterface.ConstraintPrimalStart`](@ref) and
-modifying the function with [`MathOptInterface.modify`](@ref).
+setting the [`MOI.ConstraintFunction`](@ref) and
+[`MOI.ConstraintPrimalStart`](@ref) and
+modifying the function with [`MOI.modify`](@ref).
 
     map_function(::Type{BT}, func, i::IndexInVector) where {BT}
 
 Return the scalar function at the `i`th index of the vector function that
 would be returned by `map_function(BT, func)` except that it may compute the
 `i`th element. This is used by [`bridged_function`](@ref) and for getting
-the [`MathOptInterface.VariablePrimal`](@ref) and
-[`MathOptInterface.VariablePrimalStart`](@ref) of variable bridges.
+the [`MOI.VariablePrimal`](@ref) and
+[`MOI.VariablePrimalStart`](@ref) of variable bridges.
 """
 function map_function end
 
@@ -54,10 +54,10 @@ end
 Return the image of `func` through the inverse of the linear map `A` defined in
 [`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
 used by [`Variable.unbridged_map`](@ref) and for setting the
-[`MathOptInterface.VariablePrimalStart`](@ref) of variable bridges
-and for getting the [`MathOptInterface.ConstraintFunction`](@ref),
-the [`MathOptInterface.ConstraintPrimal`](@ref) and the
-[`MathOptInterface.ConstraintPrimalStart`](@ref) of constraint bridges.
+[`MOI.VariablePrimalStart`](@ref) of variable bridges
+and for getting the [`MOI.ConstraintFunction`](@ref),
+the [`MOI.ConstraintPrimal`](@ref) and the
+[`MOI.ConstraintPrimalStart`](@ref) of constraint bridges.
 """
 function inverse_map_function end
 
@@ -66,8 +66,8 @@ function inverse_map_function end
 
 Return the image of `func` through the adjoint of the linear map `A` defined in
 [`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
-used for getting the [`MathOptInterface.ConstraintDual`](@ref) and
-[`MathOptInterface.ConstraintDualStart`](@ref) of constraint bridges.
+used for getting the [`MOI.ConstraintDual`](@ref) and
+[`MOI.ConstraintDualStart`](@ref) of constraint bridges.
 """
 function adjoint_map_function end
 
@@ -77,7 +77,7 @@ function adjoint_map_function end
 Return the image of `func` through the inverse of the adjoint of the linear map
 `A` defined in [`Variable.SetMapBridge`](@ref) and
 [`Constraint.SetMapBridge`](@ref). This is used for getting the
-[`MathOptInterface.ConstraintDual`](@ref) of variable bridges and setting the
-[`MathOptInterface.ConstraintDualStart`](@ref) of constraint bridges.
+[`MOI.ConstraintDual`](@ref) of variable bridges and setting the
+[`MOI.ConstraintDualStart`](@ref) of constraint bridges.
 """
 function inverse_adjoint_map_function end

--- a/src/FileFormats/CBF/CBF.jl
+++ b/src/FileFormats/CBF/CBF.jl
@@ -7,9 +7,7 @@
 module CBF
 
 import ..FileFormats
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 MOI.Utilities.@model(
     Model,

--- a/src/FileFormats/FileFormats.jl
+++ b/src/FileFormats/FileFormats.jl
@@ -6,8 +6,7 @@
 
 module FileFormats
 
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 import CodecBzip2
 import CodecZlib

--- a/src/FileFormats/LP/LP.jl
+++ b/src/FileFormats/LP/LP.jl
@@ -7,8 +7,7 @@
 module LP
 
 import ..FileFormats
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 # Julia 1.6 removes Grisu from Base. Previously, we went
 #   _print_shortest(io, x) = Base.Grisu.print_shortest(io, x)

--- a/src/FileFormats/MOF/MOF.jl
+++ b/src/FileFormats/MOF/MOF.jl
@@ -9,9 +9,7 @@ module MOF
 import ..FileFormats
 import OrderedCollections
 import JSON
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 const SCHEMA_PATH = joinpath(@__DIR__, "mof.1.2.schema.json")
 const VERSION = v"1.2"

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -8,8 +8,7 @@ module MPS
 
 import ..FileFormats
 
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 # Julia 1.6 removes Grisu from Base. Previously, we went
 #   print_shortest(io, x) = Base.Grisu.print_shortest(io, x)

--- a/src/FileFormats/NL/NL.jl
+++ b/src/FileFormats/NL/NL.jl
@@ -6,10 +6,8 @@
 
 module NL
 
-import MathOptInterface
+import MathOptInterface as MOI
 import NaNMath
-
-const MOI = MathOptInterface
 
 include("NLExpr.jl")
 

--- a/src/FileFormats/SDPA/SDPA.jl
+++ b/src/FileFormats/SDPA/SDPA.jl
@@ -77,9 +77,9 @@ shared with the matrices `A_i` and `C`.
 In other words, the geometric conic form contains free variables and affine
 constraints in either the nonnegative orthant or the positive semidefinite cone.
 That is, in the MathOptInterface's terminology,
-[`MathOptInterface.VectorAffineFunction`](@ref)-in-[`MathOptInterface.Nonnegatives`](@ref)
+[`MOI.VectorAffineFunction`](@ref)-in-[`MOI.Nonnegatives`](@ref)
 and
-[`MathOptInterface.VectorAffineFunction`](@ref)-in-[`MathOptInterface.PositiveSemidefiniteConeTriangle`](@ref)
+[`MOI.VectorAffineFunction`](@ref)-in-[`MOI.PositiveSemidefiniteConeTriangle`](@ref)
 constraints.
 
 The corresponding *standard conic* form of the dual SDP is as follows:
@@ -94,10 +94,10 @@ The corresponding *standard conic* form of the dual SDP is as follows:
 In other words, the standard conic form contains nonnegative and positive
 semidefinite variables with equality constraints.
 That is, in the MathOptInterface's terminology,
-[`MathOptInterface.VectorOfVariables`](@ref)-in-[`MathOptInterface.Nonnegatives`](@ref),
-[`MathOptInterface.VectorOfVariables`](@ref)-in-[`MathOptInterface.PositiveSemidefiniteConeTriangle`](@ref)
+[`MOI.VectorOfVariables`](@ref)-in-[`MOI.Nonnegatives`](@ref),
+[`MOI.VectorOfVariables`](@ref)-in-[`MOI.PositiveSemidefiniteConeTriangle`](@ref)
 and
-[`MathOptInterface.ScalarAffineFunction`](@ref)-in-[`MathOptInterface.EqualTo`](@ref)
+[`MOI.ScalarAffineFunction`](@ref)-in-[`MOI.EqualTo`](@ref)
 constraints.
 
 If a model is in standard conic form, use `Dualization.jl` to transform it into
@@ -105,21 +105,21 @@ the geometric conic form before writting it. Otherwise, the nonnegative (resp.
 positive semidefinite) variables will be bridged into free variables with
 affine constraints constraining them to belong to the nonnegative orthant
 (resp. positive semidefinite cone) by the
-[`MathOptInterface.Bridges.Constraint.VectorFunctionizeBridge`](@ref). Moreover, equality
+[`MOI.Bridges.Constraint.VectorFunctionizeBridge`](@ref). Moreover, equality
 constraints will be bridged into pairs of affine constraints in the nonnegative
 orthant by the
-[`MathOptInterface.Bridges.Constraint.SplitIntervalBridge`](@ref)
+[`MOI.Bridges.Constraint.SplitIntervalBridge`](@ref)
 and then the
-[`MathOptInterface.Bridges.Constraint.VectorizeBridge`](@ref).
+[`MOI.Bridges.Constraint.VectorizeBridge`](@ref).
 
 If a solver is in standard conic form, use `Dualization.jl` to transform the
 model read into standard conic form before copying it to the solver. Otherwise,
 the free variables will be bridged into pairs of variables in the nonnegative
 orthant by the
-[`MathOptInterface.Bridges.Variable.FreeBridge`](@ref)
+[`MOI.Bridges.Variable.FreeBridge`](@ref)
 and affine constraints will be bridged into equality constraints
 by creating a slack variable by the
-[`MathOptInterface.Bridges.Constraint.VectorSlackBridge`](@ref).
+[`MOI.Bridges.Constraint.VectorSlackBridge`](@ref).
 """
 function Model(; number_type::Type = Float64)
     model = Model{number_type}()

--- a/src/FileFormats/SDPA/SDPA.jl
+++ b/src/FileFormats/SDPA/SDPA.jl
@@ -9,9 +9,7 @@ module SDPA
 # See http://plato.asu.edu/ftp/sdpa_format.txt
 
 import ..FileFormats
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 MOI.Utilities.@model(
     Model,

--- a/src/MathOptInterface.jl
+++ b/src/MathOptInterface.jl
@@ -6,6 +6,8 @@
 
 module MathOptInterface
 
+import MutableArithmetics as MA
+
 """
     ModelLike
 

--- a/src/Nonlinear/Nonlinear.jl
+++ b/src/Nonlinear/Nonlinear.jl
@@ -16,13 +16,11 @@ module Nonlinear
 
 import Base.Meta: isexpr
 import ForwardDiff
-import ..MathOptInterface
+import ..MathOptInterface as MOI
 import OrderedCollections: OrderedDict
 import SparseArrays
 
 using SpecialFunctions
-
-const MOI = MathOptInterface
 
 # Override basic math functions to return NaN instead of throwing errors.
 # This is what NLP solvers expect, and sometimes the results aren't needed

--- a/src/Nonlinear/ReverseAD/ReverseAD.jl
+++ b/src/Nonlinear/ReverseAD/ReverseAD.jl
@@ -7,11 +7,9 @@
 module ReverseAD
 
 import ForwardDiff
-import MathOptInterface
+import MathOptInterface as MOI
 import ..Nonlinear
 import SparseArrays
-
-const MOI = MathOptInterface
 
 # Override basic math functions to return NaN instead of throwing errors.
 # This is what NLP solvers expect, and sometimes the results aren't needed

--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -8,8 +8,7 @@ module Test
 
 import LinearAlgebra
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 
 using Test

--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -9,7 +9,7 @@ module Test
 import LinearAlgebra
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 
 using Test
 

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -6980,8 +6980,8 @@ end
         config::Config,
     )
 
-Test adding [`MathOptInterface.VariableIndex`](@ref)-in-[`MathOptInterface.EqualTo](@ref)`
-on [`MathOptInterface.HermitianPositiveSemidefiniteConeTriangle`](@ref)
+Test adding [`MOI.VariableIndex`](@ref)-in-[`MOI.EqualTo](@ref)`
+on [`MOI.HermitianPositiveSemidefiniteConeTriangle`](@ref)
 variables.
 ```
 """

--- a/src/Utilities/CleverDicts.jl
+++ b/src/Utilities/CleverDicts.jl
@@ -10,7 +10,7 @@ module CleverDicts
 # it is the original use-case for `CleverDict`, and it would be type-piracy for
 # solvers using `CleverDicts` to implement it themselves.
 
-import MathOptInterface
+import MathOptInterface as MOI
 import OrderedCollections
 
 """
@@ -28,18 +28,18 @@ deletions.
 """
 function key_to_index end
 
-function index_to_key(::Type{MathOptInterface.VariableIndex}, index::Int64)
-    return MathOptInterface.VariableIndex(index)
+function index_to_key(::Type{MOI.VariableIndex}, index::Int64)
+    return MOI.VariableIndex(index)
 end
 
 function index_to_key(
-    ::Type{MathOptInterface.ConstraintIndex{F,S}},
+    ::Type{MOI.ConstraintIndex{F,S}},
     index::Int64,
 ) where {F,S}
-    return MathOptInterface.ConstraintIndex{F,S}(index)
+    return MOI.ConstraintIndex{F,S}(index)
 end
 
-key_to_index(key::MathOptInterface.Index) = key.value
+key_to_index(key::MOI.Index) = key.value
 
 # Now, on with `CleverDicts`.
 

--- a/src/Utilities/DoubleDicts.jl
+++ b/src/Utilities/DoubleDicts.jl
@@ -6,9 +6,7 @@
 
 module DoubleDicts
 
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 abstract type AbstractDoubleDict{V} <: AbstractDict{MOI.ConstraintIndex,V} end
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -9,11 +9,8 @@ module Utilities
 using LinearAlgebra # For dot
 using OrderedCollections # for OrderedDict in UniversalFallback
 
-import MutableArithmetics
-const MA = MutableArithmetics
-
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
+import MutableArithmetics as MA
 
 const MOIU = MOI.Utilities # used in macro
 

--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -12,7 +12,7 @@ using OrderedCollections # for OrderedDict in UniversalFallback
 import MathOptInterface as MOI
 import MutableArithmetics as MA
 
-const MOIU = MOI.Utilities # used in macro
+import MathOptInterface.Utilities as MOIU # used in macro
 
 const SVF = MOI.VariableIndex
 const VVF = MOI.VectorOfVariables

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -211,7 +211,7 @@ end
 Attaches the optimizer to `model`, copying all model data into it. Can be called
 only from the `EMPTY_OPTIMIZER` state. If the copy succeeds, the
 `CachingOptimizer` will be in state `ATTACHED_OPTIMIZER` after the call,
-otherwise an error is thrown; see [`MathOptInterface.copy_to`](@ref) for more details on which
+otherwise an error is thrown; see [`MOI.copy_to`](@ref) for more details on which
 errors can be thrown.
 """
 function attach_optimizer(model::CachingOptimizer)

--- a/src/Utilities/copy/index_map.jl
+++ b/src/Utilities/copy/index_map.jl
@@ -25,7 +25,7 @@ end
 """
     IndexMap()
 
-The dictionary-like object returned by [`MathOptInterface.copy_to`](@ref).
+The dictionary-like object returned by [`MOI.copy_to`](@ref).
 """
 function IndexMap()
     var_map = CleverDicts.CleverDict{MOI.VariableIndex,MOI.VariableIndex}()

--- a/src/Utilities/free_variables.jl
+++ b/src/Utilities/free_variables.jl
@@ -19,7 +19,7 @@ that does not support any constraint nor objective function.
 The following model type represents a conic model in geometric form. As opposed
 to [`VariablesContainer`](@ref), `FreeVariables` does not support constraint
 bounds so they are bridged into an affine constraint in the
-[`MathOptInterface.Nonnegatives`](@ref) cone as expected for the geometric
+[`MOI.Nonnegatives`](@ref) cone as expected for the geometric
 conic form.
 ```jldocstest
 julia> MOI.Utilities.@product_of_sets(

--- a/src/Utilities/matrix_of_constraints.jl
+++ b/src/Utilities/matrix_of_constraints.jl
@@ -553,7 +553,7 @@ function_constants(b::Vector, rows) = b[rows]
 """
     set_with_dimension(::Type{S}, dim) where {S<:MOI.AbstractVectorSet}
 
-Returns the instance of `S` of [`MathOptInterface.dimension`](@ref) `dim`.
+Returns the instance of `S` of [`MOI.dimension`](@ref) `dim`.
 This needs to be implemented for sets of type `S` to be useable with
 [`MatrixOfConstraints`](@ref).
 """

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -21,7 +21,7 @@ end
 
 This is called by `AbstractModel` to inform the `constraints` field that a
 variable has been added. This is similar to
-[`MathOptInterface.add_variable`](@ref) except that it should return `nothing`.
+[`MOI.add_variable`](@ref) except that it should return `nothing`.
 """
 function _add_variable end
 
@@ -546,14 +546,14 @@ functions, `typed_scalar_functions` typed scalar functions, `vector_functions`
 vector functions and `typed_vector_functions` typed vector functions.
 To give no set/function, write `()`, to give one set `S`, write `(S,)`.
 
-The function [`MathOptInterface.VariableIndex`](@ref) should not be given in
-`scalar_functions`. The model supports [`MathOptInterface.VariableIndex`](@ref)-in-`S`
-constraints where `S` is [`MathOptInterface.EqualTo`](@ref),
-[`MathOptInterface.GreaterThan`](@ref), [`MathOptInterface.LessThan`](@ref),
-[`MathOptInterface.Interval`](@ref), [`MathOptInterface.Integer`](@ref),
-[`MathOptInterface.ZeroOne`](@ref), [`MathOptInterface.Semicontinuous`](@ref)
-or [`MathOptInterface.Semiinteger`](@ref). The sets supported
-with the [`MathOptInterface.VariableIndex`](@ref) cannot be controlled from the
+The function [`MOI.VariableIndex`](@ref) should not be given in
+`scalar_functions`. The model supports [`MOI.VariableIndex`](@ref)-in-`S`
+constraints where `S` is [`MOI.EqualTo`](@ref),
+[`MOI.GreaterThan`](@ref), [`MOI.LessThan`](@ref),
+[`MOI.Interval`](@ref), [`MOI.Integer`](@ref),
+[`MOI.ZeroOne`](@ref), [`MOI.Semicontinuous`](@ref)
+or [`MOI.Semiinteger`](@ref). The sets supported
+with the [`MOI.VariableIndex`](@ref) cannot be controlled from the
 macro, use the [`UniversalFallback`](@ref) to support more sets.
 
 This macro creates a model specialized for specific types of constraint,
@@ -563,9 +563,9 @@ constraints and attributes, use [`UniversalFallback`](@ref).
 
 If `is_optimizer = true`, the resulting struct is a
 of [`GenericOptimizer`](@ref), which is a subtype of
-[`MathOptInterface.AbstractOptimizer`](@ref), otherwise, it is a
+[`MOI.AbstractOptimizer`](@ref), otherwise, it is a
 [`GenericModel`](@ref), which is a subtype of
-[`MathOptInterface.ModelLike`](@ref).
+[`MOI.ModelLike`](@ref).
 
 ### Examples
 

--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -282,7 +282,7 @@ instead.
 
 ## Example
 
-```jldoctest; setup=:(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=:(import MathOptInterface as MOI)
 julia> model = MOI.Utilities.Model{Float64}();
 
 julia> MOI.Utilities.loadfromstring!(model, \"\"\"

--- a/src/Utilities/penalty_relaxation.jl
+++ b/src/Utilities/penalty_relaxation.jl
@@ -34,7 +34,7 @@ this function to compute the violation of the constraint.
 
 ## Examples
 
-```jldoctest; setup=:(import MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=:(import MathOptInterface as MOI)
 julia> model = MOI.Utilities.Model{Float64}();
 
 julia> x = MOI.add_variable(model);
@@ -189,7 +189,7 @@ To modify variable bounds, rewrite them as linear constraints.
 
 ## Examples
 
-```jldoctest; setup=:(import MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=:(import MathOptInterface as MOI)
 julia> model = MOI.Utilities.Model{Float64}();
 
 julia> x = MOI.add_variable(model);
@@ -214,7 +214,7 @@ julia> map[c] isa MOI.ScalarAffineFunction{Float64}
 true
 ```
 
-```jldoctest; setup=:(import MathOptInterface; const MOI = MathOptInterface)
+```jldoctest; setup=:(import MathOptInterface as MOI)
 julia> model = MOI.Utilities.Model{Float64}();
 
 julia> x = MOI.add_variable(model);

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -7,14 +7,14 @@
 """
     UniversalFallback
 
-The `UniversalFallback` can be applied on a [`MathOptInterface.ModelLike`](@ref)
+The `UniversalFallback` can be applied on a [`MOI.ModelLike`](@ref)
 `model` to create the model `UniversalFallback(model)` supporting *any*
 constraint and attribute. This allows to have a specialized implementation in
 `model` for performance critical constraints and attributes while still
 supporting other attributes with a small performance penalty. Note that `model`
 is unaware of constraints and attributes stored by `UniversalFallback` so this
 is not appropriate if `model` is an optimizer (for this reason,
-[`MathOptInterface.optimize!`](@ref) has not been implemented). In that case,
+[`MOI.optimize!`](@ref) has not been implemented). In that case,
 optimizer bridges should be used instead.
 """
 mutable struct UniversalFallback{MT} <: MOI.ModelLike
@@ -138,14 +138,14 @@ end
 """
     throw_unsupported(uf::UniversalFallback; excluded_attributes = MOI.AnyAttribute[])
 
-Throws [`MathOptInterface.UnsupportedAttribute`](@ref) if there are any model,
+Throws [`MOI.UnsupportedAttribute`](@ref) if there are any model,
 variable or constraint attribute such that 1) `is_copyable(attr)` returns
 `true`, 2) the attribute was set to `uf` but not to `uf.model` and 3) the
 attribute is not in `excluded_attributes`.
 
 Suppose `Optimizer` supports only the constraints and attributes
 that `OptimizerCache` supports in addition to
-[`MathOptInterface.VariablePrimalStart`](@ref).
+[`MOI.VariablePrimalStart`](@ref).
 Then, this function can be used in the implementation of the following method:
 ```julia
 function MOI.copy_to(

--- a/src/indextypes.jl
+++ b/src/indextypes.jl
@@ -4,14 +4,12 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-import MutableArithmetics
-
 """
     AbstractFunction
 
 Abstract supertype for function objects.
 """
-abstract type AbstractFunction <: MutableArithmetics.AbstractMutable end
+abstract type AbstractFunction <: MA.AbstractMutable end
 
 """
     AbstractScalarFunction

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -25,10 +25,7 @@ Return the [`output_dimension`](@ref) that an [`AbstractFunction`](@ref) should 
 ### Examples
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> MOI.dimension(MOI.Reals(4))
 4
@@ -57,10 +54,7 @@ If the dual cone is not defined it returns an error.
 ### Examples
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> MOI.dual_set(MOI.Reals(4))
 MathOptInterface.Zeros(4)
@@ -85,10 +79,7 @@ Return the type of dual set of sets of type `S`, as returned by
 ### Examples
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> MOI.dual_set_type(MOI.Reals)
 MathOptInterface.Zeros
@@ -1092,10 +1083,7 @@ The constraint
 ``\\{(y, x) \\in \\{0, 1\\} \\times \\mathbb{R}^2 : y = 1 \\implies x_1 + x_2 \\leq 9 \\}``
 is defined as
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1222,10 +1210,7 @@ called `distinct`.
 To enforce `x[1] != x[2]` AND `x[1] != x[3]` AND `x[2] != x[3]`:
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1270,10 +1255,7 @@ This constraint is called `bin_packing` in MiniZinc.
 ## Example
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1356,10 +1338,7 @@ a (potentially sub-optimal) tour in the travelling salesperson problem.
 ## Example
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1402,10 +1381,7 @@ To ensure that `3` appears at least once in each of the subsets `{a, b}` and
 `{b, c}`:
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1465,10 +1441,7 @@ This constraint is called `among` by MiniZinc.
 ## Example
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1531,10 +1504,7 @@ To model:
  * if `n == 3`, then `x[1] != x[2]`, `x[2] != x[3]` and `x[3] != x[1]`
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1580,10 +1550,7 @@ This constraint is called `count_gt` in MiniZinc.
 ## Example
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1636,10 +1603,7 @@ This constraint is called `cumulative` in MiniZinc.
 ## Example
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1699,10 +1663,7 @@ This constraint is called `path` in MiniZinc.
 ## Example
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1801,10 +1762,7 @@ This constraint is called `table` in MiniZinc.
 ## Example
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
@@ -1844,10 +1802,7 @@ The set ``\\{x \\in \\bar{\\mathbb{R}}^d: x_i \\in [lower_i, upper_i] \\forall i
 ## Example
 
 ```jldoctest
-julia> using MathOptInterface
-
-julia> const MOI = MathOptInterface
-MathOptInterface
+julia> import MathOptInterface as MOI
 
 julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}

--- a/test/Benchmarks/Benchmarks.jl
+++ b/test/Benchmarks/Benchmarks.jl
@@ -6,7 +6,7 @@
 
 using Test
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 
 const NUM_BENCHMARKS = length(MOI.Benchmarks.BENCHMARKS)
 

--- a/test/Benchmarks/Benchmarks.jl
+++ b/test/Benchmarks/Benchmarks.jl
@@ -4,9 +4,8 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-using MathOptInterface, Test
-
-const MOI = MathOptInterface
+using Test
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 
 const NUM_BENCHMARKS = length(MOI.Benchmarks.BENCHMARKS)

--- a/test/Bridges/Constraint/all_different.jl
+++ b/test/Bridges/Constraint/all_different.jl
@@ -8,8 +8,7 @@ module TestConstraintAllDifferent
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/all_different_reif.jl
+++ b/test/Bridges/Constraint/all_different_reif.jl
@@ -8,8 +8,7 @@ module TestConstraintReifiedAllDifferent
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/bin_packing.jl
+++ b/test/Bridges/Constraint/bin_packing.jl
@@ -8,8 +8,7 @@ module TestConstraintBinPacking
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/bridge.jl
+++ b/test/Bridges/Constraint/bridge.jl
@@ -8,8 +8,7 @@ module TestConstraintBridge
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/circuit.jl
+++ b/test/Bridges/Constraint/circuit.jl
@@ -8,8 +8,7 @@ module TestConstraintCircuit
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/count_at_least.jl
+++ b/test/Bridges/Constraint/count_at_least.jl
@@ -8,8 +8,7 @@ module TestConstraintCountAtLeast
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/count_belongs.jl
+++ b/test/Bridges/Constraint/count_belongs.jl
@@ -8,8 +8,7 @@ module TestConstraintCountBelongs
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/count_distinct.jl
+++ b/test/Bridges/Constraint/count_distinct.jl
@@ -8,8 +8,7 @@ module TestConstraintCountDistinct
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/count_distinct_reif.jl
+++ b/test/Bridges/Constraint/count_distinct_reif.jl
@@ -8,8 +8,7 @@ module TestConstraintReifiedCountDistinct
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/count_greater_than.jl
+++ b/test/Bridges/Constraint/count_greater_than.jl
@@ -8,8 +8,7 @@ module TestConstraintCountGreaterThan
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/det.jl
+++ b/test/Bridges/Constraint/det.jl
@@ -8,8 +8,7 @@ module TestConstraintDet
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/flip_sign.jl
+++ b/test/Bridges/Constraint/flip_sign.jl
@@ -8,8 +8,7 @@ module TestConstraintFlipSign
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/functionize.jl
+++ b/test/Bridges/Constraint/functionize.jl
@@ -8,8 +8,7 @@ module TestConstraintFunctionize
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/geomean.jl
+++ b/test/Bridges/Constraint/geomean.jl
@@ -8,8 +8,7 @@ module TestConstraintGeomean
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -93,11 +92,11 @@ function test_conic_GeometricMeanCone_VectorAffineFunction()
     MOI.set.(mock, MOI.ConstraintName(), rsoc, ["rsoc21", "rsoc11", "rsoc12"])
     s = """
     variables: t, x, y, z, x21, x11, x12
-    lessthan1: t + -0.5 * x21 in MathOptInterface.LessThan(0.0)
-    lessthan2: x + y + z in MathOptInterface.LessThan(3.0)
-    rsoc11: [1.0x, y, x11] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc12: [z, 0.5 * x21, x12] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc21: [1.0x11, x12, x21] in MathOptInterface.RotatedSecondOrderCone(3)
+    lessthan1: t + -0.5 * x21 in LessThan(0.0)
+    lessthan2: x + y + z in LessThan(3.0)
+    rsoc11: [1.0x, y, x11] in RotatedSecondOrderCone(3)
+    rsoc12: [z, 0.5 * x21, x12] in RotatedSecondOrderCone(3)
+    rsoc21: [1.0x11, x12, x21] in RotatedSecondOrderCone(3)
     maxobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -135,8 +134,8 @@ function test_conic_GeometricMeanCone_VectorAffineFunction()
     MOI.set(bridged_mock, MOI.ConstraintName(), geomean[1], "geomean")
     s = """
     variables: t, x, y, z
-    lessthan: x + y + z in MathOptInterface.LessThan(3.0)
-    geomean: [1.0t, x, y, z] in MathOptInterface.GeometricMeanCone(4)
+    lessthan: x + y + z in LessThan(3.0)
+    geomean: [1.0t, x, y, z] in GeometricMeanCone(4)
     maxobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -250,31 +249,31 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_2()
     varnames_str = vcat("t", [", " * v for v in var_names[2:end]])
     s = """
     variables: $(varnames_str...)
-    lessthan: t + -0.25 * x41 in MathOptInterface.LessThan(0.0)
-    equalto1: 1.0x1 in MathOptInterface.EqualTo(1.0)
-    equalto2: 1.0x2 in MathOptInterface.EqualTo(1.0)
-    equalto3: 1.0x3 in MathOptInterface.EqualTo(1.0)
-    equalto4: 1.0x4 in MathOptInterface.EqualTo(1.0)
-    equalto5: 1.0x5 in MathOptInterface.EqualTo(1.0)
-    equalto6: 1.0x6 in MathOptInterface.EqualTo(1.0)
-    equalto7: 1.0x7 in MathOptInterface.EqualTo(1.0)
-    equalto8: 1.0x8 in MathOptInterface.EqualTo(1.0)
-    equalto9: 1.0x9 in MathOptInterface.EqualTo(1.0)
-    rsoc41: [1.0x31, x32, x41] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc31: [1.0x21, x22, x31] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc32: [1.0x23, x24, x32] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc21: [1.0x11, x12, x21] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc22: [1.0x13, x14, x22] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc23: [1.0x15, x16, x23] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc24: [1.0x17, x18, x24] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc11: [1.0x1, x2, x11] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc12: [1.0x3, x4, x12] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc13: [1.0x5, x6, x13] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc14: [1.0x7, x8, x14] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc15: [1.0x9, 0.25 * x41, x15] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc16: [0.25 * x41, 0.25 * x41, x16] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc17: [0.25 * x41, 0.25 * x41, x17] in MathOptInterface.RotatedSecondOrderCone(3)
-    rsoc18: [0.25 * x41, 0.25 * x41, x18] in MathOptInterface.RotatedSecondOrderCone(3)
+    lessthan: t + -0.25 * x41 in LessThan(0.0)
+    equalto1: 1.0x1 in EqualTo(1.0)
+    equalto2: 1.0x2 in EqualTo(1.0)
+    equalto3: 1.0x3 in EqualTo(1.0)
+    equalto4: 1.0x4 in EqualTo(1.0)
+    equalto5: 1.0x5 in EqualTo(1.0)
+    equalto6: 1.0x6 in EqualTo(1.0)
+    equalto7: 1.0x7 in EqualTo(1.0)
+    equalto8: 1.0x8 in EqualTo(1.0)
+    equalto9: 1.0x9 in EqualTo(1.0)
+    rsoc41: [1.0x31, x32, x41] in RotatedSecondOrderCone(3)
+    rsoc31: [1.0x21, x22, x31] in RotatedSecondOrderCone(3)
+    rsoc32: [1.0x23, x24, x32] in RotatedSecondOrderCone(3)
+    rsoc21: [1.0x11, x12, x21] in RotatedSecondOrderCone(3)
+    rsoc22: [1.0x13, x14, x22] in RotatedSecondOrderCone(3)
+    rsoc23: [1.0x15, x16, x23] in RotatedSecondOrderCone(3)
+    rsoc24: [1.0x17, x18, x24] in RotatedSecondOrderCone(3)
+    rsoc11: [1.0x1, x2, x11] in RotatedSecondOrderCone(3)
+    rsoc12: [1.0x3, x4, x12] in RotatedSecondOrderCone(3)
+    rsoc13: [1.0x5, x6, x13] in RotatedSecondOrderCone(3)
+    rsoc14: [1.0x7, x8, x14] in RotatedSecondOrderCone(3)
+    rsoc15: [1.0x9, 0.25 * x41, x15] in RotatedSecondOrderCone(3)
+    rsoc16: [0.25 * x41, 0.25 * x41, x16] in RotatedSecondOrderCone(3)
+    rsoc17: [0.25 * x41, 0.25 * x41, x17] in RotatedSecondOrderCone(3)
+    rsoc18: [0.25 * x41, 0.25 * x41, x18] in RotatedSecondOrderCone(3)
     maxobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -314,16 +313,16 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_2()
 
     s = """
     variables: t, x1, x2, x3, x4, x5, x6, x7, x8, x9
-    equalto1: 1.0x1 in MathOptInterface.EqualTo(1.0)
-    equalto2: 1.0x2 in MathOptInterface.EqualTo(1.0)
-    equalto3: 1.0x3 in MathOptInterface.EqualTo(1.0)
-    equalto4: 1.0x4 in MathOptInterface.EqualTo(1.0)
-    equalto5: 1.0x5 in MathOptInterface.EqualTo(1.0)
-    equalto6: 1.0x6 in MathOptInterface.EqualTo(1.0)
-    equalto7: 1.0x7 in MathOptInterface.EqualTo(1.0)
-    equalto8: 1.0x8 in MathOptInterface.EqualTo(1.0)
-    equalto9: 1.0x9 in MathOptInterface.EqualTo(1.0)
-    geomean: [1.0t, x1, x2, x3, x4, x5, x6, x7, x8, x9] in MathOptInterface.GeometricMeanCone(10)
+    equalto1: 1.0x1 in EqualTo(1.0)
+    equalto2: 1.0x2 in EqualTo(1.0)
+    equalto3: 1.0x3 in EqualTo(1.0)
+    equalto4: 1.0x4 in EqualTo(1.0)
+    equalto5: 1.0x5 in EqualTo(1.0)
+    equalto6: 1.0x6 in EqualTo(1.0)
+    equalto7: 1.0x7 in EqualTo(1.0)
+    equalto8: 1.0x8 in EqualTo(1.0)
+    equalto9: 1.0x9 in EqualTo(1.0)
+    geomean: [1.0t, x1, x2, x3, x4, x5, x6, x7, x8, x9] in GeometricMeanCone(10)
     maxobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -415,9 +414,9 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_3()
 
     s = """
     variables: t, x
-    lessthan1: t + -1.0x in MathOptInterface.LessThan(0.0)
-    lessthan2: 1.0x in MathOptInterface.LessThan(2.0)
-    nonneg: [1.0x] in MathOptInterface.Nonnegatives(1)
+    lessthan1: t + -1.0x in LessThan(0.0)
+    lessthan2: 1.0x in LessThan(2.0)
+    nonneg: [1.0x] in Nonnegatives(1)
     maxobjective: 2.0 * t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -455,8 +454,8 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_3()
 
     s = """
     variables: t, x
-    lessthan: 1.0x in MathOptInterface.LessThan(2.0)
-    geomean: [1.0t, x] in MathOptInterface.GeometricMeanCone(2)
+    lessthan: 1.0x in LessThan(2.0)
+    geomean: [1.0t, x] in GeometricMeanCone(2)
     maxobjective: 2.0 * t
     """
     model = MOI.Utilities.Model{Float64}()

--- a/test/Bridges/Constraint/geomean_to_power.jl
+++ b/test/Bridges/Constraint/geomean_to_power.jl
@@ -8,8 +8,7 @@ module TestConstraintGeomeanToPower
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/geomean_to_relentr.jl
+++ b/test/Bridges/Constraint/geomean_to_relentr.jl
@@ -8,8 +8,7 @@ module TestConstraintGeomeanToRelentr
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -105,9 +104,9 @@ function test_conic_GeometricMeanCone_VectorAffineFunction()
 
     s = """
     variables: t, x, y, z, aux
-    less: x + y + z in MathOptInterface.LessThan(3.0)
-    nonneg: [aux] in MathOptInterface.Nonnegatives(1)
-    relentr: [0.0, x, y, z, t + aux, t + aux, t + aux] in MathOptInterface.RelativeEntropyCone(7)
+    less: x + y + z in LessThan(3.0)
+    nonneg: [aux] in Nonnegatives(1)
+    relentr: [0.0, x, y, z, t + aux, t + aux, t + aux] in RelativeEntropyCone(7)
     maxobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -139,8 +138,8 @@ function test_conic_GeometricMeanCone_VectorAffineFunction()
 
     s = """
     variables: t, x, y, z
-    less: x + y + z in MathOptInterface.LessThan(3.0)
-    geomean: [1.0t, x, y, z] in MathOptInterface.GeometricMeanCone(4)
+    less: x + y + z in LessThan(3.0)
+    geomean: [1.0t, x, y, z] in GeometricMeanCone(4)
     maxobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -249,17 +248,17 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_2()
 
     s = """
     variables: t, x1, x2, x3, x4, x5, x6, x7, x8, x9, aux
-    equalto1: 1.0x1 in MathOptInterface.EqualTo(1.0)
-    equalto2: 1.0x2 in MathOptInterface.EqualTo(1.0)
-    equalto3: 1.0x3 in MathOptInterface.EqualTo(1.0)
-    equalto4: 1.0x4 in MathOptInterface.EqualTo(1.0)
-    equalto5: 1.0x5 in MathOptInterface.EqualTo(1.0)
-    equalto6: 1.0x6 in MathOptInterface.EqualTo(1.0)
-    equalto7: 1.0x7 in MathOptInterface.EqualTo(1.0)
-    equalto8: 1.0x8 in MathOptInterface.EqualTo(1.0)
-    equalto9: 1.0x9 in MathOptInterface.EqualTo(1.0)
-    nonneg: [aux] in MathOptInterface.Nonnegatives(1)
-    relentr: [0.0, x1, x2, x3, x4, x5, x6, x7, x8, x9, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux] in MathOptInterface.RelativeEntropyCone(19)
+    equalto1: 1.0x1 in EqualTo(1.0)
+    equalto2: 1.0x2 in EqualTo(1.0)
+    equalto3: 1.0x3 in EqualTo(1.0)
+    equalto4: 1.0x4 in EqualTo(1.0)
+    equalto5: 1.0x5 in EqualTo(1.0)
+    equalto6: 1.0x6 in EqualTo(1.0)
+    equalto7: 1.0x7 in EqualTo(1.0)
+    equalto8: 1.0x8 in EqualTo(1.0)
+    equalto9: 1.0x9 in EqualTo(1.0)
+    nonneg: [aux] in Nonnegatives(1)
+    relentr: [0.0, x1, x2, x3, x4, x5, x6, x7, x8, x9, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux, t + aux] in RelativeEntropyCone(19)
     maxobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -292,16 +291,16 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_2()
 
     s = """
     variables: t, x1, x2, x3, x4, x5, x6, x7, x8, x9
-    equalto1: 1.0x1 in MathOptInterface.EqualTo(1.0)
-    equalto2: 1.0x2 in MathOptInterface.EqualTo(1.0)
-    equalto3: 1.0x3 in MathOptInterface.EqualTo(1.0)
-    equalto4: 1.0x4 in MathOptInterface.EqualTo(1.0)
-    equalto5: 1.0x5 in MathOptInterface.EqualTo(1.0)
-    equalto6: 1.0x6 in MathOptInterface.EqualTo(1.0)
-    equalto7: 1.0x7 in MathOptInterface.EqualTo(1.0)
-    equalto8: 1.0x8 in MathOptInterface.EqualTo(1.0)
-    equalto9: 1.0x9 in MathOptInterface.EqualTo(1.0)
-    geomean: [1.0t, x1, x2, x3, x4, x5, x6, x7, x8, x9] in MathOptInterface.GeometricMeanCone(10)
+    equalto1: 1.0x1 in EqualTo(1.0)
+    equalto2: 1.0x2 in EqualTo(1.0)
+    equalto3: 1.0x3 in EqualTo(1.0)
+    equalto4: 1.0x4 in EqualTo(1.0)
+    equalto5: 1.0x5 in EqualTo(1.0)
+    equalto6: 1.0x6 in EqualTo(1.0)
+    equalto7: 1.0x7 in EqualTo(1.0)
+    equalto8: 1.0x8 in EqualTo(1.0)
+    equalto9: 1.0x9 in EqualTo(1.0)
+    geomean: [1.0t, x1, x2, x3, x4, x5, x6, x7, x8, x9] in GeometricMeanCone(10)
     maxobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -408,9 +407,9 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_3()
     MOI.set(mock, MOI.ConstraintName(), less[1], "less")
     s = """
     variables: t, x, aux
-    less: 1.0x in MathOptInterface.LessThan(2.0)
-    nonneg: [aux] in MathOptInterface.Nonnegatives(1)
-    relentr: [0.0, x, t + aux] in MathOptInterface.RelativeEntropyCone(3)
+    less: 1.0x in LessThan(2.0)
+    nonneg: [aux] in Nonnegatives(1)
+    relentr: [0.0, x, t + aux] in RelativeEntropyCone(3)
     maxobjective: 2.0t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -442,8 +441,8 @@ function test_conic_GeometricMeanCone_VectorAffineFunction_3()
 
     s = """
     variables: t, x
-    less: 1.0x in MathOptInterface.LessThan(2.0)
-    geomean: [1.0t, x] in MathOptInterface.GeometricMeanCone(2)
+    less: 1.0x in LessThan(2.0)
+    geomean: [1.0t, x] in GeometricMeanCone(2)
     maxobjective: 2.0t
     """
     model = MOI.Utilities.Model{Float64}()

--- a/test/Bridges/Constraint/hermitian.jl
+++ b/test/Bridges/Constraint/hermitian.jl
@@ -8,8 +8,7 @@ module TestConstraintHermitianToSymmetricPSD
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/hyper_rectangle.jl
+++ b/test/Bridges/Constraint/hyper_rectangle.jl
@@ -8,8 +8,7 @@ module TestConstraintHyperRectangle
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/indicator_activate_on_zero.jl
+++ b/test/Bridges/Constraint/indicator_activate_on_zero.jl
@@ -8,8 +8,7 @@ module TestConstraintIndicatorActiveOnFalse
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/indicator_flipsign.jl
+++ b/test/Bridges/Constraint/indicator_flipsign.jl
@@ -8,8 +8,7 @@ module TestConstraintIndicatorFlipSign
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/indicator_sos.jl
+++ b/test/Bridges/Constraint/indicator_sos.jl
@@ -8,8 +8,7 @@ module TestConstraintIndicatorSOS1
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -205,9 +204,9 @@ function test_model_equality()
     s = """
     variables: z, x, w
     maxobjective: z
-    sos1: [w, z] in MathOptInterface.SOS1([0.4, 0.6])
+    sos1: [w, z] in SOS1([0.4, 0.6])
     ineq: x + w <= 8.0
-    z in MathOptInterface.ZeroOne()
+    z in ZeroOne()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
@@ -224,7 +223,7 @@ function test_model_equality()
         2,
         (
             (MOI.VariableIndex, MOI.ZeroOne, 1),
-            (MOI.VectorOfVariables, MathOptInterface.SOS1{Float64}, 0),
+            (MOI.VectorOfVariables, MOI.SOS1{Float64}, 0),
             (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}, 0),
         ),
         used_bridges = 1,
@@ -234,7 +233,7 @@ function test_model_equality()
     model = MOI.Utilities.Model{Float64}()
     sbridged = """
     variables: x, z
-    z in MathOptInterface.ZeroOne()
+    z in ZeroOne()
     maxobjective: z
     """
     MOI.Utilities.loadfromstring!(model, sbridged)

--- a/test/Bridges/Constraint/interval.jl
+++ b/test/Bridges/Constraint/interval.jl
@@ -8,8 +8,7 @@ module TestConstraintSplitInterval
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/ltgt_to_interval.jl
+++ b/test/Bridges/Constraint/ltgt_to_interval.jl
@@ -9,8 +9,7 @@ module TestConstraintToInterval
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/map.jl
+++ b/test/Bridges/Constraint/map.jl
@@ -8,8 +8,7 @@ module TestConstraintMap
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/norm_spec_nuc_to_psd.jl
+++ b/test/Bridges/Constraint/norm_spec_nuc_to_psd.jl
@@ -8,8 +8,7 @@ module TestConstraintNormSpectral
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -89,7 +88,7 @@ function test_NormSpectral()
 
     s = """
     variables: t
-    psd: [t, 0.0, t, 0.0, 0.0, t, 1.0, 1.0, 0.0, t, 1.0, -1.0, 1.0, 0.0, t] in MathOptInterface.PositiveSemidefiniteConeTriangle(5)
+    psd: [t, 0.0, t, 0.0, 0.0, t, 1.0, 1.0, 0.0, t, 1.0, -1.0, 1.0, 0.0, t] in PositiveSemidefiniteConeTriangle(5)
     minobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -107,7 +106,7 @@ function test_NormSpectral()
 
     s = """
     variables: t
-    spec: [t, 1.0, 1.0, 1.0, -1.0, 0.0, 1.0] in MathOptInterface.NormSpectralCone(2, 3)
+    spec: [t, 1.0, 1.0, 1.0, -1.0, 0.0, 1.0] in NormSpectralCone(2, 3)
     minobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -235,7 +234,7 @@ function test_NormNuclear()
     s = """
     variables: t, U11, U12, U22, U31, U32, U33, V11, V12, V22
     greater: t + -0.5U11 + -0.5U22 + -0.5U33 + -0.5V11 + -0.5V22 >= 0.0
-    psd: [U11, U12, U22, U31, U32, U33, 1.0, 1.0, 0.0, V11, 1.0, -1.0, 1.0, V12, V22] in MathOptInterface.PositiveSemidefiniteConeTriangle(5)
+    psd: [U11, U12, U22, U31, U32, U33, 1.0, 1.0, 0.0, V11, 1.0, -1.0, 1.0, V12, V22] in PositiveSemidefiniteConeTriangle(5)
     minobjective: t
     """
     model = MOI.Utilities.Model{Float64}()
@@ -259,7 +258,7 @@ function test_NormNuclear()
 
     s = """
     variables: t
-    nuc: [t, 1.0, 1.0, 1.0, -1.0, 0.0, 1.0] in MathOptInterface.NormNuclearCone(2, 3)
+    nuc: [t, 1.0, 1.0, 1.0, -1.0, 0.0, 1.0] in NormNuclearCone(2, 3)
     minobjective: t
     """
     model = MOI.Utilities.Model{Float64}()

--- a/test/Bridges/Constraint/norm_to_lp.jl
+++ b/test/Bridges/Constraint/norm_to_lp.jl
@@ -8,8 +8,7 @@ module TestConstraintNormInfinity
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -91,9 +90,9 @@ function test_NormInfinity_1()
 
     s = """
     variables: x, y, z
-    nonneg: [x + -1.0y, x + -1.0z, x + y, x + z] in MathOptInterface.Nonnegatives(4)
-    x_eq: [-1.0 + x] in MathOptInterface.Zeros(1)
-    y_eq: [-0.5 + y] in MathOptInterface.Zeros(1)
+    nonneg: [x + -1.0y, x + -1.0z, x + y, x + z] in Nonnegatives(4)
+    x_eq: [-1.0 + x] in Zeros(1)
+    y_eq: [-0.5 + y] in Zeros(1)
     maxobjective: y + z
     """
     model = MOI.Utilities.Model{Float64}()
@@ -132,9 +131,9 @@ function test_NormInfinity_1()
 
     s = """
     variables: x, y, z
-    norminf: [1.0x, y, z] in MathOptInterface.NormInfinityCone(3)
-    x_eq: [-1.0 + x] in MathOptInterface.Zeros(1)
-    y_eq: [-0.5 + y] in MathOptInterface.Zeros(1)
+    norminf: [1.0x, y, z] in NormInfinityCone(3)
+    x_eq: [-1.0 + x] in Zeros(1)
+    y_eq: [-0.5 + y] in Zeros(1)
     maxobjective: y + z
     """
     model = MOI.Utilities.Model{Float64}()
@@ -216,8 +215,8 @@ function test_conic_NormInfinityCone_3()
 
     s = """
     variables: x, y1, y2, y3
-    nonneg1: [x + -1.0y1 + -3.0, x + -1.0y2 + -3.0, x + -1.0y3 + -3.0, x + y1 + 1.0, x + y2 + 1.0, x + y3 + 1.0] in MathOptInterface.Nonnegatives(6)
-    nonneg2: [y1 + 1.0, y2 + 1.0, y3 + 1.0] in MathOptInterface.Nonnegatives(3)
+    nonneg1: [x + -1.0y1 + -3.0, x + -1.0y2 + -3.0, x + -1.0y3 + -3.0, x + y1 + 1.0, x + y2 + 1.0, x + y3 + 1.0] in Nonnegatives(6)
+    nonneg2: [y1 + 1.0, y2 + 1.0, y3 + 1.0] in Nonnegatives(3)
     minobjective: x
     """
     model = MOI.Utilities.Model{Float64}()
@@ -255,8 +254,8 @@ function test_conic_NormInfinityCone_3()
 
     s = """
     variables: x, y1, y2, y3
-    norminf: [x + -1.0, y1 + 2.0, y2 + 2.0, y3 + 2.0] in MathOptInterface.NormInfinityCone(4)
-    nonneg: [y1 + 1.0, y2 + 1.0, y3 + 1.0] in MathOptInterface.Nonnegatives(3)
+    norminf: [x + -1.0, y1 + 2.0, y2 + 2.0, y3 + 2.0] in NormInfinityCone(4)
+    nonneg: [y1 + 1.0, y2 + 1.0, y3 + 1.0] in Nonnegatives(3)
     minobjective: x
     """
     model = MOI.Utilities.Model{Float64}()
@@ -371,9 +370,9 @@ function test_conic_NormOneCone_VectorOfVariables()
 
     s = """
     variables: x, y, z, u, v
-    nonneg: [x + -1.0u + -1.0v, u + -1.0y, v + -1.0z, u + y, v + z] in MathOptInterface.Nonnegatives(5)
-    x_eq: [-1.0 + x] in MathOptInterface.Zeros(1)
-    y_eq: [-0.5 + y] in MathOptInterface.Zeros(1)
+    nonneg: [x + -1.0u + -1.0v, u + -1.0y, v + -1.0z, u + y, v + z] in Nonnegatives(5)
+    x_eq: [-1.0 + x] in Zeros(1)
+    y_eq: [-0.5 + y] in Zeros(1)
     maxobjective: y + z
     """
     model = MOI.Utilities.Model{Float64}()
@@ -406,9 +405,9 @@ function test_conic_NormOneCone_VectorOfVariables()
 
     s = """
     variables: x, y, z
-    normone: [1.0x, y, z] in MathOptInterface.NormOneCone(3)
-    x_eq: [-1.0 + x] in MathOptInterface.Zeros(1)
-    y_eq: [-0.5 + y] in MathOptInterface.Zeros(1)
+    normone: [1.0x, y, z] in NormOneCone(3)
+    x_eq: [-1.0 + x] in Zeros(1)
+    y_eq: [-0.5 + y] in Zeros(1)
     maxobjective: y + z
     """
     model = MOI.Utilities.Model{Float64}()
@@ -484,8 +483,8 @@ function test_conic_NormOneCone()
     MOI.set(mock, MOI.ConstraintName(), nonneg[2], "nonneg2")
     s = """
     variables: x, y1, y2, y3, z1, z2, z3
-    nonneg1: [x + -1.0 + -1.0z1 + -1.0z2 + -1.0z3, z1 + -1.0y1 + -2.0, z2 + -1.0y2 + -2.0, z3 + -1.0y3 + -2.0, z1 + y1 + 2.0, z2 + y2 + 2.0, z3 + y3 + 2.0] in MathOptInterface.Nonnegatives(7)
-    nonneg2: [y1 + 1.0, y2 + 1.0, y3 + 1.0] in MathOptInterface.Nonnegatives(3)
+    nonneg1: [x + -1.0 + -1.0z1 + -1.0z2 + -1.0z3, z1 + -1.0y1 + -2.0, z2 + -1.0y2 + -2.0, z3 + -1.0y3 + -2.0, z1 + y1 + 2.0, z2 + y2 + 2.0, z3 + y3 + 2.0] in Nonnegatives(7)
+    nonneg2: [y1 + 1.0, y2 + 1.0, y3 + 1.0] in Nonnegatives(3)
     minobjective: x
     """
     model = MOI.Utilities.Model{Float64}()
@@ -522,8 +521,8 @@ function test_conic_NormOneCone()
     MOI.set(bridged_mock, MOI.ConstraintName(), nonneg[1], "nonneg")
     s = """
     variables: x, y1, y2, y3
-    normone: [x + -1.0, y1 + 2.0, y2 + 2.0, y3 + 2.0] in MathOptInterface.NormOneCone(4)
-    nonneg: [y1 + 1.0, y2 + 1.0, y3 + 1.0] in MathOptInterface.Nonnegatives(3)
+    normone: [x + -1.0, y1 + 2.0, y2 + 2.0, y3 + 2.0] in NormOneCone(4)
+    nonneg: [y1 + 1.0, y2 + 1.0, y3 + 1.0] in Nonnegatives(3)
     minobjective: x
     """
     model = MOI.Utilities.Model{Float64}()

--- a/test/Bridges/Constraint/number_conversion.jl
+++ b/test/Bridges/Constraint/number_conversion.jl
@@ -8,8 +8,7 @@ module TestConstraintNumberConversion
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/quad_to_soc.jl
+++ b/test/Bridges/Constraint/quad_to_soc.jl
@@ -10,8 +10,7 @@ import LinearAlgebra
 import SparseArrays
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/relentr_to_exp.jl
+++ b/test/Bridges/Constraint/relentr_to_exp.jl
@@ -8,8 +8,7 @@ module TestConstraintRelativeEntropyToExponential
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -93,8 +92,8 @@ function test_RelativeEntropy()
     s = """
     variables: u, y1, y2
     greater: u + -1.0y1 + -1.0y2 >= 0.0
-    exps1: [-1.0y1, 2.0, 1.0] in MathOptInterface.ExponentialCone()
-    exps2: [-1.0y2, 3.0, 5.0] in MathOptInterface.ExponentialCone()
+    exps1: [-1.0y1, 2.0, 1.0] in ExponentialCone()
+    exps2: [-1.0y2, 3.0, 5.0] in ExponentialCone()
     minobjective: u
     """
     model = MOI.Utilities.Model{Float64}()
@@ -117,7 +116,7 @@ function test_RelativeEntropy()
 
     s = """
     variables: u
-    relentr: [u, 1.0, 5.0, 2.0, 3.0] in MathOptInterface.RelativeEntropyCone(5)
+    relentr: [u, 1.0, 5.0, 2.0, 3.0] in RelativeEntropyCone(5)
     minobjective: u
     """
     model = MOI.Utilities.Model{Float64}()

--- a/test/Bridges/Constraint/rsoc.jl
+++ b/test/Bridges/Constraint/rsoc.jl
@@ -8,8 +8,7 @@ module TestConstraintRSOC
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/scalarize.jl
+++ b/test/Bridges/Constraint/scalarize.jl
@@ -8,8 +8,7 @@ module TestConstraintScalarize
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/semi_to_binary.jl
+++ b/test/Bridges/Constraint/semi_to_binary.jl
@@ -8,8 +8,7 @@ module TestConstraintSemiToBinary
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/slack.jl
+++ b/test/Bridges/Constraint/slack.jl
@@ -8,8 +8,7 @@ module TestConstraintSlack
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/soc_to_nonconvex_quad.jl
+++ b/test/Bridges/Constraint/soc_to_nonconvex_quad.jl
@@ -8,8 +8,7 @@ module TestConstraintSOCtoNonConvexQuad
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/soc_to_psd.jl
+++ b/test/Bridges/Constraint/soc_to_psd.jl
@@ -8,8 +8,7 @@ module TestConstraintSOCtoPSD
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/split_complex_equalto.jl
+++ b/test/Bridges/Constraint/split_complex_equalto.jl
@@ -8,8 +8,7 @@ module TestConstraintSplitComplexEqualTo
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/split_complex_zeros.jl
+++ b/test/Bridges/Constraint/split_complex_zeros.jl
@@ -8,8 +8,7 @@ module TestConstraintSplitComplexZeros
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/square.jl
+++ b/test/Bridges/Constraint/square.jl
@@ -8,8 +8,7 @@ module TestConstraintSquare
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/table.jl
+++ b/test/Bridges/Constraint/table.jl
@@ -8,8 +8,7 @@ module TestConstraintTable
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/vectorize.jl
+++ b/test/Bridges/Constraint/vectorize.jl
@@ -8,8 +8,7 @@ module TestConstraintVectorize
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Constraint/zero_one.jl
+++ b/test/Bridges/Constraint/zero_one.jl
@@ -8,8 +8,7 @@ module TestConstraintZeroOne
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Objective/functionize.jl
+++ b/test/Bridges/Objective/functionize.jl
@@ -8,8 +8,7 @@ module TestObjectiveFunctionize
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Objective/map.jl
+++ b/test/Bridges/Objective/map.jl
@@ -8,8 +8,7 @@ module TestObjectiveMap
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Objective/quadratize.jl
+++ b/test/Bridges/Objective/quadratize.jl
@@ -8,8 +8,7 @@ module TestObjectiveQuadratize
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Objective/slack.jl
+++ b/test/Bridges/Objective/slack.jl
@@ -8,8 +8,7 @@ module TestObjectiveSlack
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -302,7 +301,7 @@ function test_original()
         ],
     )
     err = ArgumentError(
-        "Objective bridge of type `$(MathOptInterface.Bridges.Objective.SlackBridge{Float64,MathOptInterface.ScalarQuadraticFunction{Float64},MathOptInterface.ScalarQuadraticFunction{Float64}})`" *
+        "Objective bridge of type `$(MOI.Bridges.Objective.SlackBridge{Float64,MOI.ScalarQuadraticFunction{Float64},MOI.ScalarQuadraticFunction{Float64}})`" *
         " does not support modifying the objective sense. As a workaround, set" *
         " the sense to `MOI.FEASIBILITY_SENSE` to clear the objective function" *
         " and bridges.",

--- a/test/Bridges/Objective/vector_slack.jl
+++ b/test/Bridges/Objective/vector_slack.jl
@@ -8,8 +8,7 @@ module TestObjectiveVectorSlack
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Variable/bridge.jl
+++ b/test/Bridges/Variable/bridge.jl
@@ -8,8 +8,7 @@ module TestVariableBridge
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Variable/flip_sign.jl
+++ b/test/Bridges/Variable/flip_sign.jl
@@ -8,8 +8,7 @@ module TestVariableFlipSign
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 include("../utilities.jl")
 
@@ -69,23 +68,17 @@ function test_NonposToNonneg()
     )
     con_w = MOI.get(
         mock,
-        MOI.ListOfConstraintIndices{
-            MathOptInterface.VectorOfVariables,
-            MathOptInterface.Zeros,
-        }(),
+        MOI.ListOfConstraintIndices{MOI.VectorOfVariables,MOI.Zeros}(),
     )[1]
     con_yz = MOI.get(
         mock,
-        MOI.ListOfConstraintIndices{
-            MathOptInterface.VectorOfVariables,
-            MathOptInterface.Nonnegatives,
-        }(),
+        MOI.ListOfConstraintIndices{MOI.VectorOfVariables,MOI.Nonnegatives}(),
     )
     con_ex = MOI.get(
         mock,
         MOI.ListOfConstraintIndices{
-            MathOptInterface.VectorAffineFunction{Float64},
-            MathOptInterface.Zeros,
+            MOI.VectorAffineFunction{Float64},
+            MOI.Zeros,
         }(),
     )[1]
 
@@ -102,18 +95,15 @@ function test_NonposToNonneg()
     )
     con_v = MOI.get(
         bridged_mock,
-        MOI.ListOfConstraintIndices{
-            MathOptInterface.VectorOfVariables,
-            MathOptInterface.Nonpositives,
-        }(),
+        MOI.ListOfConstraintIndices{MOI.VectorOfVariables,MOI.Nonpositives}(),
     )[1]
     MOI.set(bridged_mock, MOI.ConstraintName(), con_v, "cv")
     s = """
     variables: x, y, z, w
-    cw: [w] in MathOptInterface.Zeros(1)
-    cy: [y] in MathOptInterface.Nonnegatives(1)
-    cz: [z] in MathOptInterface.Nonnegatives(1)
-    cex: [1*x + -1*w + 4.0, -1*y + 3.0, 1*x + 1*z + -12.0] in MathOptInterface.Zeros(3)
+    cw: [w] in Zeros(1)
+    cy: [y] in Nonnegatives(1)
+    cz: [z] in Nonnegatives(1)
+    cex: [1*x + -1*w + 4.0, -1*y + 3.0, 1*x + 1*z + -12.0] in Zeros(3)
     minobjective: 3*x + -2*y + -4*z
     """
     model = MOI.Utilities.Model{Float64}()
@@ -126,10 +116,10 @@ function test_NonposToNonneg()
     )
     s = """
     variables: x, z, w, v
-    cv: [v] in MathOptInterface.Nonpositives(1)
-    cw: [w] in MathOptInterface.Zeros(1)
-    cz: [z] in MathOptInterface.Nonnegatives(1)
-    cex: [1*x + -1*w + 4.0, 1*v + 3.0, 1*x + 1*z + -12.0] in MathOptInterface.Zeros(3)
+    cv: [v] in Nonpositives(1)
+    cw: [w] in Zeros(1)
+    cz: [z] in Nonnegatives(1)
+    cex: [1*x + -1*w + 4.0, 1*v + 3.0, 1*x + 1*z + -12.0] in Zeros(3)
     minobjective: 3*x + 2*v + -4*z
     """
     model = MOI.Utilities.Model{Float64}()

--- a/test/Bridges/Variable/free.jl
+++ b/test/Bridges/Variable/free.jl
@@ -8,8 +8,7 @@ module TestVariableFree
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -85,8 +84,8 @@ function test_modification_multirow_vectoraffine_nonpos()
     )
     s = """
     variables: xpos, xneg
-    nonneg: [xpos, xneg] in MathOptInterface.Nonnegatives(2)
-    c: [4.0xpos + -4.0xneg + -1.0, 3.0xpos + -3.0xneg + -1.0] in MathOptInterface.Nonpositives(2)
+    nonneg: [xpos, xneg] in Nonnegatives(2)
+    c: [4.0xpos + -4.0xneg + -1.0, 3.0xpos + -3.0xneg + -1.0] in Nonpositives(2)
     maxobjective: xpos + -1.0xneg
     """
     model = MOI.Utilities.Model{Float64}()
@@ -94,7 +93,7 @@ function test_modification_multirow_vectoraffine_nonpos()
     MOI.Test.util_test_models_equal(mock, model, var_names, ["nonneg", "c"])
     s = """
     variables: x
-    c: [4.0x + -1.0, 3.0x + -1.0] in MathOptInterface.Nonpositives(2)
+    c: [4.0x + -1.0, 3.0x + -1.0] in Nonpositives(2)
     maxobjective: 1.0x
     """
     model = MOI.Utilities.Model{Float64}()
@@ -281,7 +280,7 @@ function test_linear_transform()
     )
     s = """
     variables: v1pos, v2pos, v1neg, v2neg
-    nonneg: [v1pos, v2pos, v1neg, v2neg] in MathOptInterface.Nonnegatives(4)
+    nonneg: [v1pos, v2pos, v1neg, v2neg] in Nonnegatives(4)
     c1: v1pos + -1.0v1neg + v2pos + -1.0v2neg >= 1.0
     c2: v1pos + -1.0v1neg + v2pos + -1.0v2neg <= 2.0
     minobjective: v1pos + -1.0v1neg + v2pos + -1.0v2neg

--- a/test/Bridges/Variable/hermitian.jl
+++ b/test/Bridges/Variable/hermitian.jl
@@ -8,8 +8,7 @@ module TestVariableHermitianToSymmetricPSD
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 import LinearAlgebra
 

--- a/test/Bridges/Variable/map.jl
+++ b/test/Bridges/Variable/map.jl
@@ -8,8 +8,7 @@ module TestVariableMap
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/Variable/rsoc_to_psd.jl
+++ b/test/Bridges/Variable/rsoc_to_psd.jl
@@ -8,8 +8,7 @@ module TestVariableRSOCtoPSD
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -69,7 +68,7 @@ function test_RSOC_of_dimension_2()
     MOI.set(mock, MOI.ConstraintName(), nonneg[1], "cab")
     s = """
     variables: a, b
-    cab: [a, b] in MathOptInterface.Nonnegatives(2)
+    cab: [a, b] in Nonnegatives(2)
     c: a + 0.5b <= 1.0
     maxobjective: 0.5b
     """
@@ -86,7 +85,7 @@ function test_RSOC_of_dimension_2()
     MOI.set(bridged_mock, MOI.ConstraintName(), cxy, "cxy")
     s = """
     variables: x, y
-    cxy: [x, y] in MathOptInterface.RotatedSecondOrderCone(2)
+    cxy: [x, y] in RotatedSecondOrderCone(2)
     c: x + y <= 1.0
     maxobjective: 1.0y
     """
@@ -177,7 +176,7 @@ function test_RSOC4()
 
     s = """
     variables: Q11, Q12, Q13, Q22, Q23, Q33
-    psd: [Q11, Q12, Q22, Q13, Q23, Q33] in MathOptInterface.PositiveSemidefiniteConeTriangle(3)
+    psd: [Q11, Q12, Q22, Q13, Q23, Q33] in PositiveSemidefiniteConeTriangle(3)
     Q23 == 0.0
     diag33: Q22 + -1.0Q33 == 0.0
     c: Q11 + 0.5Q22 <= 2.0
@@ -221,7 +220,7 @@ function test_RSOC4()
 
     s = """
     variables: t, u, x, y
-    rsoc: [t, u, x, y] in MathOptInterface.RotatedSecondOrderCone(4)
+    rsoc: [t, u, x, y] in RotatedSecondOrderCone(4)
     c: t + u <= 2.0
     maxobjective: x + y
     """

--- a/test/Bridges/Variable/rsoc_to_soc.jl
+++ b/test/Bridges/Variable/rsoc_to_soc.jl
@@ -8,8 +8,7 @@ module TestVariableRSOCtoSOC
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -66,7 +65,7 @@ function test_rotatedsoc4()
     s2 = √2
     s = """
     variables: a, b, c, d
-    soc: [a, b, c, d] in MathOptInterface.SecondOrderCone(4)
+    soc: [a, b, c, d] in SecondOrderCone(4)
     c: $s2*a <= 2.0
     maxobjective: c + d
     """
@@ -92,7 +91,7 @@ function test_rotatedsoc4()
 
     s = """
     variables: t, u, x, y
-    rsoc: [t, u, x, y] in MathOptInterface.RotatedSecondOrderCone(4)
+    rsoc: [t, u, x, y] in RotatedSecondOrderCone(4)
     c: t + u <= 2.0
     maxobjective: x + y
     """

--- a/test/Bridges/Variable/soc_to_rsoc.jl
+++ b/test/Bridges/Variable/soc_to_rsoc.jl
@@ -8,8 +8,7 @@ module TestVariableSOCtoRSOC
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -67,8 +66,8 @@ function test_soc1v()
     invs2 = 1 / √2
     s = """
     variables: a, b, c
-    rsoc: [a, b, c] in MathOptInterface.RotatedSecondOrderCone(3)
-    ceq: [$invs2*a + $invs2*b + -1.0] in MathOptInterface.Zeros(1)
+    rsoc: [a, b, c] in RotatedSecondOrderCone(3)
+    ceq: [$invs2*a + $invs2*b + -1.0] in Zeros(1)
     maxobjective: $invs2*a + -$invs2*b + c
     """
     model = MOI.Utilities.Model{Float64}()
@@ -90,8 +89,8 @@ function test_soc1v()
 
     s = """
     variables: x, y, z
-    soc: [x, y, z] in MathOptInterface.SecondOrderCone(3)
-    ceq: [x + -1.0] in MathOptInterface.Zeros(1)
+    soc: [x, y, z] in SecondOrderCone(3)
+    ceq: [x + -1.0] in Zeros(1)
     maxobjective: y + z
     """
     model = MOI.Utilities.Model{Float64}()

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -8,8 +8,7 @@ module TestVariableVectorize
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -62,7 +61,7 @@ function test_get_scalar_constraint()
         )
         s = """
         variables: y
-        cy: [y] in MathOptInterface.Nonnegatives(1)
+        cy: [y] in Nonnegatives(1)
         c: 2.0y >= 3.0
         """
         model = MOI.Utilities.Model{Float64}()
@@ -145,7 +144,7 @@ function test_exp3_with_add_constrained_variable_y()
     @test length(cis) == 1
 
     err = ArgumentError(
-        "Variable bridge of type `$(MathOptInterface.Bridges.Variable.VectorizeBridge{Float64,MathOptInterface.Nonpositives})`" *
+        "Variable bridge of type `$(MOI.Bridges.Variable.VectorizeBridge{Float64,MOI.Nonpositives})`" *
         " does not support accessing the attribute `MathOptInterface.Test.UnknownVariableAttribute()`.",
     )
     @test_throws err MOI.get(
@@ -196,9 +195,9 @@ function test_exp3_with_add_constrained_variable_y()
     )
     s = """
     variables: x, z
-    zc: [z] in MathOptInterface.Nonpositives(1)
+    zc: [z] in Nonpositives(1)
     xc: 2.0x <= 4.0
-    ec: [x, 1.0, z + 5.0] in MathOptInterface.ExponentialCone()
+    ec: [x, 1.0, z + 5.0] in ExponentialCone()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)
@@ -209,7 +208,7 @@ function test_exp3_with_add_constrained_variable_y()
     variables: x, y
     y <= 5.0
     xc: 2.0x <= 4.0
-    ec: [x, 1.0, y] in MathOptInterface.ExponentialCone()
+    ec: [x, 1.0, y] in ExponentialCone()
     """
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, s)

--- a/test/Bridges/Variable/zeros.jl
+++ b/test/Bridges/Variable/zeros.jl
@@ -8,8 +8,7 @@ module TestVariableZeros
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -43,7 +42,7 @@ function test_zeros()
     s = """
     variables: x, y, z
     x >= 0.0
-    cyz: [y, z] in MathOptInterface.Zeros(2)
+    cyz: [y, z] in Zeros(2)
     minobjective: x
     """
     model = MOI.Utilities.Model{Float64}()

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -8,9 +8,7 @@ module TestBridgeOptimizer
 
 using Test
 
-using MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/debug.jl
+++ b/test/Bridges/debug.jl
@@ -8,9 +8,7 @@ module TestBridgesDebug
 
 using Test
 
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Bridges/identity_bridge.jl
+++ b/test/Bridges/identity_bridge.jl
@@ -7,8 +7,7 @@
 # Dummy bridges used for testing
 module IdentityBridges
 
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 const F{T} = MOI.ScalarAffineFunction{T}
 const S{T} = MOI.EqualTo{T}

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -8,9 +8,7 @@ module TestBridgesLazyBridgeOptimizer
 
 using Test
 
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/FileFormats/CBF/CBF.jl
+++ b/test/FileFormats/CBF/CBF.jl
@@ -6,10 +6,9 @@
 
 module TestCBF
 
-import MathOptInterface
 using Test
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 const CBF = MOI.FileFormats.CBF
 const CBF_TEST_FILE = "test.cbf"

--- a/test/FileFormats/CBF/CBF.jl
+++ b/test/FileFormats/CBF/CBF.jl
@@ -9,7 +9,7 @@ module TestCBF
 using Test
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 const CBF = MOI.FileFormats.CBF
 const CBF_TEST_FILE = "test.cbf"
 const MODELS_DIR = joinpath(@__DIR__, "models")

--- a/test/FileFormats/FileFormats.jl
+++ b/test/FileFormats/FileFormats.jl
@@ -6,10 +6,9 @@
 
 module TestFileFormats
 
-using MathOptInterface
 using Test
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__, all = true)

--- a/test/FileFormats/LP/LP.jl
+++ b/test/FileFormats/LP/LP.jl
@@ -6,10 +6,9 @@
 
 module TestLP
 
-import MathOptInterface
 using Test
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const LP = MOI.FileFormats.LP
 const LP_TEST_FILE = "test.lp"
 
@@ -493,18 +492,10 @@ function test_read_model1()
           constraints
     @test (MOI.VariableIndex, MOI.GreaterThan{Float64}) in constraints
     @test (MOI.VariableIndex, MOI.Interval{Float64}) in constraints
-    @test (MathOptInterface.VariableIndex, MathOptInterface.Integer) in
-          constraints
-    @test (MathOptInterface.VariableIndex, MathOptInterface.ZeroOne) in
-          constraints
-    @test (
-        MathOptInterface.VectorOfVariables,
-        MathOptInterface.SOS1{Float64},
-    ) in constraints
-    @test (
-        MathOptInterface.VectorOfVariables,
-        MathOptInterface.SOS2{Float64},
-    ) in constraints
+    @test (MOI.VariableIndex, MOI.Integer) in constraints
+    @test (MOI.VariableIndex, MOI.ZeroOne) in constraints
+    @test (MOI.VectorOfVariables, MOI.SOS1{Float64}) in constraints
+    @test (MOI.VectorOfVariables, MOI.SOS2{Float64}) in constraints
     return
 end
 
@@ -519,10 +510,8 @@ function test_read_model2()
           constraints
     @test (MOI.VariableIndex, MOI.GreaterThan{Float64}) in constraints
     @test (MOI.VariableIndex, MOI.Interval{Float64}) in constraints
-    @test (MathOptInterface.VariableIndex, MathOptInterface.Integer) in
-          constraints
-    @test (MathOptInterface.VariableIndex, MathOptInterface.ZeroOne) in
-          constraints
+    @test (MOI.VariableIndex, MOI.Integer) in constraints
+    @test (MOI.VariableIndex, MOI.ZeroOne) in constraints
     # Adicionar testes dos bounds de V8
     @test MOI.get(model, MOI.VariableName(), MOI.VariableIndex(8)) == "V8"
     @test model.variables.lower[8] == -Inf

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -11,7 +11,7 @@ import JSONSchema
 using Test
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 const MOF = MOI.FileFormats.MOF
 
 const TEST_MOF_FILE = "test.mof.json"

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -8,10 +8,9 @@ module TestMOF
 
 import JSON
 import JSONSchema
-import MathOptInterface
 using Test
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 const MOF = MOI.FileFormats.MOF
 

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -9,7 +9,7 @@ module TestMPS
 using Test
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 const MPS = MOI.FileFormats.MPS
 const MPS_TEST_FILE = "test.mps"
 

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -6,10 +6,9 @@
 
 module TestMPS
 
-import MathOptInterface
 using Test
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 const MPS = MOI.FileFormats.MPS
 const MPS_TEST_FILE = "test.mps"

--- a/test/FileFormats/NL/NL.jl
+++ b/test/FileFormats/NL/NL.jl
@@ -6,8 +6,7 @@
 
 module TestNLModel
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const NL = MOI.FileFormats.NL
 
 using Test

--- a/test/FileFormats/NL/read.jl
+++ b/test/FileFormats/NL/read.jl
@@ -7,9 +7,7 @@
 module TestNonlinearRead
 
 using Test
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const NL = MOI.FileFormats.NL
 
 function runtests()

--- a/test/FileFormats/NL/sol.jl
+++ b/test/FileFormats/NL/sol.jl
@@ -7,9 +7,7 @@
 module TestNonlinearSolFiles
 
 using Test
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const NL = MOI.FileFormats.NL
 
 function runtests()

--- a/test/FileFormats/SDPA/SDPA.jl
+++ b/test/FileFormats/SDPA/SDPA.jl
@@ -6,10 +6,9 @@
 
 module TestSDPA
 
-import MathOptInterface
 using Test
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 const SDPA = MOI.FileFormats.SDPA
 const SDPA_TEST_FILE = "test.sdpa"

--- a/test/FileFormats/SDPA/SDPA.jl
+++ b/test/FileFormats/SDPA/SDPA.jl
@@ -9,7 +9,7 @@ module TestSDPA
 using Test
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 const SDPA = MOI.FileFormats.SDPA
 const SDPA_TEST_FILE = "test.sdpa"
 const SDPA_MODELS_DIR = joinpath(@__DIR__, "models")

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -7,11 +7,10 @@
 module TestNonlinear
 
 using Test
-import MathOptInterface
+import MathOptInterface as MOI
 import ForwardDiff
 import LinearAlgebra
 
-const MOI = MathOptInterface
 const Nonlinear = MOI.Nonlinear
 
 function runtests()

--- a/test/Nonlinear/ReverseAD.jl
+++ b/test/Nonlinear/ReverseAD.jl
@@ -8,10 +8,9 @@ module TestReverseAD
 
 using Test
 import LinearAlgebra
-import MathOptInterface
+import MathOptInterface as MOI
 import SparseArrays
 
-const MOI = MathOptInterface
 const Nonlinear = MOI.Nonlinear
 const ReverseAD = Nonlinear.ReverseAD
 const Coloring = ReverseAD.Coloring

--- a/test/Test/Test.jl
+++ b/test/Test/Test.jl
@@ -6,8 +6,7 @@
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 # Some tests are excluded because UniversalFallback accepts absolutely
 # everything.

--- a/test/Utilities/CleverDicts.jl
+++ b/test/Utilities/CleverDicts.jl
@@ -6,11 +6,11 @@
 
 module TestCleverDicts
 
-using MathOptInterface
 using Test
 
-const CleverDicts = MathOptInterface.Utilities.CleverDicts
-const MOI = MathOptInterface
+import MathOptInterface as MOI
+
+const CleverDicts = MOI.Utilities.CleverDicts
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -40,13 +40,13 @@ function test_MyKey()
 end
 
 function test_Abstract_Value()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,Any}()
+    d = CleverDicts.CleverDict{MOI.VariableIndex,Any}()
     key = CleverDicts.add_item(d, :a)
-    @test key == MathOptInterface.VariableIndex(1)
-    @test d[MathOptInterface.VariableIndex(1)] == :a
+    @test key == MOI.VariableIndex(1)
+    @test d[MOI.VariableIndex(1)] == :a
     key = CleverDicts.add_item(d, "b")
-    @test key == MathOptInterface.VariableIndex(2)
-    @test d[MathOptInterface.VariableIndex(2)] == "b"
+    @test key == MOI.VariableIndex(2)
+    @test d[MOI.VariableIndex(2)] == "b"
     for (k, v) in d
         if k.value == 1
             @test v == :a
@@ -59,17 +59,17 @@ function test_Abstract_Value()
 end
 
 function test_get_set()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
+    d = CleverDicts.CleverDict{MOI.VariableIndex,String}()
     key = CleverDicts.add_item(d, "first")
-    @test key == MathOptInterface.VariableIndex(1)
+    @test key == MOI.VariableIndex(1)
     @test get(d, key, nothing) == "first"
-    @test get(d, MathOptInterface.VariableIndex(2), nothing) === nothing
+    @test get(d, MOI.VariableIndex(2), nothing) === nothing
     @test Dict(key => "first") == d
     @test Dict(key => "second") != d
     sizehint!(d, 1)
     @test d[key] == "first"
     @test haskey(d, key) == true
-    @test_throws KeyError d[MathOptInterface.VariableIndex(2)]
+    @test_throws KeyError d[MOI.VariableIndex(2)]
     delete!(d, key)
     sizehint!(d, 2)
     @test_throws KeyError d[key]
@@ -77,7 +77,7 @@ function test_get_set()
     # @test_throws KeyError d[key] = "key"
     @test haskey(d, key) == false
     key2 = CleverDicts.add_item(d, "second")
-    @test key2 == MathOptInterface.VariableIndex(2)
+    @test key2 == MOI.VariableIndex(2)
     @test d[key2] == "second"
     d[key2] = "third"
     @test d[key2] == "third"
@@ -89,25 +89,25 @@ function test_get_set()
     empty!(d)
 
     key = CleverDicts.add_item(d, "first")
-    @test key == MathOptInterface.VariableIndex(1)
+    @test key == MOI.VariableIndex(1)
     @test d[key] == "first"
     d[key] = "zeroth"
     @test d[key] == "zeroth"
     @test haskey(d, key) == true
-    @test_throws KeyError d[MathOptInterface.VariableIndex(2)]
+    @test_throws KeyError d[MOI.VariableIndex(2)]
     delete!(d, key)
     @test_throws KeyError d[key]
     # set index is valid now
     # @test_throws KeyError d[key] = "key"
     @test haskey(d, key) == false
     key2 = CleverDicts.add_item(d, "second")
-    @test key2 == MathOptInterface.VariableIndex(2)
+    @test key2 == MOI.VariableIndex(2)
     @test d[key2] == "second"
     return
 end
 
 function test_LinearIndex()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
+    d = CleverDicts.CleverDict{MOI.VariableIndex,String}()
     key = CleverDicts.add_item(d, "first")
     @test d[CleverDicts.LinearIndex(1)] == "first"
     key2 = CleverDicts.add_item(d, "second")
@@ -121,77 +121,71 @@ function test_LinearIndex()
 end
 
 function test_keys_values()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
+    d = CleverDicts.CleverDict{MOI.VariableIndex,String}()
     key = CleverDicts.add_item(d, "first")
     key2 = CleverDicts.add_item(d, "second")
-    @test collect(keys(d)) ==
-          [MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(2)]
+    @test collect(keys(d)) == [MOI.VariableIndex(1), MOI.VariableIndex(2)]
     @test collect(values(d)) == ["first", "second"]
     delete!(d, key)
     key3 = CleverDicts.add_item(d, "third")
-    @test collect(keys(d)) ==
-          [MathOptInterface.VariableIndex(2), MathOptInterface.VariableIndex(3)]
+    @test collect(keys(d)) == [MOI.VariableIndex(2), MOI.VariableIndex(3)]
     @test collect(values(d)) == ["second", "third"]
     return
 end
 
 function test_iterate()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
+    d = CleverDicts.CleverDict{MOI.VariableIndex,String}()
     key = CleverDicts.add_item(d, "first")
     key2 = CleverDicts.add_item(d, "second")
-    my_keys = MathOptInterface.VariableIndex[]
+    my_keys = MOI.VariableIndex[]
     my_values = String[]
     for (k, v) in d
         push!(my_keys, k)
         push!(my_values, v)
     end
-    @test my_keys ==
-          [MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(2)]
+    @test my_keys == [MOI.VariableIndex(1), MOI.VariableIndex(2)]
     @test my_values == ["first", "second"]
     delete!(d, key)
     key3 = CleverDicts.add_item(d, "third")
-    my_keys = MathOptInterface.VariableIndex[]
+    my_keys = MOI.VariableIndex[]
     my_values = String[]
     for (k, v) in d
         push!(my_keys, k)
         push!(my_values, v)
     end
-    @test my_keys ==
-          [MathOptInterface.VariableIndex(2), MathOptInterface.VariableIndex(3)]
+    @test my_keys == [MOI.VariableIndex(2), MOI.VariableIndex(3)]
     @test my_values == ["second", "third"]
     return
 end
 
 function test_iterate_2()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
+    d = CleverDicts.CleverDict{MOI.VariableIndex,String}()
     key = CleverDicts.add_item(d, "first")
     key2 = CleverDicts.add_item(d, "second")
-    my_keys = MathOptInterface.VariableIndex[]
+    my_keys = MOI.VariableIndex[]
     my_values = String[]
     for (k, v) in d
         push!(my_keys, k)
         push!(my_values, v)
     end
-    @test my_keys ==
-          [MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(2)]
+    @test my_keys == [MOI.VariableIndex(1), MOI.VariableIndex(2)]
     @test my_values == ["first", "second"]
     delete!(d, key)
     @test d[CleverDicts.LinearIndex(1)] == "second"
     key3 = CleverDicts.add_item(d, "third")
-    my_keys = MathOptInterface.VariableIndex[]
+    my_keys = MOI.VariableIndex[]
     my_values = String[]
     for (k, v) in d
         push!(my_keys, k)
         push!(my_values, v)
     end
-    @test my_keys ==
-          [MathOptInterface.VariableIndex(2), MathOptInterface.VariableIndex(3)]
+    @test my_keys == [MOI.VariableIndex(2), MOI.VariableIndex(3)]
     @test my_values == ["second", "third"]
     return
 end
 
 function test_iterate_3()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
+    d = CleverDicts.CleverDict{MOI.VariableIndex,String}()
     y = 0
     for (k, v) in d
         y += 1
@@ -201,7 +195,7 @@ function test_iterate_3()
 end
 
 function test_haskey()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
+    d = CleverDicts.CleverDict{MOI.VariableIndex,String}()
     @test !haskey(d, 1)
     k = CleverDicts.add_item(d, "a")
     @test haskey(d, k)
@@ -214,7 +208,7 @@ function test_haskey()
 end
 
 function test_isempty()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
+    d = CleverDicts.CleverDict{MOI.VariableIndex,String}()
     @test isempty(d) == true
     k = CleverDicts.add_item(d, "a")
     @test isempty(d) == false
@@ -226,9 +220,9 @@ function test_isempty()
 end
 
 function test_delete!()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
+    d = CleverDicts.CleverDict{MOI.VariableIndex,String}()
     @test length(d) == 0
-    @test delete!(d, MathOptInterface.VariableIndex(0)) == d
+    @test delete!(d, MOI.VariableIndex(0)) == d
     k1 = CleverDicts.add_item(d, "a")
     k2 = CleverDicts.add_item(d, "b")
     d[CleverDicts.LinearIndex(2)] == "b"
@@ -242,20 +236,20 @@ function test_delete!()
 end
 
 function test_negative_index()
-    d = CleverDicts.CleverDict{MathOptInterface.VariableIndex,String}()
-    d[MathOptInterface.VariableIndex(-3)] = "a"
-    @test d[MathOptInterface.VariableIndex(-3)] == "a"
+    d = CleverDicts.CleverDict{MOI.VariableIndex,String}()
+    d[MOI.VariableIndex(-3)] = "a"
+    @test d[MOI.VariableIndex(-3)] == "a"
     @test_throws ErrorException CleverDicts.add_item(d, "b")
-    d[MathOptInterface.VariableIndex(0)] = "b"
-    @test d[MathOptInterface.VariableIndex(-3)] == "a"
-    @test d[MathOptInterface.VariableIndex(0)] == "b"
+    d[MOI.VariableIndex(0)] = "b"
+    @test d[MOI.VariableIndex(-3)] == "a"
+    @test d[MOI.VariableIndex(0)] == "b"
     @test_throws ErrorException CleverDicts.add_item(d, "c")
     return
 end
 
 function test_convert()
-    vals = [MathOptInterface.VariableIndex(-i) for i in 1:10]
-    d = Dict(MathOptInterface.VariableIndex(i) => vals[i] for i in 1:10)
+    vals = [MOI.VariableIndex(-i) for i in 1:10]
+    d = Dict(MOI.VariableIndex(i) => vals[i] for i in 1:10)
     T = CleverDicts.CleverDict{
         MOI.VariableIndex,
         MOI.VariableIndex,

--- a/test/Utilities/CleverDicts.jl
+++ b/test/Utilities/CleverDicts.jl
@@ -9,8 +9,7 @@ module TestCleverDicts
 using Test
 
 import MathOptInterface as MOI
-
-const CleverDicts = MOI.Utilities.CleverDicts
+import MathOptInterface.Utilities.CleverDicts
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/DoubleDicts.jl
+++ b/test/Utilities/DoubleDicts.jl
@@ -9,8 +9,7 @@ module TestDoubleDicts
 using Test
 
 import MathOptInterface as MOI
-
-const DoubleDicts = MOI.Utilities.DoubleDicts
+import MathOptInterface.Utilities.DoubleDicts
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/DoubleDicts.jl
+++ b/test/Utilities/DoubleDicts.jl
@@ -8,10 +8,9 @@ module TestDoubleDicts
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
-const DoubleDicts = MathOptInterface.Utilities.DoubleDicts
+const DoubleDicts = MOI.Utilities.DoubleDicts
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -8,9 +8,7 @@ module TestCachingOptimizer
 
 using Test
 
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 
 function runtests()

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -9,7 +9,7 @@ module TestCachingOptimizer
 using Test
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/constraints.jl
+++ b/test/Utilities/constraints.jl
@@ -7,8 +7,7 @@
 module TestConstraints
 
 using Test
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -9,7 +9,7 @@ module TestCopy
 using Test
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 
 const DoubleDicts = MathOptInterface.Utilities.DoubleDicts
 

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -10,8 +10,7 @@ using Test
 
 import MathOptInterface as MOI
 import MathOptInterface.Utilities as MOIU
-
-const DoubleDicts = MathOptInterface.Utilities.DoubleDicts
+import MathOptInterface.Utilities.DoubleDicts
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -8,8 +8,7 @@ module TestCopy
 
 using Test
 
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 
 const DoubleDicts = MathOptInterface.Utilities.DoubleDicts

--- a/test/Utilities/distance_to_set.jl
+++ b/test/Utilities/distance_to_set.jl
@@ -9,9 +9,7 @@ module TestFeasibilityChecker
 using Test
 
 import LinearAlgebra
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -6,13 +6,10 @@
 
 module TestFunctions
 
-using MathOptInterface: VectorOfVariables
 using Test
-using MathOptInterface
-import MutableArithmetics
 
-const MOI = MathOptInterface
-const MA = MutableArithmetics
+import MathOptInterface as MOI
+import MutableArithmetics as MA
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/lazy_iterators.jl
+++ b/test/Utilities/lazy_iterators.jl
@@ -6,10 +6,9 @@
 
 module TestLazyIterators
 
-using MathOptInterface
 using Test
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -8,10 +8,8 @@ module TestMatrixOfConstraints
 
 using Test
 
-import MathOptInterface
+import MathOptInterface as MOI
 import SparseArrays
-
-const MOI = MathOptInterface
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -7,8 +7,7 @@
 module TestMockOptimizer
 
 using Test
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 
 function runtests()

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -8,7 +8,7 @@ module TestMockOptimizer
 
 using Test
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/model.jl
+++ b/test/Utilities/model.jl
@@ -8,9 +8,7 @@ module TestModel
 
 using Test
 
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)
@@ -35,33 +33,33 @@ defined in a testset. If it runs without error, then we're okay.
 """
 module TestExternalModel
 
-using MathOptInterface
+import MathOptInterface as MOI
 
-struct NewSet <: MathOptInterface.AbstractScalarSet end
+struct NewSet <: MOI.AbstractScalarSet end
 
-struct NewFunction <: MathOptInterface.AbstractScalarFunction end
+struct NewFunction <: MOI.AbstractScalarFunction end
 
-MathOptInterface.Utilities.canonicalize!(f::NewFunction) = f
+MOI.Utilities.canonicalize!(f::NewFunction) = f
 
 Base.copy(::NewFunction) = NewFunction()
 
 Base.copy(::NewSet) = NewSet()
 
-MathOptInterface.Utilities.@model(
+MOI.Utilities.@model(
     ExternalModel,
-    (MathOptInterface.ZeroOne, NewSet),
+    (MOI.ZeroOne, NewSet),
     (),
     (),
     (),
     (NewFunction,),
-    (MathOptInterface.ScalarAffineFunction,),
+    (MOI.ScalarAffineFunction,),
     (),
     (),
 )
 
-MathOptInterface.Utilities.@model(
+MOI.Utilities.@model(
     ExternalOptimizer,
-    (MathOptInterface.ZeroOne, NewSet),
+    (MOI.ZeroOne, NewSet),
     (),
     (),
     (),

--- a/test/Utilities/mutable_arithmetics.jl
+++ b/test/Utilities/mutable_arithmetics.jl
@@ -8,11 +8,8 @@ module TestMutableArithmetics
 
 using Test
 
-import MutableArithmetics
-const MA = MutableArithmetics
-
-using MathOptInterface
-const MOI = MathOptInterface
+import MutableArithmetics as MA
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/objective_container.jl
+++ b/test/Utilities/objective_container.jl
@@ -8,9 +8,7 @@ module TestObjectiveContainer
 
 using Test
 
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -6,10 +6,9 @@
 
 module TestParser
 
-using MathOptInterface
 using Test
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 
 function runtests()

--- a/test/Utilities/parser.jl
+++ b/test/Utilities/parser.jl
@@ -9,7 +9,7 @@ module TestParser
 using Test
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/penalty_relaxation.jl
+++ b/test/Utilities/penalty_relaxation.jl
@@ -7,9 +7,7 @@
 module TestPenaltyRelaxation
 
 using Test
-using MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/print.jl
+++ b/test/Utilities/print.jl
@@ -9,7 +9,7 @@ module TestPrint
 using Test
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/print.jl
+++ b/test/Utilities/print.jl
@@ -8,8 +8,7 @@ module TestPrint
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 
 function runtests()

--- a/test/Utilities/product_of_sets.jl
+++ b/test/Utilities/product_of_sets.jl
@@ -8,8 +8,7 @@ module TestProductOfSets
 
 using Test
 
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/sets.jl
+++ b/test/Utilities/sets.jl
@@ -8,9 +8,7 @@ module TestSets
 
 using SparseArrays
 using Test
-using MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 
 function runtests()

--- a/test/Utilities/sets.jl
+++ b/test/Utilities/sets.jl
@@ -9,7 +9,7 @@ module TestSets
 using SparseArrays
 using Test
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/sparse_matrix.jl
+++ b/test/Utilities/sparse_matrix.jl
@@ -9,8 +9,7 @@ module TestSparseMatrix
 import SparseArrays
 using Test
 
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/universalfallback.jl
+++ b/test/Utilities/universalfallback.jl
@@ -8,9 +8,7 @@ module TestUniversalFallback
 
 using Test
 
-import MathOptInterface
-
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/variable_container.jl
+++ b/test/Utilities/variable_container.jl
@@ -7,8 +7,7 @@
 module TestVariableContainer
 
 using Test
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/variables.jl
+++ b/test/Utilities/variables.jl
@@ -9,7 +9,7 @@ module TestVariables
 using Test
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/Utilities/variables.jl
+++ b/test/Utilities/variables.jl
@@ -6,10 +6,9 @@
 
 module TestVariables
 
-using MathOptInterface
 using Test
 
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 
 function runtests()

--- a/test/attributes.jl
+++ b/test/attributes.jl
@@ -7,8 +7,7 @@
 module TestAttributes
 
 using Test
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 include("dummy.jl")
 

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -8,8 +8,7 @@ module TestConstraints
 
 using Test
 
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 function runtests()
     for name in names(@__MODULE__; all = true)

--- a/test/dummy.jl
+++ b/test/dummy.jl
@@ -5,7 +5,7 @@
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
 import MathOptInterface as MOI
-const MOIU = MOI.Utilities
+import MathOptInterface.Utilities as MOIU
 
 abstract type AbstractDummyModel <: MOI.ModelLike end
 

--- a/test/dummy.jl
+++ b/test/dummy.jl
@@ -4,8 +4,7 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 const MOIU = MOI.Utilities
 
 abstract type AbstractDummyModel <: MOI.ModelLike end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -7,8 +7,7 @@
 module TestErrors
 
 using Test
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 include("dummy.jl")
 
@@ -139,8 +138,8 @@ function test_errors_DeleteNotAllowed()
         MOI.delete(model, ci)
     catch err
         @test sprint(showerror, err) ==
-              "$(MathOptInterface.DeleteNotAllowed{MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex,MathOptInterface.EqualTo{Float64}}}):" *
-              " Deleting the index $(MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex,MathOptInterface.EqualTo{Float64}}(1))" *
+              "$(MOI.DeleteNotAllowed{MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{Float64}}}):" *
+              " Deleting the index $(MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{Float64}}(1))" *
               " cannot be performed. You may want to use a `CachingOptimizer`" *
               " in `AUTOMATIC` mode or you may need to call `reset_optimizer`" *
               " before doing this operation if the `CachingOptimizer` is in" *
@@ -234,8 +233,8 @@ function test_errors_ModifyNotAllowed_constraint()
     err = MOI.ModifyConstraintNotAllowed(ci, change)
     @test_throws err MOI.modify(model, ci, change)
     @test sprint(showerror, err) ==
-          "$(MathOptInterface.ModifyConstraintNotAllowed{MathOptInterface.VariableIndex,MathOptInterface.EqualTo{Float64},MathOptInterface.ScalarConstantChange{Float64}}):" *
-          " Modifying the constraints $(MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex,MathOptInterface.EqualTo{Float64}}(1))" *
+          "$(MOI.ModifyConstraintNotAllowed{MOI.VariableIndex,MOI.EqualTo{Float64},MOI.ScalarConstantChange{Float64}}):" *
+          " Modifying the constraints $(MOI.ConstraintIndex{MOI.VariableIndex,MOI.EqualTo{Float64}}(1))" *
           " with MathOptInterface.ScalarConstantChange{Float64}(1.0) cannot" *
           " be performed. You may want to use a `CachingOptimizer` in" *
           " `AUTOMATIC` mode or you may need to call `reset_optimizer`" *
@@ -250,8 +249,8 @@ function test_errors_ModifyNotAllowed_objective()
     err = MOI.ModifyObjectiveNotAllowed(change)
     @test_throws err MOI.modify(model, attr, change)
     @test sprint(showerror, err) ==
-          "$(MathOptInterface.ModifyObjectiveNotAllowed{MathOptInterface.ScalarConstantChange{Float64}}):" *
-          " Modifying the objective function with $(MathOptInterface.ScalarConstantChange{Float64}(1.0))" *
+          "$(MOI.ModifyObjectiveNotAllowed{MOI.ScalarConstantChange{Float64}}):" *
+          " Modifying the objective function with $(MOI.ScalarConstantChange{Float64}(1.0))" *
           " cannot be performed. You may want to use a `CachingOptimizer`" *
           " in `AUTOMATIC` mode or you may need to call `reset_optimizer`" *
           " before doing this operation if the `CachingOptimizer` is in" *

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -7,8 +7,7 @@
 module TestFunctions
 
 using Test
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 """
     test_isbits()

--- a/test/hygiene.jl
+++ b/test/hygiene.jl
@@ -8,14 +8,13 @@ module Hygiene
 
 using Test
 
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 # Dict is used in the @model macro but setting Dict in the outer scope
 # should not affect it
 Dict = nothing
 
-MathOptInterface.Utilities.@model(
+MOI.Utilities.@model(
     LPModel,                      # Name of model
     (),                                                         # untyped scalar sets
     (MOI.EqualTo, MOI.GreaterThan, MOI.LessThan, MOI.Interval), #   typed scalar sets
@@ -29,7 +28,7 @@ MathOptInterface.Utilities.@model(
 
 model = LPModel{Float64}()
 
-@test model isa MathOptInterface.ModelLike
-@test model isa MathOptInterface.Utilities.AbstractModel{Float64}
+@test model isa MOI.ModelLike
+@test model isa MOI.Utilities.AbstractModel{Float64}
 
 end

--- a/test/instantiate.jl
+++ b/test/instantiate.jl
@@ -7,8 +7,7 @@
 module TestInstantiate
 
 using Test
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 struct DummyOptimizer <: MOI.AbstractOptimizer end
 MOI.is_empty(::DummyOptimizer) = true

--- a/test/issue980.jl
+++ b/test/issue980.jl
@@ -6,8 +6,7 @@
 
 module Issue980
 
-import MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 abstract type StaticArray end
 (::Type{SA})(x...) where {SA<:StaticArray} = SA(x)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -7,8 +7,7 @@
 module TestSets
 
 using Test
-using MathOptInterface
-const MOI = MathOptInterface
+import MathOptInterface as MOI
 
 include("dummy.jl")
 


### PR DESCRIPTION
After using `import MultiObjectiveAlgorithms as MOA`, I realized that we've never exploited this Julia syntax in MOI (because most of the code pre-dates Julia introducing it).

I think we can and should be recommend that people use `import MathOptInterface as MOI` instead of `import MathOptInterface; const MOI = MathOptInterface`. The latter leads to a mixture of `MathOptInterface.` and `MOI.` in the code, gets around the `using` / `import` confusion, and `MOI` doesn't export anything.

The diff touches a lot of files, but the changes are trivial.