### PR TITLE
[Utilities] Fix for empty product of sets

### DIFF
--- a/src/Utilities/product_of_sets.jl
+++ b/src/Utilities/product_of_sets.jl
@@ -206,7 +206,12 @@ end
 
 function MOI.dimension(sets::OrderedProductOfSets)
     @assert sets.final_touch
-    return sets.num_rows[end]
+    if isempty(sets.num_rows)
+        # There is not set type
+        return 0
+    else
+        return sets.num_rows[end]
+    end
 end
 
 function rows(

--- a/src/Utilities/product_of_sets.jl
+++ b/src/Utilities/product_of_sets.jl
@@ -207,7 +207,7 @@ end
 function MOI.dimension(sets::OrderedProductOfSets)
     @assert sets.final_touch
     if isempty(sets.num_rows)
-        # There is not set type
+        # There is no set type
         return 0
     else
         return sets.num_rows[end]

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -621,6 +621,7 @@ function test_empty_product_of_sets(T = Int)
         model.constraints.coefficients,
     )
     @test size(A) == (0, 1)
+    return
 end
 
 end

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -55,7 +55,7 @@ MOI.Utilities.@product_of_sets(
     MOI.SecondOrderCone,
 )
 
-function _new_VectorSets(V=VectorSets)
+function _new_VectorSets(V = VectorSets)
     return MOI.Utilities.GenericOptimizer{
         Int,
         MOI.Utilities.ObjectiveContainer{Int},
@@ -612,7 +612,7 @@ end
 
 MOI.Utilities.@product_of_sets(EmptyProductOfSets)
 
-function test_empty_product_of_sets(T=Int)
+function test_empty_product_of_sets(T = Int)
     model = _new_VectorSets(EmptyProductOfSets)
     x = MOI.add_variable(model)
     MOI.Utilities.final_touch(model, nothing)

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -55,7 +55,7 @@ MOI.Utilities.@product_of_sets(
     MOI.SecondOrderCone,
 )
 
-function _new_VectorSets()
+function _new_VectorSets(V=VectorSets)
     return MOI.Utilities.GenericOptimizer{
         Int,
         MOI.Utilities.ObjectiveContainer{Int},
@@ -68,7 +68,7 @@ function _new_VectorSets()
                 MOI.Utilities.OneBasedIndexing,
             },
             Vector{Int},
-            VectorSets{Int},
+            V{Int},
         },
     }()
 end
@@ -608,6 +608,19 @@ function test_set_with_dimension()
         @test_throws AssertionError MOI.Utilities.set_with_dimension(S, 4)
     end
     return
+end
+
+MOI.Utilities.@product_of_sets(EmptyProductOfSets)
+
+function test_empty_product_of_sets(T=Int)
+    model = _new_VectorSets(EmptyProductOfSets)
+    x = MOI.add_variable(model)
+    MOI.Utilities.final_touch(model, nothing)
+    A = convert(
+        SparseArrays.SparseMatrixCSC{T,Int},
+        model.constraints.coefficients,
+    )
+    @test size(A) == (0, 1)
 end
 
 end


### PR DESCRIPTION
I got this error when working on https://github.com/jump-dev/DiffOpt.jl/pull/231. For a program with a quadratic objective and no constraints except variable bounds, the DiffOpt's product of sets don't record any set type hence the product of sets has no set type.