### PR TITLE
Remove test_basic_F_Parameter because it does not support generic constraints

### DIFF
--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -72,7 +72,6 @@ _set(::Any, ::Type{S}) where {S} = _set(S)
 _set(::Type{T}, ::Type{MOI.LessThan}) where {T} = MOI.LessThan(one(T))
 _set(::Type{T}, ::Type{MOI.GreaterThan}) where {T} = MOI.GreaterThan(one(T))
 _set(::Type{T}, ::Type{MOI.EqualTo}) where {T} = MOI.EqualTo(one(T))
-_set(::Type{T}, ::Type{MOI.Parameter}) where {T} = MOI.Parameter(one(T))
 _set(::Type{T}, ::Type{MOI.Interval}) where {T} = MOI.Interval(zero(T), one(T))
 _set(::Type{MOI.ZeroOne}) = MOI.ZeroOne()
 _set(::Type{MOI.Integer}) = MOI.Integer()
@@ -265,7 +264,6 @@ for s in [
     :GreaterThan,
     :LessThan,
     :EqualTo,
-    :Parameter,
     :Interval,
     :ZeroOne,
     :Semicontinuous,


### PR DESCRIPTION
x-ref #2102

SolverTests are still failing because the Parameter set has some non-standard interpretations (it doesn't make sense to have `ScalarAffineFunction-in-Parameter` constraints).