### PR TITLE
Prep for v1.13.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.13.0"
+version = "1.13.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,14 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.13.1 (March 3, 2022)
+
+### Other
+
+ - Added the Google style guide to the documentation linter Vale, and fixed the
+   resulting warnings (#2110)
+ - Improved the docstrings in `src/functions.jl` (#2108)
+
 ## v1.13.0 (February 28, 2022)
 
 ### Added


### PR DESCRIPTION
This release is necessary so that I can add the Google style guide to the full JuMP documentation.