### PR TITLE
Print algebraic form of AbstractFunction by default

### DIFF
--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -14,7 +14,7 @@ Use [`add_variable`](@ref) to add a single variable.
 
 ```jldoctest variables; setup=:(model = MOI.Utilities.Model{Float64}(); )
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 ```
 [`add_variable`](@ref) returns a [`VariableIndex`](@ref) type, which is used to
 refer to the added variable in other calls.
@@ -29,8 +29,8 @@ Use [`add_variables`](@ref) to add a number of variables.
 ```jldoctest variables
 julia> y = MOI.add_variables(model, 2)
 2-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(2)
- MathOptInterface.VariableIndex(3)
+ MOI.VariableIndex(2)
+ MOI.VariableIndex(3)
 ```
 
 !!! warning

--- a/docs/src/submodules/FileFormats/overview.md
+++ b/docs/src/submodules/FileFormats/overview.md
@@ -78,7 +78,7 @@ julia> src = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> MOI.add_variable(src)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> dest = MOI.FileFormats.Model(format = MOI.FileFormats.FORMAT_MOF)
 A MathOptFormat Model
@@ -119,7 +119,7 @@ julia> MOI.read_from_file(dest, "file.mof.json")
 
 julia> MOI.get(dest, MOI.ListOfVariableIndices())
 1-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(1)
+ MOI.VariableIndex(1)
 
 julia> rm("file.mof.json")  # Clean up after ourselves.
 ```

--- a/docs/src/submodules/Nonlinear/overview.md
+++ b/docs/src/submodules/Nonlinear/overview.md
@@ -62,7 +62,7 @@ incorporate [`VariableIndex`](@ref)es, but these must be interpolated into
 the expression with `$`:
 ```jldoctest nonlinear_developer
 julia> x = MOI.VariableIndex(1)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> input = :(1 + sin($x)^2)
 :(1 + sin(MathOptInterface.VariableIndex(1)) ^ 2)
@@ -429,9 +429,9 @@ julia> expr = Any[:+, 2, :^, 2, :sin, 1, x, 2.0, x]
  2
   :sin
  1
-  MathOptInterface.VariableIndex(1)
+  MOI.VariableIndex(1)
  2.0
-  MathOptInterface.VariableIndex(1)
+  MOI.VariableIndex(1)
 ```
 The `Int` after each operator `Symbol` specifies the number of arguments.
 

--- a/docs/src/submodules/Utilities/overview.md
+++ b/docs/src/submodules/Utilities/overview.md
@@ -279,7 +279,7 @@ Use `print` to print the formulation of the model.
 julia> model = MOI.Utilities.Model{Float64}();
 
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.set(model, MOI.VariableName(), x, "x_var")
 
@@ -345,7 +345,7 @@ VariableIndex-in-GreaterThan{Float64}
  v[2] >= 0.0
 
 julia> map[c]
-MathOptInterface.ScalarAffineFunction{Float64}(MathOptInterface.ScalarAffineTerm{Float64}[MathOptInterface.ScalarAffineTerm{Float64}(1.0, MathOptInterface.VariableIndex(2))], 0.0)
+0.0 + 1.0 MOI.VariableIndex(2)
 ```
 
 You can also modify a single constraint using [`Utilities.ScalarPenaltyRelaxation`](@ref):
@@ -373,7 +373,7 @@ VariableIndex-in-GreaterThan{Float64}
  v[2] >= 0.0
 
 julia> f
-MathOptInterface.ScalarAffineFunction{Float64}(MathOptInterface.ScalarAffineTerm{Float64}[MathOptInterface.ScalarAffineTerm{Float64}(1.0, MathOptInterface.VariableIndex(2))], 0.0)
+0.0 + 1.0 MOI.VariableIndex(2)
 ```
 
 ## Utilities.MatrixOfConstraints

--- a/docs/src/tutorials/manipulating_expressions.md
+++ b/docs/src/tutorials/manipulating_expressions.md
@@ -22,7 +22,7 @@ The simplest scalar function is simply a variable:
 
 ```jldoctest expr; setup=:(model = MOI.Utilities.CachingOptimizer(MOI.Utilities.Model{Float64}(), MOI.Utilities.AUTOMATIC); )
 julia> x = MOI.add_variable(model) # Create the variable x
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 ```
 
 This type of function is extremely simple; to express more complex functions,
@@ -32,14 +32,14 @@ can be built using the standard constructor:
 
 ```jldoctest expr
 julia> f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1, x)], 2) # x + 2
-MathOptInterface.ScalarAffineFunction{Int64}(MathOptInterface.ScalarAffineTerm{Int64}[MathOptInterface.ScalarAffineTerm{Int64}(1, MathOptInterface.VariableIndex(1))], 2)
+(2) + (1) MOI.VariableIndex(1)
 ```
 
 However, you can also use operators to build the same scalar function:
 
 ```jldoctest expr
 julia> f = x + 2
-MathOptInterface.ScalarAffineFunction{Int64}(MathOptInterface.ScalarAffineTerm{Int64}[MathOptInterface.ScalarAffineTerm{Int64}(1, MathOptInterface.VariableIndex(1))], 2)
+(2) + (1) MOI.VariableIndex(1)
 ```
 
 ### Creating scalar quadratic functions
@@ -50,13 +50,13 @@ obtain a quadratic function as a product of affine functions:
 
 ```jldoctest expr
 julia> 1 * x * x
-MathOptInterface.ScalarQuadraticFunction{Int64}(MathOptInterface.ScalarQuadraticTerm{Int64}[MathOptInterface.ScalarQuadraticTerm{Int64}(2, MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(1))], MathOptInterface.ScalarAffineTerm{Int64}[], 0)
+(0) + 1.0 MOI.VariableIndex(1)²
 
 julia> f * f  # (x + 2)²
-MathOptInterface.ScalarQuadraticFunction{Int64}(MathOptInterface.ScalarQuadraticTerm{Int64}[MathOptInterface.ScalarQuadraticTerm{Int64}(2, MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(1))], MathOptInterface.ScalarAffineTerm{Int64}[MathOptInterface.ScalarAffineTerm{Int64}(2, MathOptInterface.VariableIndex(1)), MathOptInterface.ScalarAffineTerm{Int64}(2, MathOptInterface.VariableIndex(1))], 4)
+(4) + (2) MOI.VariableIndex(1) + (2) MOI.VariableIndex(1) + 1.0 MOI.VariableIndex(1)²
 
 julia> f^2  # (x + 2)² too
-MathOptInterface.ScalarQuadraticFunction{Int64}(MathOptInterface.ScalarQuadraticTerm{Int64}[MathOptInterface.ScalarQuadraticTerm{Int64}(2, MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(1))], MathOptInterface.ScalarAffineTerm{Int64}[MathOptInterface.ScalarAffineTerm{Int64}(2, MathOptInterface.VariableIndex(1)), MathOptInterface.ScalarAffineTerm{Int64}(2, MathOptInterface.VariableIndex(1))], 4)
+(4) + (2) MOI.VariableIndex(1) + (2) MOI.VariableIndex(1) + 1.0 MOI.VariableIndex(1)²
 ```
 
 ### Creating vector functions
@@ -73,7 +73,10 @@ dimension corresponding to a dimension of the vector.
 
 ```jldoctest expr
 julia> g = MOI.Utilities.vectorize([f, 2 * f])
-MathOptInterface.VectorAffineFunction{Int64}(MathOptInterface.VectorAffineTerm{Int64}[MathOptInterface.VectorAffineTerm{Int64}(1, MathOptInterface.ScalarAffineTerm{Int64}(1, MathOptInterface.VariableIndex(1))), MathOptInterface.VectorAffineTerm{Int64}(2, MathOptInterface.ScalarAffineTerm{Int64}(2, MathOptInterface.VariableIndex(1)))], [2, 4])
+┌                              ┐
+│(2) + (1) MOI.VariableIndex(1)│
+│(4) + (2) MOI.VariableIndex(1)│
+└                              ┘
 ```
 
 !!! warning
@@ -108,7 +111,7 @@ function:
 
 ```jldoctest expr
 julia> MOI.Utilities.canonical(f + f) # Returns 2x + 4
-MathOptInterface.ScalarAffineFunction{Int64}(MathOptInterface.ScalarAffineTerm{Int64}[MathOptInterface.ScalarAffineTerm{Int64}(2, MathOptInterface.VariableIndex(1))], 4)
+(4) + (2) MOI.VariableIndex(1)
 ```
 
 ## Exploring functions
@@ -124,8 +127,8 @@ vector function:
 ```jldoctest expr
 julia> MOI.Utilities.scalarize(g) # Returns a vector [f, 2 * f].
 2-element Vector{MathOptInterface.ScalarAffineFunction{Int64}}:
- MathOptInterface.ScalarAffineFunction{Int64}(MathOptInterface.ScalarAffineTerm{Int64}[MathOptInterface.ScalarAffineTerm{Int64}(1, MathOptInterface.VariableIndex(1))], 2)
- MathOptInterface.ScalarAffineFunction{Int64}(MathOptInterface.ScalarAffineTerm{Int64}[MathOptInterface.ScalarAffineTerm{Int64}(2, MathOptInterface.VariableIndex(1))], 4)
+ (2) + (1) MOI.VariableIndex(1)
+ (4) + (2) MOI.VariableIndex(1)
 ```
 
 !!! note

--- a/src/Utilities/print.jl
+++ b/src/Utilities/print.jl
@@ -637,22 +637,32 @@ function Base.print(io::IO, model::MOI.ModelLike; kwargs...)
     return _print_model(io, _PrintOptions(MIME("text/plain"); kwargs...), model)
 end
 
-struct _NoVariableNameModel <: MOI.ModelLike end
+struct _NoVariableNameModel{M} <: MOI.ModelLike end
 
 function MOI.get(
-    ::_NoVariableNameModel,
+    ::_NoVariableNameModel{MIME"text/plain"},
     ::MOI.VariableName,
     x::MOI.VariableIndex,
 )
     return "MOI.VariableIndex($(x.value))"
 end
 
+function MOI.get(
+    ::_NoVariableNameModel{MIME"text/latex"},
+    ::MOI.VariableName,
+    ::MOI.VariableIndex,
+)
+    return ""  # Leave as default
+end
+
 function Base.show(io::IO, mime::MIME"text/plain", f::MOI.AbstractFunction)
-    print(io, _to_string(_PrintOptions(mime), _NoVariableNameModel(), f))
+    model = _NoVariableNameModel{MIME"text/plain"}()
+    print(io, _to_string(_PrintOptions(mime), model, f))
     return
 end
 
 function Base.show(io::IO, mime::MIME"text/latex", f::MOI.AbstractFunction)
-    print(io, _to_string(_PrintOptions(mime), _NoVariableNameModel(), f))
+    model = _NoVariableNameModel{MIME"text/latex"}()
+    print(io, _to_string(_PrintOptions(mime), model, f))
     return
 end

--- a/src/Utilities/print.jl
+++ b/src/Utilities/print.jl
@@ -642,7 +642,7 @@ struct _NoVariableNameModel <: MOI.ModelLike end
 function MOI.get(
     ::_NoVariableNameModel,
     ::MOI.VariableName,
-    x::MOI.VariableIndex
+    x::MOI.VariableIndex,
 )
     return "MOI.VariableIndex($(x.value))"
 end

--- a/src/Utilities/print.jl
+++ b/src/Utilities/print.jl
@@ -636,3 +636,23 @@ end
 function Base.print(io::IO, model::MOI.ModelLike; kwargs...)
     return _print_model(io, _PrintOptions(MIME("text/plain"); kwargs...), model)
 end
+
+struct _NoVariableNameModel <: MOI.ModelLike end
+
+function MOI.get(
+    ::_NoVariableNameModel,
+    ::MOI.VariableName,
+    x::MOI.VariableIndex
+)
+    return "MOI.VariableIndex($(x.value))"
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", f::MOI.AbstractFunction)
+    print(io, _to_string(_PrintOptions(mime), _NoVariableNameModel(), f))
+    return
+end
+
+function Base.show(io::IO, mime::MIME"text/latex", f::MOI.AbstractFunction)
+    print(io, _to_string(_PrintOptions(mime), _NoVariableNameModel(), f))
+    return
+end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -81,7 +81,7 @@ Represents the scalar-valued term `coefficient * variable`.
 julia> import MathOptInterface as MOI
 
 julia> x = MOI.VariableIndex(1)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.ScalarAffineTerm(2.0, x)
 MathOptInterface.ScalarAffineTerm{Float64}(2.0, MathOptInterface.VariableIndex(1))
@@ -126,7 +126,7 @@ coefficients are summed together.
 julia> import MathOptInterface as MOI
 
 julia> x = MOI.VariableIndex(1)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> terms = [MOI.ScalarAffineTerm(2.0, x), MOI.ScalarAffineTerm(3.0, x)]
 2-element Vector{MathOptInterface.ScalarAffineTerm{Float64}}:
@@ -134,7 +134,7 @@ julia> terms = [MOI.ScalarAffineTerm(2.0, x), MOI.ScalarAffineTerm(3.0, x)]
  MathOptInterface.ScalarAffineTerm{Float64}(3.0, MathOptInterface.VariableIndex(1))
 
 julia> f = MOI.ScalarAffineFunction(terms, 4.0)
-MathOptInterface.ScalarAffineFunction{Float64}(MathOptInterface.ScalarAffineTerm{Float64}[MathOptInterface.ScalarAffineTerm{Float64}(2.0, MathOptInterface.VariableIndex(1)), MathOptInterface.ScalarAffineTerm{Float64}(3.0, MathOptInterface.VariableIndex(1))], 4.0)
+4.0 + 2.0 MOI.VariableIndex(1) + 3.0 MOI.VariableIndex(1)
 ```
 """
 mutable struct ScalarAffineFunction{T} <: AbstractScalarFunction
@@ -168,7 +168,7 @@ Represents the scalar-valued term ``c x_i x_j`` where ``c`` is `coefficient`,
 julia> import MathOptInterface as MOI
 
 julia> x = MOI.VariableIndex(1)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.ScalarQuadraticTerm(2.0, x, x)
 MathOptInterface.ScalarQuadraticTerm{Float64}(2.0, MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(1))
@@ -258,7 +258,7 @@ julia> quadratic_terms = [
  MathOptInterface.ScalarQuadraticTerm{Float64}(3.0, MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(2))
 
 julia> f = MOI.ScalarQuadraticFunction(quadratic_terms, affine_terms, constant)
-MathOptInterface.ScalarQuadraticFunction{Float64}(MathOptInterface.ScalarQuadraticTerm{Float64}[MathOptInterface.ScalarQuadraticTerm{Float64}(4.0, MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(1)), MathOptInterface.ScalarQuadraticTerm{Float64}(3.0, MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(2))], MathOptInterface.ScalarAffineTerm{Float64}[MathOptInterface.ScalarAffineTerm{Float64}(4.0, MathOptInterface.VariableIndex(1))], 5.0)
+5.0 + 4.0 MOI.VariableIndex(1) + 2.0 MOI.VariableIndex(1)² + 3.0 MOI.VariableIndex(1)*MOI.VariableIndex(2)
 ```
 
 """
@@ -306,11 +306,15 @@ julia> import MathOptInterface as MOI
 
 julia> x = MOI.VariableIndex.(1:2)
 2-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(1)
- MathOptInterface.VariableIndex(2)
+ MOI.VariableIndex(1)
+ MOI.VariableIndex(2)
 
 julia> f = MOI.VectorOfVariables([x[1], x[2], x[1]])
-MathOptInterface.VectorOfVariables(MathOptInterface.VariableIndex[MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(2), MathOptInterface.VariableIndex(1)])
+┌                    ┐
+│MOI.VariableIndex(1)│
+│MOI.VariableIndex(2)│
+│MOI.VariableIndex(1)│
+└                    ┘
 
 julia> MOI.output_dimension(f)
 3
@@ -404,7 +408,10 @@ julia> terms = [
        ];
 
 julia> f = MOI.VectorAffineFunction(terms, [4.0, 5.0])
-MathOptInterface.VectorAffineFunction{Float64}(MathOptInterface.VectorAffineTerm{Float64}[MathOptInterface.VectorAffineTerm{Float64}(1, MathOptInterface.ScalarAffineTerm{Float64}(2.0, MathOptInterface.VariableIndex(1))), MathOptInterface.VectorAffineTerm{Float64}(2, MathOptInterface.ScalarAffineTerm{Float64}(3.0, MathOptInterface.VariableIndex(1)))], [4.0, 5.0])
+┌                              ┐
+│4.0 + 2.0 MOI.VariableIndex(1)│
+│5.0 + 3.0 MOI.VariableIndex(1)│
+└                              ┘
 
 julia> MOI.output_dimension(f)
 2
@@ -516,7 +523,10 @@ julia> quad_terms = [
            ];
 
 julia> f = MOI.VectorQuadraticFunction(quad_terms, affine_terms, constants)
-MathOptInterface.VectorQuadraticFunction{Float64}(MathOptInterface.VectorQuadraticTerm{Float64}[MathOptInterface.VectorQuadraticTerm{Float64}(1, MathOptInterface.ScalarQuadraticTerm{Float64}(2.0, MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(1))), MathOptInterface.VectorQuadraticTerm{Float64}(2, MathOptInterface.ScalarQuadraticTerm{Float64}(3.0, MathOptInterface.VariableIndex(1), MathOptInterface.VariableIndex(2)))], MathOptInterface.VectorAffineTerm{Float64}[MathOptInterface.VectorAffineTerm{Float64}(1, MathOptInterface.ScalarAffineTerm{Float64}(2.0, MathOptInterface.VariableIndex(1))), MathOptInterface.VectorAffineTerm{Float64}(2, MathOptInterface.ScalarAffineTerm{Float64}(3.0, MathOptInterface.VariableIndex(1)))], [4.0, 5.0])
+┌                                                                              ┐
+│4.0 + 2.0 MOI.VariableIndex(1) + 1.0 MOI.VariableIndex(1)²                    │
+│5.0 + 3.0 MOI.VariableIndex(1) + 3.0 MOI.VariableIndex(1)*MOI.VariableIndex(2)│
+└                                                                              ┘
 
 julia> MOI.output_dimension(f)
 2

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -161,7 +161,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.add_constraint(model, x, MOI.GreaterThan(0.0))
 MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.GreaterThan{Float64}}(1)
@@ -187,7 +187,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.add_constraint(model, x, MOI.LessThan(2.0))
 MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.LessThan{Float64}}(1)
@@ -213,7 +213,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.add_constraint(model, x, MOI.EqualTo(2.0))
 MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.EqualTo{Float64}}(1)
@@ -280,7 +280,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.add_constraint(model, x, MOI.Interval(1.0, 2.0))
 MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.Interval{Float64}}(1)
@@ -341,7 +341,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.add_constraint(model, x, MOI.Integer())
 MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.Integer}(1)
@@ -365,7 +365,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.add_constraint(model, x, MOI.ZeroOne())
 MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}(1)
@@ -387,7 +387,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.add_constraint(model, x, MOI.Semicontinuous(2.0, 3.0))
 MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.Semicontinuous{Float64}}(1)
@@ -420,7 +420,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> MOI.add_constraint(model, x, MOI.Semiinteger(2.0, 3.0))
 MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.Semiinteger{Float64}}(1)
@@ -600,7 +600,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> x = MOI.add_variables(model, 3);
 
@@ -643,7 +643,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> x = MOI.add_variables(model, 3);
 
@@ -686,7 +686,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> x = MOI.add_variables(model, 3);
 
@@ -729,10 +729,10 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> u = MOI.add_variable(model)
-MathOptInterface.VariableIndex(2)
+MOI.VariableIndex(2)
 
 julia> x = MOI.add_variables(model, 3);
 
@@ -784,7 +784,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> x = MOI.add_variables(model, 3);
 
@@ -999,12 +999,12 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> X = reshape(MOI.add_variables(model, 6), 2, 3)
 2×3 Matrix{MathOptInterface.VariableIndex}:
- VariableIndex(2)  VariableIndex(4)  VariableIndex(6)
- VariableIndex(3)  VariableIndex(5)  VariableIndex(7)
+ MOI.VariableIndex(2)  MOI.VariableIndex(4)  MOI.VariableIndex(6)
+ MOI.VariableIndex(3)  MOI.VariableIndex(5)  MOI.VariableIndex(7)
 
 julia> MOI.add_constraint(
            model,
@@ -1055,12 +1055,12 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> X = reshape(MOI.add_variables(model, 6), 2, 3)
 2×3 Matrix{MathOptInterface.VariableIndex}:
- VariableIndex(2)  VariableIndex(4)  VariableIndex(6)
- VariableIndex(3)  VariableIndex(5)  VariableIndex(7)
+ MOI.VariableIndex(2)  MOI.VariableIndex(4)  MOI.VariableIndex(6)
+ MOI.VariableIndex(3)  MOI.VariableIndex(5)  MOI.VariableIndex(7)
 
 julia> MOI.add_constraint(
            model,
@@ -1421,7 +1421,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> X = MOI.add_variables(model, 3);
 
@@ -1475,12 +1475,12 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> X = reshape(MOI.add_variables(model, 4), 2, 2)
 2×2 Matrix{MathOptInterface.VariableIndex}:
- VariableIndex(2)  VariableIndex(4)
- VariableIndex(3)  VariableIndex(5)
+ MOI.VariableIndex(2)  MOI.VariableIndex(4)
+ MOI.VariableIndex(3)  MOI.VariableIndex(5)
 
 julia> MOI.add_constraint(
            model,
@@ -1533,7 +1533,7 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> X = MOI.add_variables(model, 3);
 
@@ -1587,12 +1587,12 @@ julia> model = MOI.Utilities.Model{Float64}()
 MOIU.Model{Float64}
 
 julia> t = MOI.add_variable(model)
-MathOptInterface.VariableIndex(1)
+MOI.VariableIndex(1)
 
 julia> X = reshape(MOI.add_variables(model, 4), 2, 2)
 2×2 Matrix{MathOptInterface.VariableIndex}:
- VariableIndex(2)  VariableIndex(4)
- VariableIndex(3)  VariableIndex(5)
+ MOI.VariableIndex(2)  MOI.VariableIndex(4)
+ MOI.VariableIndex(3)  MOI.VariableIndex(5)
 
 julia> MOI.add_constraint(
            model,
@@ -1749,8 +1749,8 @@ MOIU.Model{Float64}
 
 julia> x = MOI.add_variables(model, 2)
 2-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(1)
- MathOptInterface.VariableIndex(2)
+ MOI.VariableIndex(1)
+ MOI.VariableIndex(2)
 
 julia> y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
 (MathOptInterface.VariableIndex(3), MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}(3))
@@ -1763,7 +1763,10 @@ julia> f = MOI.VectorAffineFunction(
            ],
            [0.0, 0.0],
        )
-MathOptInterface.VectorAffineFunction{Float64}(MathOptInterface.VectorAffineTerm{Float64}[MathOptInterface.VectorAffineTerm{Float64}(1, MathOptInterface.ScalarAffineTerm{Float64}(1.0, MathOptInterface.VariableIndex(3))), MathOptInterface.VectorAffineTerm{Float64}(2, MathOptInterface.ScalarAffineTerm{Float64}(1.0, MathOptInterface.VariableIndex(1))), MathOptInterface.VectorAffineTerm{Float64}(2, MathOptInterface.ScalarAffineTerm{Float64}(1.0, MathOptInterface.VariableIndex(2)))], [0.0, 0.0])
+┌                                                         ┐
+│0.0 + 1.0 MOI.VariableIndex(3)                           │
+│0.0 + 1.0 MOI.VariableIndex(1) + 1.0 MOI.VariableIndex(2)│
+└                                                         ┘
 
 julia> s = MOI.Indicator{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(9.0))
 MathOptInterface.Indicator{MathOptInterface.ACTIVATE_ON_ONE, MathOptInterface.LessThan{Float64}}(MathOptInterface.LessThan{Float64}(9.0))
@@ -1907,9 +1910,9 @@ MOIU.Model{Float64}
 
 julia> x = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
 3-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(1)
- MathOptInterface.VariableIndex(2)
- MathOptInterface.VariableIndex(3)
+ MOI.VariableIndex(1)
+ MOI.VariableIndex(2)
+ MOI.VariableIndex(3)
 
 julia> MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.AllDifferent(3))
 MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInterface.AllDifferent}(1)
@@ -1952,11 +1955,11 @@ MOIU.Model{Float64}
 
 julia> bins = MOI.add_variables(model, 5)
 5-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(1)
- MathOptInterface.VariableIndex(2)
- MathOptInterface.VariableIndex(3)
- MathOptInterface.VariableIndex(4)
- MathOptInterface.VariableIndex(5)
+ MOI.VariableIndex(1)
+ MOI.VariableIndex(2)
+ MOI.VariableIndex(3)
+ MOI.VariableIndex(4)
+ MOI.VariableIndex(5)
 
 julia> weights = Float64[1, 1, 2, 2, 3]
 5-element Vector{Float64}:
@@ -2035,9 +2038,9 @@ MOIU.Model{Float64}
 
 julia> x = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
 3-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(1)
- MathOptInterface.VariableIndex(2)
- MathOptInterface.VariableIndex(3)
+ MOI.VariableIndex(1)
+ MOI.VariableIndex(2)
+ MOI.VariableIndex(3)
 
 julia> MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.Circuit(3))
 MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInterface.Circuit}(1)
@@ -2141,9 +2144,9 @@ julia> n, _ = MOI.add_constrained_variable(model, MOI.Integer())
 
 julia> x = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
 3-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(2)
- MathOptInterface.VariableIndex(3)
- MathOptInterface.VariableIndex(4)
+ MOI.VariableIndex(2)
+ MOI.VariableIndex(3)
+ MOI.VariableIndex(4)
 
 julia> set = Set([3, 4, 5])
 Set{Int64} with 3 elements:
@@ -2204,9 +2207,9 @@ julia> n, _ = MOI.add_constrained_variable(model, MOI.Integer())
 
 julia> x = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
 3-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(2)
- MathOptInterface.VariableIndex(3)
- MathOptInterface.VariableIndex(4)
+ MOI.VariableIndex(2)
+ MOI.VariableIndex(3)
+ MOI.VariableIndex(4)
 
 julia> MOI.add_constraint(model, MOI.VectorOfVariables(vcat(n, x)), MOI.CountDistinct(4))
 MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInterface.CountDistinct}(1)
@@ -2253,9 +2256,9 @@ julia> y, _ = MOI.add_constrained_variable(model, MOI.Integer())
 
 julia> x = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
 3-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(3)
- MathOptInterface.VariableIndex(4)
- MathOptInterface.VariableIndex(5)
+ MOI.VariableIndex(3)
+ MOI.VariableIndex(4)
+ MOI.VariableIndex(5)
 
 julia> MOI.add_constraint(model, MOI.VectorOfVariables([c; y; x]), MOI.CountGreaterThan(5))
 MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInterface.CountGreaterThan}(1)
@@ -2300,21 +2303,21 @@ MOIU.Model{Float64}
 
 julia> s = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
 3-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(1)
- MathOptInterface.VariableIndex(2)
- MathOptInterface.VariableIndex(3)
+ MOI.VariableIndex(1)
+ MOI.VariableIndex(2)
+ MOI.VariableIndex(3)
 
 julia> d = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
 3-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(4)
- MathOptInterface.VariableIndex(5)
- MathOptInterface.VariableIndex(6)
+ MOI.VariableIndex(4)
+ MOI.VariableIndex(5)
+ MOI.VariableIndex(6)
 
 julia> r = [MOI.add_constrained_variable(model, MOI.Integer())[1] for _ in 1:3]
 3-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(7)
- MathOptInterface.VariableIndex(8)
- MathOptInterface.VariableIndex(9)
+ MOI.VariableIndex(7)
+ MOI.VariableIndex(8)
+ MOI.VariableIndex(9)
 
 julia> b, _ = MOI.add_constrained_variable(model, MOI.Integer())
 (MathOptInterface.VariableIndex(10), MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.Integer}(10))
@@ -2385,10 +2388,10 @@ julia> t, _ = MOI.add_constrained_variable(model, MOI.Integer())
 
 julia> ns = MOI.add_variables(model, N)
 4-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(3)
- MathOptInterface.VariableIndex(4)
- MathOptInterface.VariableIndex(5)
- MathOptInterface.VariableIndex(6)
+ MOI.VariableIndex(3)
+ MOI.VariableIndex(4)
+ MOI.VariableIndex(5)
+ MOI.VariableIndex(6)
 
 julia> MOI.add_constraint.(model, ns, MOI.ZeroOne())
 4-element Vector{MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}}:
@@ -2399,11 +2402,11 @@ julia> MOI.add_constraint.(model, ns, MOI.ZeroOne())
 
 julia> es = MOI.add_variables(model, E)
 5-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(7)
- MathOptInterface.VariableIndex(8)
- MathOptInterface.VariableIndex(9)
- MathOptInterface.VariableIndex(10)
- MathOptInterface.VariableIndex(11)
+ MOI.VariableIndex(7)
+ MOI.VariableIndex(8)
+ MOI.VariableIndex(9)
+ MOI.VariableIndex(10)
+ MOI.VariableIndex(11)
 
 julia> MOI.add_constraint.(model, es, MOI.ZeroOne())
 5-element Vector{MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}}:
@@ -2459,9 +2462,9 @@ MOIU.Model{Float64}
 
 julia> x = MOI.add_variables(model, 3)
 3-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(1)
- MathOptInterface.VariableIndex(2)
- MathOptInterface.VariableIndex(3)
+ MOI.VariableIndex(1)
+ MOI.VariableIndex(2)
+ MOI.VariableIndex(3)
 
 julia> table = Float64[1 1 0; 0 1 1; 1 0 1; 1 1 1]
 4×3 Matrix{Float64}:
@@ -2499,9 +2502,9 @@ MOIU.Model{Float64}
 
 julia> x = MOI.add_variables(model, 3)
 3-element Vector{MathOptInterface.VariableIndex}:
- MathOptInterface.VariableIndex(1)
- MathOptInterface.VariableIndex(2)
- MathOptInterface.VariableIndex(3)
+ MOI.VariableIndex(1)
+ MOI.VariableIndex(2)
+ MOI.VariableIndex(3)
 
 julia> MOI.add_constraint(
            model,
@@ -2554,7 +2557,7 @@ julia> z, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
 (MathOptInterface.VariableIndex(1), MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}(1))
 
 julia> x = MOI.add_variable(model)
-MathOptInterface.VariableIndex(2)
+MOI.VariableIndex(2)
 
 julia> MOI.add_constraint(
            model,

--- a/test/Utilities/print.jl
+++ b/test/Utilities/print.jl
@@ -675,6 +675,27 @@ function test_print_with_acronym()
     return
 end
 
+function test_default_printing()
+    x = MOI.VariableIndex(1)
+    y = MOI.VariableIndex(2)
+    aff = 2.0 * x + 1.0
+    model = MOI.Utilities._NoVariableNameModel()
+    for mime in (MIME("text/plain"), MIME("text/latex"))
+        options = MOI.Utilities._PrintOptions(mime)
+        for f in (
+            x,
+            2.0 * x + 1.0,
+            2.0 * x + 1.0 + 1.0 * x * y + 2.0 * x * x,
+            MOI.Utilities.vectorize([x, y]),
+            MOI.Utilities.vectorize([x, 2 // 3 * y + 1 // 4]),
+        )
+            result = MOI.Utilities._to_string(options, model, f)
+            @test sprint(show, mime, f) == result
+        end
+    end
+    return
+end
+
 end
 
 TestPrint.runtests()

--- a/test/Utilities/print.jl
+++ b/test/Utilities/print.jl
@@ -679,8 +679,8 @@ function test_default_printing()
     x = MOI.VariableIndex(1)
     y = MOI.VariableIndex(2)
     aff = 2.0 * x + 1.0
-    model = MOI.Utilities._NoVariableNameModel()
     for mime in (MIME("text/plain"), MIME("text/latex"))
+        model = MOI.Utilities._NoVariableNameModel{typeof(mime)}()
         options = MOI.Utilities._PrintOptions(mime)
         for f in (
             x,
@@ -693,6 +693,8 @@ function test_default_printing()
             @test sprint(show, mime, f) == result
         end
     end
+    @test sprint(show, MIME("text/plain"), x) == "MOI.VariableIndex(1)"
+    @test sprint(show, MIME("text/latex"), x) == "v_{1}"
     return
 end
 


### PR DESCRIPTION
Closes #2111 

Open to ideas for what we should print, exactly.

Docstrings can all be updated using `--fix` when building the docs:

```julia
julia> ARGS
1-element Vector{String}:
 "--fix"

julia> include("docs/make.jl")
WARNING: redefinition of constant _PAGES. This may fail, cause incorrect answers, or produce other errors.
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: Doctest: running doctests.
[ Info: Skipped ExpandTemplates step (doctest only).
[ Info: Skipped CrossReferences step (doctest only).
[ Info: Skipped CheckDocument step (doctest only).
[ Info: Skipped Populate step (doctest only).
[ Info: Skipped RenderDocument step (doctest only).
  3.325270 seconds (4.70 M allocations: 319.401 MiB, 3.95% gc time)
┌ Warning: Documenter could not auto-detect the building environment Skipping deployment.
└ @ Documenter ~/.julia/packages/Documenter/H5y27/src/deployconfig.jl:75
```