### PR TITLE
[docs] Add Google style guide for Vale and fix errors and warnings

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -1,10 +1,10 @@
 StylesPath = styles
-MinAlertLevel = suggestion
+MinAlertLevel = warning
 
 Vocab = JuMP-Vocab
 
 [*.md]
-BasedOnStyles = Vale
+BasedOnStyles = Vale, Google
 
 # Skip \\token and \token LaTeX commands
 TokenIgnores = \\\\[a-z]+, \\[a-z]+, [a-zA-Z]+_[_a-zA-Z]+

--- a/docs/src/background/infeasibility_certificates.md
+++ b/docs/src/background/infeasibility_certificates.md
@@ -70,7 +70,7 @@ A problem is unbounded if and only if:
 
 A feasible primal solution—if one exists—can be obtained by setting
 [`ObjectiveSense`](@ref) to `FEASIBILITY_SENSE` before optimizing. Therefore,
-most solvers terminate after they prove the dual is infeasible via a certificate
+most solvers stop after they prove the dual is infeasible via a certificate
 of dual infeasibility, but _before_ they have found a feasible primal solution.
 This is also the reason that MathOptInterface defines the `DUAL_INFEASIBLE`
 status instead of `UNBOUNDED`.
@@ -138,9 +138,9 @@ If the solver has found a certificate of primal infeasibility:
 
 ### Infeasibility certificates of variable bounds
 
-Many linear solvers (e.g., Gurobi) do not provide explicit access to the primal
-infeasibility certificate of a variable bound. However, given a set of linear
-constraints:
+Many linear solvers (for example, Gurobi) do not provide explicit access to the
+primal infeasibility certificate of a variable bound. However, given a set of
+linear constraints:
 ```math
 \begin{align}
 l_A \le A x \le u_A \\

--- a/docs/src/background/motivation.md
+++ b/docs/src/background/motivation.md
@@ -12,17 +12,17 @@ To address a number of limitations of MathProgBase, MOI is designed to:
 - Be simple and extensible
   * unifying linear, quadratic, and conic optimization,
   * seamlessly facilitating extensions to essentially arbitrary constraints and
-    functions (e.g., indicator constraints, complementarity constraints, and
-    piecewise-linear functions)
+    functions (for example, indicator constraints, complementarity constraints,
+    and piecewise-linear functions)
 - Be fast
    * by allowing access to a solver's in-memory representation of a problem
      without writing intermediate files (when possible)
-   * by using multiple dispatch and avoiding requiring containers of non-concrete
-     types
-- Allow a solver to return multiple results (e.g., a pool of solutions)
-- Allow a solver to return extra arbitrary information via attributes (e.g.,
-  variable- and constraint-wise membership in an irreducible inconsistent subset
-  for infeasibility analysis)
+   * by using multiple dispatch and avoiding requiring containers of
+     non-concrete types
+- Allow a solver to return multiple results (for example, a pool of solutions)
+- Allow a solver to return extra arbitrary information via attributes (for
+  example, variable- and constraint-wise membership in an irreducible
+  inconsistent subset for infeasibility analysis)
 - Provide a greatly expanded set of status codes explaining what happened during
   the optimization procedure
 - Enable a solver to more precisely specify which problem classes it supports

--- a/docs/src/background/naming_conventions.md
+++ b/docs/src/background/naming_conventions.md
@@ -17,16 +17,16 @@ Sets encode the structure of constraints. Their names should follow the
 following conventions:
 
 * Abstract types in the set hierarchy should begin with `Abstract` and end in
-  `Set`, e.g., [`AbstractScalarSet`](@ref), [`AbstractVectorSet`](@ref).
-* Vector-valued conic sets should end with `Cone`, e.g.,
+  `Set`, for example, [`AbstractScalarSet`](@ref), [`AbstractVectorSet`](@ref).
+* Vector-valued conic sets should end with `Cone`, for example,
   [`NormInfinityCone`](@ref), [`SecondOrderCone`](@ref).
 * Vector-valued Cartesian products should be plural and not end in `Cone`,
-  e.g., [`Nonnegatives`](@ref), not `NonnegativeCone`.
+  for example, [`Nonnegatives`](@ref), not `NonnegativeCone`.
 * Matrix-valued conic sets should provide two representations: `ConeSquare` and
-  `ConeTriangle`, e.g., [`RootDetConeTriangle`](@ref) and
+  `ConeTriangle`, for example, [`RootDetConeTriangle`](@ref) and
   [`RootDetConeSquare`](@ref). See [Matrix cones](@ref) for more details.
-* Scalar sets should be singular, not plural, e.g., [`Integer`](@ref), not
-  `Integers`.
+* Scalar sets should be singular, not plural, for example, [`Integer`](@ref),
+  not `Integers`.
 * As much as possible, the names should follow established conventions in the
   domain where this set is used: for instance, convex sets should have names
   close to those of [CVX](http://web.cvxr.com/cvx/doc/), and

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -392,7 +392,7 @@ removed, similar to how Julia 1.0 was Julia 0.7 with deprecations removed.
 ### Troubleshooting problems when updating
 
 If you experience problems when updating, you are likely using previously
-deprecated functionality. (By default, Julia does not warn when you use
+deprecated features. (By default, Julia does not warn when you use
 deprecated features.)
 
 To find the deprecated features you are using, start Julia with `--depwarn=yes`:
@@ -1091,7 +1091,7 @@ This release contains backports from the ongoing development of the v0.10 releas
 ## v0.8.0 (December 18, 2018)
 
 - Rename all enum values to follow the JuMP naming guidelines for constants,
-  e.g., `Optimal` becomes `OPTIMAL`, and `DualInfeasible` becomes
+  for example, `Optimal` becomes `OPTIMAL`, and `DualInfeasible` becomes
   `DUAL_INFEASIBLE`.
 - Rename CachingOptimizer methods for style compliance.
 - Add an `MOI.TerminationStatusCode` called `ALMOST_DUAL_INFEASIBLE`.
@@ -1180,10 +1180,10 @@ This release contains backports from the ongoing development of the v0.10 releas
 - Add test for empty rows in vector linear constraint.
 - Rework errors: `CannotError` has been renamed `NotAllowedError` and
   the distinction between `UnsupportedError` and `NotAllowedError` is now
-  about whether the element is not supported (i.e. it cannot be copied a
+  about whether the element is not supported (that is, it cannot be copied a
   model containing this element) or the operation is not allowed (either
   because it is not implemented, because it cannot be performed in the current
-  state of the model, because it cannot be performed for a specific index, ...)
+  state of the model, or because it cannot be performed for a specific index)
 - `canget` is removed. `NoSolution` is added as a result status to indicate
   that the solver does not have either a primal or dual solution available
   (See #479).

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1180,7 +1180,7 @@ This release contains backports from the ongoing development of the v0.10 releas
 - Add test for empty rows in vector linear constraint.
 - Rework errors: `CannotError` has been renamed `NotAllowedError` and
   the distinction between `UnsupportedError` and `NotAllowedError` is now
-  about whether the element is not supported (that is, it cannot be copied a
+  about whether the element is not supported (for example, it cannot be copied a
   model containing this element) or the operation is not allowed (either
   because it is not implemented, because it cannot be performed in the current
   state of the model, or because it cannot be performed for a specific index)

--- a/docs/src/manual/constraints.md
+++ b/docs/src/manual/constraints.md
@@ -112,9 +112,9 @@ nonpositive) real numbers.
 | ``Ax + b = 0``                | `VectorAffineFunction`       | `Zeros`        |
 
 By convention, solvers are not expected to support nonzero constant terms in the
-[`ScalarAffineFunction`](@ref)s the first four rows above, because they are
-redundant with the parameters of the sets. For example, encode ``2x + 1 \le 2``
-as ``2x \le 1``.
+[`ScalarAffineFunction`](@ref)s the first four rows of the preceding table
+because they are redundant with the parameters of the sets. For example, encode
+``2x + 1 \le 2`` as ``2x \le 1``.
 
 Constraints with [`VariableIndex`](@ref) in [`LessThan`](@ref), [`GreaterThan`](@ref),
 [`EqualTo`](@ref), or [`Interval`](@ref) sets have a natural interpretation as
@@ -195,7 +195,7 @@ Variable bounds are handled in a similar fashion:
  - `@variable(m, x >= 1)` becomes `VariableIndex`-in-`GreaterThan`
 
 One notable difference is that a variable with an upper and lower bound is
-translated into two constraints, rather than an interval. i.e.:
+translated into two constraints, rather than an interval, that is:
 
  - `@variable(m, 0 <= x <= 1)` becomes `VariableIndex`-in-`LessThan` *and*
     `VariableIndex`-in-`GreaterThan`.

--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -9,16 +9,16 @@ DocTestFilters = [r"MathOptInterface|MOI"]
 # Models
 
 The most significant part of MOI is the definition of the **model API** that is
-used to specify an instance of an optimization problem (e.g., by adding
+used to specify an instance of an optimization problem (for example, by adding
 variables and constraints). Objects that implement the model API must inherit
 from the [`ModelLike`](@ref) abstract type.
 
 Notably missing from the model API is the method to solve an optimization
-problem. `ModelLike` objects may store an instance (e.g., in memory or backed by
-a file format) without being linked to a particular solver. In addition to the
-model API, MOI defines [`AbstractOptimizer`](@ref) and provides methods to solve
-the model and interact with solutions. See the [Solutions](@ref manual_solutions)
-section for more details.
+problem. `ModelLike` objects may store an instance (for example, in memory or
+backed by a file format) without being linked to a particular solver. In
+addition to the model API, MOI defines [`AbstractOptimizer`](@ref) and provides
+methods to solve the model and interact with solutions. See the
+[Solutions](@ref manual_solutions) section for more details.
 
 !!! info
     Throughout the rest of the manual, `model` is used as a generic `ModelLike`,

--- a/docs/src/manual/modification.md
+++ b/docs/src/manual/modification.md
@@ -57,7 +57,7 @@ constraint (for example, from [`LessThan`](@ref) to [`GreaterThan`](@ref)). For
 these cases, MathOptInterface provides the [`transform`](@ref) method.
 
 The [`transform`](@ref) function returns a new constraint index, and the old
-constraint index (i.e., `c`) is no longer valid.
+constraint index (that is, `c`) is no longer valid.
 
 ```jldoctest transform_set; setup=:(model = MOI.Utilities.Model{Float64}(); x = MOI.add_variable(model))
 julia> c = MOI.add_constraint(
@@ -129,10 +129,8 @@ julia> MOI.get(model, MOI.ConstraintFunction(), c) ≈ new_f
 true
 ```
 
-!!! tip
-    [`ScalarConstantChange`](@ref) can also be used to modify the objective
-    function by passing an instance of [`ObjectiveFunction`](@ref) instead of
-    the constraint index `c` as we saw above.
+[`ScalarConstantChange`](@ref) can also be used to modify the objective
+function by passing an instance of [`ObjectiveFunction`](@ref):
 
 ```jldoctest scalar_constant_change
 julia> MOI.set(
@@ -207,10 +205,8 @@ julia> MOI.get(model, MOI.ConstraintFunction(), c) ≈ new_f
 true
 ```
 
-!!! tip
-    [`ScalarCoefficientChange`](@ref) can also be used to modify the objective
-    function by passing an instance of [`ObjectiveFunction`](@ref) instead of
-    the constraint index `c` as we saw above.
+[`ScalarCoefficientChange`](@ref) can also be used to modify the objective
+function by passing an instance of [`ObjectiveFunction`](@ref).
 
 ## Modify affine coefficients in a vector function
 

--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -19,7 +19,7 @@ MOI.optimize!(optimizer)
 
 ## Why did the solver stop?
 
-The optimization procedure may terminate for a number of reasons. The
+The optimization procedure may stop for a number of reasons. The
 [`TerminationStatus`](@ref) attribute of the optimizer returns a
 [`TerminationStatusCode`](@ref) object which explains why the solver stopped.
 

--- a/docs/src/manual/standard_form.md
+++ b/docs/src/manual/standard_form.md
@@ -34,8 +34,8 @@ The function types implemented in MathOptInterface.jl are:
 
 | Function         | Description |
 | :--------------- | :---------- |
-| [`VariableIndex`](@ref) | ``x_j``, i.e., projection onto a single coordinate defined by a variable index ``j``. |
-| [`VectorOfVariables`](@ref) | The projection onto multiple coordinates (i.e., extracting a sub-vector). |
+| [`VariableIndex`](@ref) | ``x_j``, the projection onto a single coordinate defined by a variable index ``j``. |
+| [`VectorOfVariables`](@ref) | The projection onto multiple coordinates (that is, extracting a sub-vector). |
 | [`ScalarAffineFunction`](@ref) | ``a^T x + b``, where ``a`` is a vector and ``b`` scalar. |
 | [`VectorAffineFunction`](@ref) | ``A x + b``, where ``A`` is a matrix and ``b`` is a vector. |
 | [`ScalarQuadraticFunction`](@ref) | ``\frac{1}{2} x^T Q x + a^T x + b``, where ``Q`` is a symmetric matrix, ``a`` is a vector, and ``b`` is a constant. |

--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -35,7 +35,7 @@ julia> y = MOI.add_variables(model, 2)
 
 !!! warning
     The integer does not necessarily correspond to the column inside an
-    optimizer!
+    optimizer.
 
 ## Delete a variable
 

--- a/docs/src/reference/errors.md
+++ b/docs/src/reference/errors.md
@@ -49,7 +49,7 @@ OptimizeInProgress
 ```
 
 Trying to submit the wrong type of [`AbstractSubmittable`](@ref) inside an
-[`AbstractCallback`](@ref) (e.g., a [`UserCut`](@ref) inside a
+[`AbstractCallback`](@ref) (for example, a [`UserCut`](@ref) inside a
 [`LazyConstraintCallback`](@ref)) will throw:
 ```@docs
 InvalidCallbackUsage

--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -115,8 +115,7 @@ Table
 
 ## Matrix sets
 
-Matrix sets are vectorized in order to be subtypes of
-[`AbstractVectorSet`](@ref).
+Matrix sets are vectorized to be subtypes of [`AbstractVectorSet`](@ref).
 
 For sets of symmetric matrices, storing both the
 `(i, j)` and `(j, i)` elements is redundant. Use the

--- a/docs/src/submodules/Benchmarks/overview.md
+++ b/docs/src/submodules/Benchmarks/overview.md
@@ -9,10 +9,10 @@ DocTestFilters = [r"MathOptInterface|MOI"]
 # The `Benchmarks` submodule
 
 To aid the development of efficient solver wrappers, MathOptInterface provides
-benchmarking functionality. Benchmarking a wrapper follows a two-step process.
+benchmarking capability. Benchmarking a wrapper follows a two-step process.
 
-First, prior to making changes, run and save the benchmark results on a given
-benchmark suite as follows:
+First, prior to making changes, create a baseline for the benchmark results on a
+given benchmark suite as follows:
 
 ```julia
 using SolverPackage  # Replace with your choice of solver.

--- a/docs/src/submodules/Bridges/overview.md
+++ b/docs/src/submodules/Bridges/overview.md
@@ -113,9 +113,9 @@ with 0 objective bridges
 with inner model MOIU.Model{Float64}
 ```
 
-That's all you have to do! Use `optimizer` as normal, and bridging will happen
-lazily behind the scenes. By lazily, we mean that bridging will only happen if
-the constraint is not supported by the `inner_optimizer`.
+Now, use `optimizer` as normal, and bridging will happen lazily behind the
+scenes. By lazily, we mean that bridging will happen if and only if the
+constraint is not supported by the `inner_optimizer`.
 
 !!! info
     Most bridges are added by default in [`Bridges.full_bridge_optimizer`](@ref).

--- a/docs/src/submodules/FileFormats/overview.md
+++ b/docs/src/submodules/FileFormats/overview.md
@@ -8,7 +8,7 @@ DocTestFilters = [r"MathOptInterface|MOI"]
 
 # The FileFormats submodule
 
-The `FileFormats` module provides functionality for reading and writing MOI
+The `FileFormats` module provides functions for reading and writing MOI
 models using [`write_to_file`](@ref) and [`read_from_file`](@ref).
 
 ## Supported file types
@@ -169,8 +169,8 @@ filename.
 ## Unsupported constraints
 
 In some cases `src` may contain constraints that are not supported by the file
-format (e.g., the CBF format supports integer variables but not binary). If so,
-copy `src` to a bridged model using [`Bridges.full_bridge_optimizer`](@ref):
+format (for example, the CBF format supports integer variables but not binary).
+If so, copy `src` to a bridged model using [`Bridges.full_bridge_optimizer`](@ref):
 ```julia
 src = MOI.Utilities.Model{Float64}()
 x = MOI.add_variable(model)
@@ -182,8 +182,8 @@ MOI.write_to_file(dest, "my_model.cbf")
 ```
 !!! note
     Even after bridging, it may still not be possible to write the model to file
-    because of unsupported constraints (e.g., PSD variables in the LP file
-    format).
+    because of unsupported constraints (for example, PSD variables in the LP
+    file format).
 
 ## Read and write to `io`
 

--- a/docs/src/submodules/Nonlinear/overview.md
+++ b/docs/src/submodules/Nonlinear/overview.md
@@ -472,7 +472,7 @@ julia> @enum(
 ```
 In practice, there are node types other than the ones listed here.
 
-Third, we create two concretely-typed structs as follows:
+Third, we create two concretely typed structs as follows:
 ```jldoctest expr_graph
 julia> struct Node
            type::NodeType
@@ -563,8 +563,8 @@ notable differences from similar packages.
 ### Design goals
 
 The JuliaDiff organization maintains a [list of packages](https://juliadiff.org)
-for doing AD in Julia. At last count, there were at least ten packages–-not
-including `ReverseAD`-–for reverse-mode AD in Julia. `ReverseAD` exists because
+for doing AD in Julia. At last count, there were at least ten packages——not
+including `ReverseAD`——for reverse-mode AD in Julia. `ReverseAD` exists because
 it has a different set of design goals.
 
  * **Goal: handle scale and sparsity.**
@@ -596,7 +596,7 @@ development of which began in early 2014(!). This was well before the other
 AD packages started development. Because we had a well-tested, working AD in JuMP,
 there was less motivation to contribute to and explore other AD packages. The
 lack of historical interaction also meant that other packages were not optimized
-for the types of problems that JuMP is built for (i.e., large-scale sparse
+for the types of problems that JuMP is built for (that is, large-scale sparse
 problems). When we first created MathOptInterface, we kept the AD in JuMP to
 simplify the transition, and post-poned the development of a first-class
 nonlinear interface in MathOptInterface.

--- a/docs/src/submodules/Test/overview.md
+++ b/docs/src/submodules/Test/overview.md
@@ -84,8 +84,8 @@ function test_runtests()
         ],
         # This argument is useful to prevent tests from failing on future
         # releases of MOI that add new tests. Don't let this number get too far
-        # behind the current MOI release though! You should periodically check
-        # for new tests in order to fix bugs and implement new features.
+        # behind the current MOI release though. You should periodically check
+        # for new tests to fix bugs and implement new features.
         exclude_tests_after = v"0.10.5",
     )
     return
@@ -130,7 +130,7 @@ end
 
 ## How to debug a failing test
 
-When writing a solver, it's likely that you will initially fail many tests!
+When writing a solver, it's likely that you will initially fail many tests.
 Some failures will be bugs, but other failures you may choose to exclude.
 
 There are two ways to exclude tests:
@@ -196,8 +196,8 @@ As an example, ECOS errored calling [`optimize!`](@ref) twice in a row. (See
 [ECOS.jl PR #72](https://github.com/jump-dev/ECOS.jl/pull/72).) We could add a
 test to ECOS.jl, but that would only stop us from re-introducing the bug to
 ECOS.jl in the future, but it would not catch other solvers in the ecosystem
-with the same bug! Instead, if we add a test to `MOI.Test`, then all solvers
-will also check that they handle a double optimize call!
+with the same bug. Instead, if we add a test to `MOI.Test`, then all solvers
+will also check that they handle a double optimize call.
 
 For this test, we care about correctness, rather than performance. therefore, we
 don't expect solvers to efficiently decide that they have already solved the
@@ -236,8 +236,8 @@ function test_unit_optimize!_twice(
     config::Config{T},
 ) where {T}
     # Use the `@requires` macro to check conditions that the test function
-    # requires in order to run. Models failing this `@requires` check will
-    # silently skip the test.
+    # requires to run. Models failing this `@requires` check will silently skip
+    # the test.
     @requires MOI.supports_constraint(
         model,
         MOI.VariableIndex,
@@ -272,8 +272,8 @@ end
 ```
 
 !!! info
-    Make sure the function is agnostic to the number type `T`! Don't assume it
-    is a `Float64` capable solver!
+    Make sure the function is agnostic to the number type `T`; don't assume it
+    is a `Float64` capable solver.
 
 We also need to write a test for the test. Place this function immediately below
 the test you just wrote in the same file:

--- a/docs/src/submodules/Utilities/overview.md
+++ b/docs/src/submodules/Utilities/overview.md
@@ -8,8 +8,8 @@ DocTestFilters = [r"MathOptInterface|MOI"]
 
 # The Utilities submodule
 
-The Utilities submodule provides a variety of functionality for managing
-`MOI.ModelLike` objects.
+The Utilities submodule provides a variety of functions and datastructures for
+managing `MOI.ModelLike` objects.
 
 ## Utilities.Model
 
@@ -41,7 +41,7 @@ fallback for MOIU.Model{Float64}
 
 !!! warning
     Adding a UniversalFallback means that your `model` will now support all
-    constraints, even if the inner-model does not! This can lead to unexpected
+    constraints, even if the inner-model does not. This can lead to unexpected
     behavior.
 
 ## Utilities.@model
@@ -56,17 +56,18 @@ eight tuples specifying the types of constraints that are supported, and then a
 `true`) or `MOI.ModelLike` (if `false`).
 
 The eight tuples are in the following order:
- 1. Un-typed scalar sets, e.g., [`Integer`](@ref)
- 2. Typed scalar sets, e.g., [`LessThan`](@ref)
- 3. Un-typed vector sets, e.g., [`Nonnegatives`](@ref)
- 4. Typed vector sets, e.g., [`PowerCone`](@ref)
- 5. Un-typed scalar functions, e.g., [`VariableIndex`](@ref)
- 6. Typed scalar functions, e.g., [`ScalarAffineFunction`](@ref)
- 7. Un-typed vector functions, e.g., [`VectorOfVariables`](@ref)
- 8. Typed vector functions, e.g., [`VectorAffineFunction`](@ref)
+ 1. Un-typed scalar sets, for example, [`Integer`](@ref)
+ 2. Typed scalar sets, for example, [`LessThan`](@ref)
+ 3. Un-typed vector sets, for example, [`Nonnegatives`](@ref)
+ 4. Typed vector sets, for example, [`PowerCone`](@ref)
+ 5. Un-typed scalar functions, for example, [`VariableIndex`](@ref)
+ 6. Typed scalar functions, for example, [`ScalarAffineFunction`](@ref)
+ 7. Un-typed vector functions, for example, [`VectorOfVariables`](@ref)
+ 8. Typed vector functions, for example, [`VectorAffineFunction`](@ref)
 
 The tuples can contain more than one element. Typed-sets must be specified
-without their type parameter, i.e., `MOI.LessThan`, not `MOI.LessThan{Float64}`.
+without their type parameter, for example, `MOI.LessThan`, not
+`MOI.LessThan{Float64}`.
 
 Here is an example:
 ```jldoctest
@@ -132,15 +133,15 @@ julia> MOI.supports(::PathOptimizer, ::MOI.ObjectiveFunction) = false
 
 !!! warning
     This macro creates a new type, so it must be called from the top-level of a
-    module, e.g., it cannot be called from inside a function.
+    module, for example, it cannot be called from inside a function.
 
 ## Utilities.CachingOptimizer
 
 A [`Utilities.CachingOptimizer`] is an MOI layer that abstracts the difference
-between solvers that support incremental modification (e.g., they support adding
-variables one-by-one), and solvers that require the entire problem in a single
-API call (e.g., they only accept the `A`, `b` and `c` matrices of a linear
-program).
+between solvers that support incremental modification (for example, they support
+adding variables one-by-one), and solvers that require the entire problem in a
+single API call (for example, they only accept the `A`, `b` and `c` matrices of
+a linear program).
 
 It has two parts:
  1. A cache, where the model can be built and modified incrementally
@@ -389,7 +390,7 @@ interest, in which case [`copy_to`](@ref) can be implemented for the solver by
 calling [`copy_to`](@ref) to this custom model.
 
 For instance, [Clp](https://github.com/jump-dev/Clp.jl) defines the following
-model
+model:
 ```julia
 MOI.Utilities.@product_of_scalar_sets(LP, MOI.EqualTo{T}, MOI.LessThan{T}, MOI.GreaterThan{T})
 const Model = MOI.Utilities.GenericModel{
@@ -403,9 +404,7 @@ const Model = MOI.Utilities.GenericModel{
 }
 ```
 
-The [`copy_to`](@ref) operation can now be implemented as follows (assuming that
-the `Model` definition above is in the `Clp` module so that it can be referred
-to as `Model`, to be distinguished with [`Utilities.Model`](@ref)):
+The [`copy_to`](@ref) operation can now be implemented as follows:
 ```julia
 function _copy_to(dest::Optimizer, src::Model)
     @assert MOI.is_empty(dest)

--- a/docs/src/tutorials/bridging_constraint.md
+++ b/docs/src/tutorials/bridging_constraint.md
@@ -336,7 +336,7 @@ provides [`modify`](@ref). Bridges can also implement this API to allow
 certain changes, such as coefficient changes.
 
 In our case, a modification of a coefficient in the original constraint
-(i.e. replacing the value of the coefficient of a variable in the affine
+(for example, replacing the value of the coefficient of a variable in the affine
 function) must be transmitted to the constraint created by the bridge,
 but with a sign change.
 

--- a/docs/src/tutorials/example.md
+++ b/docs/src/tutorials/example.md
@@ -100,14 +100,14 @@ julia> MOI.optimize!(optimizer)
 
 ## Understand why the solver stopped
 
-The first thing to check after optimization is why the solver stopped, e.g.,
-did it stop because of a time limit or did it stop because it found the optimal
-solution?
+The first thing to check after optimization is why the solver stopped, for
+example, did it stop because of a time limit or did it stop because it found the
+optimal solution?
 ```jldoctest knapsack
 julia> MOI.get(optimizer, MOI.TerminationStatus())
 OPTIMAL::TerminationStatusCode = 1
 ```
-Looks like we found an optimal solution!
+Looks like we found an optimal solution.
 
 ## Understand what solution was returned
 

--- a/docs/src/tutorials/implementing.md
+++ b/docs/src/tutorials/implementing.md
@@ -17,7 +17,7 @@ MathOptInterface for a new solver.
     [Developer chatroom](https://gitter.im/JuliaOpt/JuMP-dev) and explain a
     little bit about the solver you are wrapping. If you have questions that are
     not answered by this guide, please ask them in the [Developer chatroom](https://gitter.im/JuliaOpt/JuMP-dev)
-    so we can improve this guide!
+    so we can improve this guide.
 
 ## A note on the API
 
@@ -26,7 +26,7 @@ diversity of solvers and use-cases, we make heavy use of
 [duck-typing](https://en.wikipedia.org/wiki/Duck_typing). That is, solvers are
 not expected to implement the full API, nor is there a well-defined minimal
 subset of what must be implemented. Instead, you should implement the API as
-necessary in order to make the solver function as you require.
+necessary to make the solver function as you require.
 
 The main reason for using duck-typing is that solvers work in different ways and
 target different use-cases.
@@ -40,7 +40,7 @@ For example:
    support modification or things like variable names.
  * Other "solvers" are not solvers at all, but things like file readers. These
    may only support functions like [`read_from_file`](@ref), and may not even
-   support the ability to add variables or constraints directly!
+   support the ability to add variables or constraints directly.
  * Finally, some "solvers" are layers which take a problem as input, transform
    it according to some rules, and pass the transformed problem to an inner
    solver.
@@ -56,8 +56,8 @@ The first step in writing a wrapper is to decide whether implementing an
 interface is the right thing to do.
 
 MathOptInterface is an abstraction layer for unifying _constrained_ mathematical
-optimization solvers. If your solver doesn't fit in the category, i.e., it
-implements a derivative-free algorithm for unconstrained objective functions,
+optimization solvers. If your solver doesn't fit in the category, for example,
+it implements a derivative-free algorithm for unconstrained objective functions,
 MathOptInterface may not be the right tool for the job.
 
 !!! tip
@@ -84,7 +84,7 @@ solver from Julia.
 
 #### Wrapping solvers written in Julia
 
-If your solver is written in Julia, there's nothing to do here! Go to the next
+If your solver is written in Julia, there's nothing to do here. Go to the next
 section.
 
 #### Wrapping solvers written in C
@@ -99,7 +99,7 @@ Before writing a MathOptInterface wrapper, there are a few extra steps.
 
 ##### Create a JLL
 
-If the C code is publicly available under an open-source license, create a
+If the C code is publicly available under an open source license, create a
 JLL package via [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil). The
 easiest way to do this is to copy an existing solver. Good examples to follow
 are the [COIN-OR solvers](https://github.com/JuliaPackaging/Yggdrasil/tree/master/C/Coin-OR).
@@ -217,9 +217,9 @@ package.
 
 !!! tip
     Run the tests frequently when developing. However, at the start there is
-    going to be a lot of errors! Start by excluding large classes of tests
-    (e.g., `exclude = ["test_basic_", "test_model_"]`, implement any missing
-    methods until the tests pass, then remove an exclusion and repeat.
+    going to be a lot of errors. Start by excluding large classes of tests
+    (for example, `exclude = ["test_basic_", "test_model_"]`, implement any
+    missing methods until the tests pass, then remove an exclusion and repeat.
 
 ## Initial code
 
@@ -295,7 +295,7 @@ interface.
 !!! tip
     For this and all future methods, read the docstrings to understand what each
     method does, what it expects as input, and what it produces as output. If it
-    isn't clear, let us know and we will improve the docstrings!
+    isn't clear, let us know and we will improve the docstrings.
     It is also very helpful to look at an existing wrapper for a similar solver.
 
 You should also implement `Base.show(::IO, ::Optimizer)` to print a nice string
@@ -444,7 +444,7 @@ steps, implement the [`copy_to`](@ref) interface.
 
 !!! warning
     Writing this interface is a lot of work. The easiest way is to consult the
-    source code of a similar solver!
+    source code of a similar solver.
 
 To implement the incremental interface, implement the following functions:
 
@@ -523,9 +523,9 @@ MOI.supports_add_constrained_variables(::Optimizer, ::Type{Reals}) = false
 If you implement the incremental interface, you have the option of also
 implementing [`copy_to`](@ref).
 
-If you don't want to implement [`copy_to`](@ref), e.g., because the solver has
-no API for building the problem in a single function call, define the following
-fallback:
+If you don't want to implement [`copy_to`](@ref), for example, because the
+solver has no API for building the problem in a single function call, define the
+following fallback:
 ```julia
 MOI.supports_incremental_interface(::Optimizer) = true
 
@@ -661,9 +661,9 @@ Here are some other points to be aware of when writing your wrapper.
 
 ### Unsupported constraints at runtime
 
-In some cases, your solver may support a particular type of constraint (e.g.,
-quadratic constraints), but only if the data meets some condition (e.g., it is
-convex).
+In some cases, your solver may support a particular type of constraint (for
+example, quadratic constraints), but only if the data meets some condition (for
+example, it is convex).
 
 In this case, declare that you `support` the constraint, and throw
 [`AddConstraintNotAllowed`](@ref).
@@ -700,7 +700,7 @@ structures. Solvers may not modify any input vectors and must assume that
 input vectors will not be modified by users in the future.
 
 This applies, for example, to the `terms` vector in
-[`ScalarAffineFunction`](@ref). Vectors returned to the user, e.g., via
+[`ScalarAffineFunction`](@ref). Vectors returned to the user, for example, via
 [`ObjectiveFunction`](@ref) or
 [`ConstraintFunction`](@ref) attributes, must not be modified by the solver
 afterwards. The in-place version of [`get!`](@ref) can be used by users to avoid

--- a/docs/src/tutorials/latency.md
+++ b/docs/src/tutorials/latency.md
@@ -12,7 +12,7 @@ MathOptInterface suffers the "time-to-first-solve" problem of start-up latency.
 
 This hurts both the user- and developer-experience of MathOptInterface. In the
 first case, because simple models have a multi-second delay before solving, and
-in the latter, because our tests take so long to run!
+in the latter, because our tests take so long to run.
 
 This page contains some advice on profiling and fixing latency-related problems
 in the MathOptInterface.jl repository.
@@ -55,7 +55,7 @@ it. However, if we can precompile MathOptInterface, much of the cost can be
 shifted from start-up latency to the time it takes to precompile a package on
 installation.
 
-However, there are two things which make MathOptInterface hard to precompile...
+However, there are two things which make MathOptInterface hard to precompile.
 
 ### Lack of method ownership
 
@@ -67,10 +67,10 @@ method that is being dispatched, and so it cannot be precompiled.
     This is a slightly simplified explanation. Read the [precompilation tutorial](https://julialang.org/blog/2021/01/precompile_tutorial/)
     for a more in-depth discussion on back-edges.
 
-Unfortunately, the design of MOI means that this is a frequent occurrence! We
+Unfortunately, the design of MOI means that this is a frequent occurrence: we
 have a bunch of types in `MOI.Utilities` that wrap types defined in external
-packages (i.e., the `Optimizer`s), which implement methods of functions defined
-in `MOI` (e.g., `add_variable`, `add_constraint`).
+packages (for example, the `Optimizer`s), which implement methods of functions
+defined in `MOI` (for example, `add_variable`, `add_constraint`).
 
 Here's a simple example of method-ownership in practice:
 ```julia
@@ -102,8 +102,8 @@ ProfileView.view(flamegraph(tinf))
 we see a flamegraph with a large red-bar indicating that the method
 `MyMOI.optimize(MyMOI.Wrapper{MyOptimizer.Optimizer})` cannot be precompiled.
 
-To fix this, we need to designate a module to "own" that method (i.e., create a
-back-edge). The easiest way to do this is for `MyOptimizer` to call
+To fix this, we need to designate a module to "own" that method (that is, create
+a back-edge). The easiest way to do this is for `MyOptimizer` to call
 `MyMOI.optimize(MyMOI.Wrapper{MyOptimizer.Optimizer})` during
 `using MyOptimizer`. Let's see that in practice:
 ```julia
@@ -144,7 +144,7 @@ method was already stored in `MyOptimizer`!
 Unfortunately, this trick only works if the call-chain is fully inferrable. If
 there are breaks (due to type instability), then the benefit of doing this is
 reduced. And unfortunately for us, the design of MathOptInterface has a lot of
-type instabilities...
+type instabilities.
 
 ### Type instability in the bridge layer
 
@@ -166,8 +166,8 @@ bridges that they defined in external packages.
 
 So to recap, MathOptInterface suffers package latency because:
 
- 1. there are a large number of types and functions...
- 2. and these are split between multiple modules, including external packages...
+ 1. there are a large number of types and functions
+ 2. and these are split between multiple modules, including external packages
  3. and there are type-instabilities like those in the bridging layer.
 
 ## Resolutions

--- a/docs/src/tutorials/manipulating_expressions.md
+++ b/docs/src/tutorials/manipulating_expressions.md
@@ -87,7 +87,7 @@ MathOptInterface.VectorAffineFunction{Int64}(MathOptInterface.VectorAffineTerm{I
 ## Canonicalizing functions
 
 In more advanced use cases, you might need to ensure that a function is
-"canonical". Functions are stored as an array of terms, but there is no check
+"canonical." Functions are stored as an array of terms, but there is no check
 that these terms are redundant: a [`ScalarAffineFunction`](@ref) object might
 have two terms with the same variable, like `x + x + 1`. These terms could be
 merged without changing the semantics of the function: `2x + 1`.

--- a/docs/styles/Google/AMPM.yml
+++ b/docs/styles/Google/AMPM.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "Use 'AM' or 'PM' (preceded by a space)."
+link: 'https://developers.google.com/style/word-list'
+level: error
+nonword: true
+tokens:
+  - '\d{1,2}[AP]M'
+  - '\d{1,2} ?[ap]m'
+  - '\d{1,2} ?[aApP]\.[mM]\.'

--- a/docs/styles/Google/Colons.yml
+++ b/docs/styles/Google/Colons.yml
@@ -1,0 +1,8 @@
+extends: existence
+message: "'%s' should be in lowercase."
+link: 'https://developers.google.com/style/colons'
+nonword: true
+level: warning
+scope: sentence
+tokens:
+  - ':\s[A-Z]'

--- a/docs/styles/Google/DateFormat.yml
+++ b/docs/styles/Google/DateFormat.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "Use 'July 31, 2016' format, not '%s'."
+link: 'https://developers.google.com/style/dates-times'
+ignorecase: true
+level: error
+nonword: true
+tokens:
+  - '\d{1,2}(?:\.|/)\d{1,2}(?:\.|/)\d{4}'
+  - '\d{1,2} (?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)|May|Jun(?:e)|Jul(?:y)|Aug(?:ust)|Sep(?:tember)?|Oct(?:ober)|Nov(?:ember)?|Dec(?:ember)?) \d{4}'

--- a/docs/styles/Google/Ellipses.yml
+++ b/docs/styles/Google/Ellipses.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "In general, don't use an ellipsis."
+link: 'https://developers.google.com/style/ellipses'
+nonword: true
+level: warning
+action:
+  name: remove
+tokens:
+  - '\.\.\.'

--- a/docs/styles/Google/EmDash.yml
+++ b/docs/styles/Google/EmDash.yml
@@ -1,0 +1,12 @@
+extends: existence
+message: "Don't put a space before or after a dash."
+link: 'https://developers.google.com/style/dashes'
+nonword: true
+level: error
+action:
+  name: edit
+  params:
+    - remove
+    - ' '
+tokens:
+  - '\s[—–]\s'

--- a/docs/styles/Google/EnDash.yml
+++ b/docs/styles/Google/EnDash.yml
@@ -1,0 +1,13 @@
+extends: existence
+message: "Use an em dash ('—') instead of '–'."
+link: 'https://developers.google.com/style/dashes'
+nonword: true
+level: error
+action:
+  name: edit
+  params:
+    - replace
+    - '-'
+    - '—'
+tokens:
+  - '–'

--- a/docs/styles/Google/Exclamation.yml
+++ b/docs/styles/Google/Exclamation.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "Don't use exclamation points in text."
+link: 'https://developers.google.com/style/exclamation-points'
+nonword: true
+level: error
+action:
+  name: remove
+tokens:
+  - '\w+!(?:\s|$)'

--- a/docs/styles/Google/FirstPerson.yml
+++ b/docs/styles/Google/FirstPerson.yml
@@ -1,0 +1,13 @@
+extends: existence
+message: "Avoid first-person pronouns such as '%s'."
+link: 'https://developers.google.com/style/pronouns#personal-pronouns'
+ignorecase: true
+level: warning
+nonword: true
+tokens:
+  - (?:^|\s)I\s
+  - (?:^|\s)I,\s
+  - \bI'm\b
+  - \bme\b
+  - \bmy\b
+  - \bmine\b

--- a/docs/styles/Google/Gender.yml
+++ b/docs/styles/Google/Gender.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "Don't use '%s' as a gender-neutral pronoun."
+link: 'https://developers.google.com/style/pronouns#gender-neutral-pronouns'
+level: error
+ignorecase: true
+tokens:
+  - he/she
+  - s/he
+  - \(s\)he

--- a/docs/styles/Google/GenderBias.yml
+++ b/docs/styles/Google/GenderBias.yml
@@ -1,0 +1,47 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'."
+link: 'https://developers.google.com/style/inclusive-documentation'
+ignorecase: true
+level: error
+action:
+  name: replace
+swap:
+  (?:alumna|alumnus):          graduate
+  (?:alumnae|alumni):          graduates
+  air(?:m[ae]n|wom[ae]n):      pilot(s)
+  anchor(?:m[ae]n|wom[ae]n):   anchor(s)
+  authoress:                   author
+  camera(?:m[ae]n|wom[ae]n):   camera operator(s)
+  chair(?:m[ae]n|wom[ae]n):    chair(s)
+  congress(?:m[ae]n|wom[ae]n): member(s) of congress
+  door(?:m[ae]|wom[ae]n):      concierge(s)
+  draft(?:m[ae]n|wom[ae]n):    drafter(s)
+  fire(?:m[ae]n|wom[ae]n):     firefighter(s)
+  fisher(?:m[ae]n|wom[ae]n):   fisher(s)
+  fresh(?:m[ae]n|wom[ae]n):    first-year student(s)
+  garbage(?:m[ae]n|wom[ae]n):  waste collector(s)
+  lady lawyer:                 lawyer
+  ladylike:                    courteous
+  landlord:                    building manager
+  mail(?:m[ae]n|wom[ae]n):     mail carriers
+  man and wife:                husband and wife
+  man enough:                  strong enough
+  mankind:                     human kind
+  manmade:                     manufactured
+  manpower:                    personnel
+  men and girls:               men and women
+  middle(?:m[ae]n|wom[ae]n):   intermediary
+  news(?:m[ae]n|wom[ae]n):     journalist(s)
+  ombuds(?:man|woman):         ombuds
+  oneupmanship:                upstaging
+  poetess:                     poet
+  police(?:m[ae]n|wom[ae]n):   police officer(s)
+  repair(?:m[ae]n|wom[ae]n):   technician(s)
+  sales(?:m[ae]n|wom[ae]n):    salesperson or sales people
+  service(?:m[ae]n|wom[ae]n):  soldier(s)
+  steward(?:ess)?:             flight attendant
+  tribes(?:m[ae]n|wom[ae]n):   tribe member(s)
+  waitress:                    waiter
+  woman doctor:                doctor
+  woman scientist[s]?:         scientist(s)
+  work(?:m[ae]n|wom[ae]n):     worker(s)

--- a/docs/styles/Google/HeadingPunctuation.yml
+++ b/docs/styles/Google/HeadingPunctuation.yml
@@ -1,0 +1,13 @@
+extends: existence
+message: "Don't put a period at the end of a heading."
+link: 'https://developers.google.com/style/capitalization#capitalization-in-titles-and-headings'
+nonword: true
+level: warning
+scope: heading
+action:
+  name: edit
+  params:
+    - remove
+    - '.'
+tokens:
+  - '[a-z0-9][.]\s*$'

--- a/docs/styles/Google/LICENSE
+++ b/docs/styles/Google/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 - 2019 Joseph Kato
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/styles/Google/Latin.yml
+++ b/docs/styles/Google/Latin.yml
@@ -1,0 +1,11 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: 'https://developers.google.com/style/abbreviations'
+ignorecase: true
+level: error
+nonword: true
+action:
+  name: replace
+swap:
+  '\b(?:eg|e\.g\.)[\s,]': for example
+  '\b(?:ie|i\.e\.)[\s,]': that is

--- a/docs/styles/Google/LyHyphens.yml
+++ b/docs/styles/Google/LyHyphens.yml
@@ -1,0 +1,14 @@
+extends: existence
+message: "'%s' doesn't need a hyphen."
+link: 'https://developers.google.com/style/hyphens'
+level: error
+ignorecase: false
+nonword: true
+action:
+  name: edit
+  params:
+    - replace
+    - '-'
+    - ' '
+tokens:
+  - '\s[^\s-]+ly-'

--- a/docs/styles/Google/OptionalPlurals.yml
+++ b/docs/styles/Google/OptionalPlurals.yml
@@ -1,0 +1,12 @@
+extends: existence
+message: "Don't use plurals in parentheses such as in '%s'."
+link: 'https://developers.google.com/style/plurals-parentheses'
+level: error
+nonword: true
+action:
+  name: edit
+  params:
+    - remove
+    - '(s)'
+tokens:
+  - '\b\w+\(s\)'

--- a/docs/styles/Google/Ordinal.yml
+++ b/docs/styles/Google/Ordinal.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Spell out all ordinal numbers ('%s') in text."
+link: 'https://developers.google.com/style/numbers'
+level: error
+nonword: true
+tokens:
+  - \d+(?:st|nd|rd|th)

--- a/docs/styles/Google/OxfordComma.yml
+++ b/docs/styles/Google/OxfordComma.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Use the Oxford comma in '%s'."
+link: 'https://developers.google.com/style/commas'
+scope: sentence
+level: warning
+tokens:
+  - '(?:[^,]+,){1,}\s\w+\s(?:and|or)'

--- a/docs/styles/Google/Periods.yml
+++ b/docs/styles/Google/Periods.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Don't use periods with acronyms or initialisms such as '%s'."
+link: 'https://developers.google.com/style/abbreviations'
+level: error
+nonword: true
+tokens:
+  - '\b(?:[A-Z]\.){3,}'

--- a/docs/styles/Google/Quotes.yml
+++ b/docs/styles/Google/Quotes.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Commas and periods go inside quotation marks."
+link: 'https://developers.google.com/style/quotation-marks'
+level: error
+nonword: true
+tokens:
+  - '"[^"]+"[.,?]'

--- a/docs/styles/Google/Ranges.yml
+++ b/docs/styles/Google/Ranges.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Don't add words such as 'from' or 'between' to describe a range of numbers."
+link: 'https://developers.google.com/style/hyphens'
+nonword: true
+level: warning
+tokens:
+  - '(?:from|between)\s\d+\s?-\s?\d+'

--- a/docs/styles/Google/Slang.yml
+++ b/docs/styles/Google/Slang.yml
@@ -1,0 +1,11 @@
+extends: existence
+message: "Don't use internet slang abbreviations such as '%s'."
+link: 'https://developers.google.com/style/abbreviations'
+ignorecase: true
+level: error
+tokens:
+  - 'tl;dr'
+  - ymmv
+  - rtfm
+  - imo
+  - fwiw

--- a/docs/styles/Google/Spelling.yml
+++ b/docs/styles/Google/Spelling.yml
@@ -1,0 +1,8 @@
+extends: existence
+message: "In general, use American spelling instead of '%s'."
+link: 'https://developers.google.com/style/spelling'
+ignorecase: true
+level: warning
+tokens:
+  - '(?:\w+)nised?'
+  - '(?:\w+)logue'

--- a/docs/styles/Google/Units.yml
+++ b/docs/styles/Google/Units.yml
@@ -1,0 +1,8 @@
+extends: existence
+message: "Put a nonbreaking space between the number and the unit in '%s'."
+link: 'https://developers.google.com/style/units-of-measure'
+nonword: true
+level: error
+tokens:
+  - \d+(?:B|kB|MB|GB|TB)
+  - \d+(?:ns|ms|s|min|h|d)


### PR DESCRIPTION
Styles taken from https://github.com/errata-ai/Google. They are MIT licensed.

I haven't included all the rules because some generate too many warnings or false positives. 

 * All "suggestion" level rules
 * Google.Headings : false positives with links in headers
 * Google.Spacing : false positives with Julia syntax
 * Google.We : I violate this one all the time. It'd be a large PR to change, but we could do it in future
 * Google.Will : I violate this one all the time. It'd be a large PR to change, but we could do it in future 
 * Google.WordList : a few pedantic suggestions that don't apply well to MOI or JuMP