### PR TITLE
[Nonlinear] fix splatting when collection does not support reverse

### DIFF
--- a/src/Nonlinear/parse.jl
+++ b/src/Nonlinear/parse.jl
@@ -87,11 +87,8 @@ function _parse_splat_expression(stack, data, expr, x, parent_index)
             "`(x + 1)...`, `[x; y]...` and `g(f(y)...)` are not.",
         )
     end
-    # It isn't sufficient to call `reverse` here, because the collection might
-    # not support it. Iterate over the reverse of the collected indices instead,
-    # which _does_ work in all(?) cases.
-    for i in reverse(collect(eachindex(x.args[1])))
-        push!(stack, (parent_index, x.args[1][i]))
+    for arg in Iterators.Reverse(x.args[1])
+        push!(stack, (parent_index, arg))
     end
     return
 end

--- a/src/Nonlinear/parse.jl
+++ b/src/Nonlinear/parse.jl
@@ -87,8 +87,11 @@ function _parse_splat_expression(stack, data, expr, x, parent_index)
             "`(x + 1)...`, `[x; y]...` and `g(f(y)...)` are not.",
         )
     end
-    for xi in reverse(x.args[1])
-        push!(stack, (parent_index, xi))
+    # It isn't sufficient to call `reverse` here, because the collection might
+    # not support it. Iterate over the reverse of the collected indices instead,
+    # which _does_ work in all(?) cases.
+    for i in reverse(collect(eachindex(x.args[1])))
+        push!(stack, (parent_index, x.args[1][i]))
     end
     return
 end

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -973,6 +973,22 @@ function test_pow_complex_result()
     return
 end
 
+struct _NoReverse{T} <: AbstractArray{T,1}
+    data::Vector{T}
+end
+
+Base.eachindex(x::_NoReverse) = eachindex(x.data)
+Base.getindex(x::_NoReverse, args...) = getindex(x.data, args...)
+
+function test_parse_splat_no_reverse()
+    model = Nonlinear.Model()
+    x = MOI.VariableIndex.(1:2)
+    y = _NoReverse(x)
+    expr = Nonlinear.parse_expression(model, :(+($y...)))
+    @test expr == Nonlinear.parse_expression(model, :(+($(x[1]), $(x[2]))))
+    return
+end
+
 end
 
 TestNonlinear.runtests()


### PR DESCRIPTION
A common example of such a type is a DenseAxisArray.

Raised on Discourse: https://discourse.julialang.org/t/issue-with-memoization-with-jump-for-nlp-when-adding-nlobjective/96033