### PR TITLE
[Bridges] change print_active_bridges to use types instead of runtime objects

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -360,6 +360,9 @@ function _general_bridge_tests(bridge::B) where {B<:AbstractBridge}
         length(MOI.get(bridge, MOI.ListOfVariableIndices())) ==
         MOI.get(bridge, MOI.NumberOfVariables())
     )
+    # If zero variables, must have no constrained variable types, and vice versa
+    @test (MOI.get(bridge, MOI.NumberOfVariables()) == 0) ==
+          isempty(added_constrained_variable_types(B))
     if B <: Objective.AbstractBridge
         Test.@test set_objective_function_type(B) <: MOI.AbstractFunction
     end

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -361,8 +361,8 @@ function _general_bridge_tests(bridge::B) where {B<:AbstractBridge}
         MOI.get(bridge, MOI.NumberOfVariables())
     )
     # If zero variables, must have no constrained variable types, and vice versa
-    @test (MOI.get(bridge, MOI.NumberOfVariables()) == 0) ==
-          isempty(added_constrained_variable_types(B))
+    Test.@test (MOI.get(bridge, MOI.NumberOfVariables()) == 0) ==
+               isempty(added_constrained_variable_types(B))
     if B <: Objective.AbstractBridge
         Test.@test set_objective_function_type(B) <: MOI.AbstractFunction
     end

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -360,9 +360,9 @@ function _general_bridge_tests(bridge::B) where {B<:AbstractBridge}
         length(MOI.get(bridge, MOI.ListOfVariableIndices())) ==
         MOI.get(bridge, MOI.NumberOfVariables())
     )
-    # If zero variables, must have no constrained variable types, and vice versa
-    Test.@test (MOI.get(bridge, MOI.NumberOfVariables()) == 0) ==
-               isempty(added_constrained_variable_types(B))
+    if MOI.get(bridge, MOI.NumberOfVariables()) > 0
+        Test.@test !isempty(added_constrained_variable_types(B))
+    end
     if B <: Objective.AbstractBridge
         Test.@test set_objective_function_type(B) <: MOI.AbstractFunction
     end

--- a/src/Bridges/Constraint/bridges/count_distinct_reif.jl
+++ b/src/Bridges/Constraint/bridges/count_distinct_reif.jl
@@ -129,7 +129,7 @@ end
 function MOI.Bridges.added_constrained_variable_types(
     ::Type{<:ReifiedCountDistinctToMILPBridge},
 )
-    return Tuple{Type}[(MOI.ZeroOne,)]
+    return Tuple{Type}[(MOI.Reals,), (MOI.ZeroOne,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/Constraint/bridges/det.jl
+++ b/src/Bridges/Constraint/bridges/det.jl
@@ -144,7 +144,7 @@ function MOI.supports_constraint(
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:LogDetBridge})
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.Reals,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/Constraint/bridges/det.jl
+++ b/src/Bridges/Constraint/bridges/det.jl
@@ -366,7 +366,7 @@ function MOI.supports_constraint(
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:RootDetBridge})
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.Reals,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/Constraint/bridges/geomean.jl
+++ b/src/Bridges/Constraint/bridges/geomean.jl
@@ -173,7 +173,7 @@ function MOI.supports_constraint(
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:GeoMeanBridge})
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.Reals,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/Constraint/bridges/indicator_sos.jl
+++ b/src/Bridges/Constraint/bridges/indicator_sos.jl
@@ -99,7 +99,7 @@ end
 function MOI.Bridges.added_constrained_variable_types(
     ::Type{<:IndicatorSOS1Bridge},
 )
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.Reals,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/Constraint/bridges/norm_one.jl
+++ b/src/Bridges/Constraint/bridges/norm_one.jl
@@ -60,7 +60,7 @@ function MOI.supports_constraint(
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:NormOneBridge})
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.Reals,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/Constraint/bridges/norm_spec_nuc_to_psd.jl
+++ b/src/Bridges/Constraint/bridges/norm_spec_nuc_to_psd.jl
@@ -316,7 +316,7 @@ end
 function MOI.Bridges.added_constrained_variable_types(
     ::Type{<:NormNuclearBridge},
 )
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.Reals,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/Constraint/bridges/relentr_to_exp.jl
+++ b/src/Bridges/Constraint/bridges/relentr_to_exp.jl
@@ -78,7 +78,7 @@ end
 function MOI.Bridges.added_constrained_variable_types(
     ::Type{<:RelativeEntropyBridge},
 )
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.Reals,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/Constraint/bridges/table.jl
+++ b/src/Bridges/Constraint/bridges/table.jl
@@ -89,7 +89,7 @@ end
 function MOI.Bridges.added_constrained_variable_types(
     ::Type{<:TableToMILPBridge},
 )
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.Reals,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -88,7 +88,7 @@ function supports_objective_function(
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:SlackBridge})
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.Reals,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/Objective/bridges/vector_slack.jl
+++ b/src/Bridges/Objective/bridges/vector_slack.jl
@@ -102,7 +102,7 @@ end
 function MOI.Bridges.added_constrained_variable_types(
     ::Type{<:VectorSlackBridge},
 )
-    return Tuple{Type}[]
+    return Tuple{Type}[(MOI.Reals,)]
 end
 
 function MOI.Bridges.added_constraint_types(

--- a/src/Bridges/bridge.jl
+++ b/src/Bridges/bridge.jl
@@ -192,7 +192,11 @@ type `BT` add.
 
 ## Implementation notes
 
- * This method depends only on the type of the bridge, not the runtime value.
+ * This method depends only on the type of the bridge, not the runtime value. If
+   the bridge _may_ add a constrained variable, the type _must_ be included in
+   the return vector.
+ * If the bridge adds a free variable via [`MOI.add_variable`](@ref) or
+   [`MOI.add_variables`](@ref), the return vector _must_ include `(MOI.Reals,)`.
 
 ## Example
 
@@ -216,7 +220,9 @@ add.
 
 ## Implementation notes
 
- * This method depends only on the type of the bridge, not the runtime value.
+ * This method depends only on the type of the bridge, not the runtime value. If
+   the bridge _may_ add a constraint, the type _must_ be included in the
+   return vector.
 
 ## Example
 

--- a/src/Bridges/debug.jl
+++ b/src/Bridges/debug.jl
@@ -623,7 +623,8 @@ end
     print_active_bridges(
         [io::IO=stdout,]
         b::MOI.Bridges.LazyBridgeOptimizer,
-        F::Type{<:MOI.AbstractFunction}
+        F::Type{<:MOI.AbstractFunction},
+        S::Type{<:MOI.AbstractSet},
     )
 
 Print the set of bridges required for a constraint of type `F`-in-`S`.

--- a/src/Bridges/debug.jl
+++ b/src/Bridges/debug.jl
@@ -233,6 +233,9 @@ function print_unsupported(io::IO, b::LazyBridgeOptimizer, node::VariableNode)
         b.graph.variable_edges[node.index],
         bridge_index -> _bridge_type(b, node, bridge_index),
     )
+    if b.variable_types[node.index] == (MOI.Reals,)
+        return
+    end
     print(io, "   Cannot add free variables and then constrain them because")
     constraint_node = b.graph.variable_constraint_node[node.index]
     if constraint_node.index == -1

--- a/src/Bridges/debug.jl
+++ b/src/Bridges/debug.jl
@@ -537,18 +537,18 @@ Print the set of bridges that are active in the model `b`.
 """
 function print_active_bridges(io::IO, b::MOI.Bridges.LazyBridgeOptimizer)
     F = MOI.get(b, MOI.ObjectiveFunctionType())
-    _print_objective_tree(io, b, F, "")
+    print_active_bridges(io, b, F)
     types = MOI.get(b, MOI.ListOfConstraintTypesPresent())
     # We add a sort here to make the order reproducible, and to group similar
     # constraints together.
     for (F, S) in sort(types; by = string)
-        _print_constraint_tree(io, b, F, S, "")
+        print_active_bridges(io, b, F, S)
     end
     return
 end
 
-function print_active_bridges(b::MOI.Bridges.LazyBridgeOptimizer)
-    return print_active_bridges(stdout, b)
+function print_active_bridges(b::MOI.Bridges.LazyBridgeOptimizer, args...)
+    return print_active_bridges(stdout, b, args...)
 end
 
 function _print_supported(io, arg...)
@@ -561,23 +561,41 @@ function _print_unsupported(io, arg...)
     return Printf.printstyled(io, s; bold = false, color = :red)
 end
 
-function _print_bridge(io, b, bridge::BT, offset) where {BT}
+function _print_bridge(io, b, ::Type{BT}, offset) where {BT}
     new_offset = offset * " |  "
     for (F, S) in MOI.Bridges.added_constraint_types(BT)
-        _print_constraint_tree(io, b, F, S, new_offset)
+        print_active_bridges(io, b, F, S, new_offset)
     end
     for (S,) in MOI.Bridges.added_constrained_variable_types(BT)
-        _print_variable_tree(io, b, S, new_offset)
-    end
-    for x in MOI.get(bridge, MOI.ListOfVariableIndices())
-        if MOI.Bridges.is_bridged(b, x)
-            _print_variable(io, b, MOI.Reals, x, new_offset)
-        end
+        print_active_bridges(io, b, S, new_offset)
     end
     return
 end
 
-function _print_objective_tree(io, b, F, offset)
+"""
+    print_active_bridges(
+        [io::IO=stdout,]
+        b::MOI.Bridges.LazyBridgeOptimizer,
+        F::Type{<:MOI.AbstractFunction}
+    )
+
+Print the set of bridges required for an objective function of type `F`.
+"""
+function print_active_bridges(
+    io::IO,
+    b::MOI.Bridges.LazyBridgeOptimizer,
+    ::Type{F},
+    offset::String = "",
+) where {F<:MOI.AbstractFunction}
+    if !MOI.supports(b, MOI.ObjectiveFunction{F}())
+        throw(
+            MOI.UnsupportedAttribute(
+                MOI.ObjectiveFunction{F}(),
+                "The objective function cannot be bridged using the set of " *
+                "avaialble bridges.",
+            )
+        )
+    end
     if !MOI.Bridges.is_bridged(b, F)
         print(io, offset, " * ")
         _print_supported(io, "Supported objective: $F\n")
@@ -585,95 +603,125 @@ function _print_objective_tree(io, b, F, offset)
     end
     print(io, offset, " * ")
     _print_unsupported(io, "Unsupported objective: $F\n")
-    bridge = b.objective_map[MOI.ObjectiveFunction{F}()]
+    index = MOI.Bridges.bridge_index(b.graph, b.objective_node[(F,)])
+    B = b.objective_bridge_types[index]
+    BT = MOI.Bridges.Objective.concrete_bridge_type(B, F)
     println(io, offset, " |  bridged by:")
     print(io, offset, " |   ")
-    BT = typeof(bridge)
-    MOI.Utilities.print_with_acronym(io, "$(BT)\n")
-    println(io, offset, " |  introduces:")
-    # Only objective bridges can create new objective trees.
-    new_f = MOI.Bridges.set_objective_function_type(BT)
-    _print_objective_tree(io, b, new_f, offset * " |  ")
-    _print_bridge(io, b, bridge, offset)
+    MOI.Utilities.print_with_acronym(io, "$BT\n")
+    println(io, offset, " |  may introduce:")
+    G = MOI.Bridges.set_objective_function_type(BT)
+    print_active_bridges(io, b, G, offset * " |  ")
+    _print_bridge(io, b, BT, offset)
     return
 end
 
-function _print_constraint_tree(io, b, F, S, offset)
+"""
+    print_active_bridges(
+        [io::IO=stdout,]
+        b::MOI.Bridges.LazyBridgeOptimizer,
+        F::Type{<:MOI.AbstractFunction}
+    )
+
+Print the set of bridges required for a constraint of type `F`-in-`S`.
+"""
+function print_active_bridges(
+    io::IO,
+    b::MOI.Bridges.LazyBridgeOptimizer,
+    ::Type{F},
+    ::Type{S},
+    offset::String = "",
+) where {F<:MOI.AbstractFunction,S<:MOI.AbstractSet}
+    if !MOI.supports_constraint(b, F, S)
+        throw(
+            MOI.UnsupportedConstraint{F,S}(
+                "The constraint cannot be bridged using the set of available " *
+                "bridges.",
+            ),
+        )
+    end
     if !MOI.Bridges.is_bridged(b, F, S)
-        # This constraint is natively supported.
         print(io, offset, " * ")
         _print_supported(io, "Supported constraint: $F-in-$S\n")
         return
     end
-    for (ci, bridge) in b.constraint_map
-        # Loop through bridged constraints to see if any F,S are bridged
-        if ci isa MOI.ConstraintIndex{F,S}
-            # The exact `ci` doesn't matter, only the type.
-            print(io, offset, " * ")
-            _print_unsupported(io, "Unsupported constraint: $F-in-$S\n")
-            BT = typeof(bridge)
-            println(io, offset, " |  bridged by:")
-            print(io, offset, " |   ")
-            MOI.Utilities.print_with_acronym(io, "$(BT)\n")
-            println(io, offset, " |  introduces:")
-            _print_bridge(io, b, bridge, offset)
-            return
+    is_constraint_bridged = true
+    c_node = b.constraint_node[(F, S)]
+    if F == MOI.VariableIndex || F == MOI.VectorOfVariables
+        if !haskey(b.variable_node, (S,))
+            debug(b, S; io = devnull)
+        end
+        v_node = b.variable_node[(S,)]
+        if bridging_cost(b.graph, v_node) <= bridging_cost(b.graph, c_node)
+            is_constraint_bridged = false
         end
     end
-    # If we get here, (F, S) isn't bridged by a constraint bridge.
-    if MOI.get(b, MOI.NumberOfConstraints{F,S}()) > 0
-        _print_variable_tree(io, b, S, offset)
+    if is_constraint_bridged
+        index = MOI.Bridges.bridge_index(b.graph, c_node)
+        B = b.constraint_bridge_types[index]
+        BT = MOI.Bridges.Constraint.concrete_bridge_type(B, F, S)
+        print(io, offset, " * ")
+        _print_unsupported(io, "Unsupported constraint: $F-in-$S\n")
+        println(io, offset, " |  bridged by:")
+        print(io, offset, " |   ")
+        MOI.Utilities.print_with_acronym(io, "$BT\n")
+        println(io, offset, " |  may introduce:")
+        _print_bridge(io, b, BT, offset)
+    else
+        print_active_bridges(io, b, S, offset)
     end
     return
 end
 
-function _print_variable(io, b, S, x, offset)
+"""
+    print_active_bridges(
+        [io::IO=stdout,]
+        b::MOI.Bridges.LazyBridgeOptimizer,
+        S::Type{<:MOI.AbstractSet}
+    )
+
+Print the set of bridges required for a variable constrained to set `S`.
+"""
+function print_active_bridges(
+    io::IO,
+    b::MOI.Bridges.LazyBridgeOptimizer,
+    ::Type{S},
+    offset::String = "",
+) where {S<:MOI.AbstractSet}
+    if S <: MOI.AbstractScalarSet
+        if !MOI.supports_add_constrained_variable(b, S)
+            throw(
+                MOI.UnsupportedConstraint{MOI.VariableIndex,S}(
+                    "The variable cannot be bridged using the set of " *
+                    "available bridges.",
+                ),
+            )
+        end
+    else
+        @assert S <: MOI.AbstractVectorSet
+        if !MOI.supports_add_constrained_variables(b, S)
+            throw(
+                MOI.UnsupportedConstraint{MOI.VectorOfVariables,S}(
+                    "The variables cannot be bridged using the set of " *
+                    "available bridges.",
+                ),
+            )
+        end
+    end
+    if !MOI.Bridges.is_bridged(b, S)
+        print(io, offset, " * ")
+        _print_supported(io, "Supported variable: $S\n")
+        return
+    end
+    index = MOI.Bridges.bridge_index(b.graph, b.variable_node[(S,)])
+    B = b.variable_bridge_types[index]
+    BT = MOI.Bridges.Variable.concrete_bridge_type(B, S)
     print(io, offset, " * ")
     _print_unsupported(io, "Unsupported variable: $S\n")
-    bridge = b.variable_map[x]
     println(io, offset, " |  bridged by:")
     print(io, offset, " |    ")
-    MOI.Utilities.print_with_acronym(io, "$(typeof(bridge))\n")
-    println(io, offset, " |  introduces:")
-    _print_bridge(io, b, bridge, offset)
-    return
-end
-
-function _print_variable_tree(io, b, S::Type{<:MOI.AbstractVectorSet}, offset)
-    if !MOI.Bridges.is_bridged(b, S)
-        print(io, offset, " * ")
-        _print_supported(io, "Supported variable: $S\n")
-        return
-    end
-    indices = MOI.get(b, MOI.ListOfConstraintIndices{MOI.VectorOfVariables,S}())
-    if length(indices) > 0
-        @assert MOI.Bridges.is_bridged(b, MOI.VectorOfVariables, S)
-        ci = first(indices)
-        f = MOI.get(b, MOI.ConstraintFunction(), ci)
-        for x in f.variables
-            if haskey(b.variable_map, x)
-                _print_variable(io, b, S, x, offset)
-                break
-            end
-        end
-    end
-    return
-end
-
-function _print_variable_tree(io, b, S::Type{<:MOI.AbstractScalarSet}, offset)
-    if !MOI.Bridges.is_bridged(b, S)
-        print(io, offset, " * ")
-        _print_supported(io, "Supported variable: $S\n")
-        return
-    end
-    indices = MOI.get(b, MOI.ListOfConstraintIndices{MOI.VariableIndex,S}())
-    if length(indices) > 0
-        @assert MOI.Bridges.is_bridged(b, MOI.VariableIndex, S)
-        ci = first(indices)
-        x = MOI.get(b, MOI.ConstraintFunction(), ci)
-        if haskey(b.variable_map, x)
-            _print_variable(io, b, S, x, offset)
-        end
-    end
+    MOI.Utilities.print_with_acronym(io, "$BT\n")
+    println(io, offset, " |  may introduce:")
+    _print_bridge(io, b, BT, offset)
     return
 end

--- a/src/Bridges/debug.jl
+++ b/src/Bridges/debug.jl
@@ -592,8 +592,8 @@ function print_active_bridges(
             MOI.UnsupportedAttribute(
                 MOI.ObjectiveFunction{F}(),
                 "The objective function cannot be bridged using the set of " *
-                "avaialble bridges.",
-            )
+                "available bridges.",
+            ),
         )
     end
     if !MOI.Bridges.is_bridged(b, F)

--- a/src/Bridges/debug.jl
+++ b/src/Bridges/debug.jl
@@ -648,8 +648,12 @@ function print_active_bridges(
     is_constraint_bridged = true
     c_node = b.constraint_node[(F, S)]
     if F == MOI.VariableIndex || F == MOI.VectorOfVariables
-        if !haskey(b.variable_node, (S,))
-            debug(b, S; io = devnull)
+        # Call `MOI.supports_` here to build the necessary nodes in the bridging
+        # graph.
+        if F == MOI.VariableIndex
+            MOI.supports_add_constrained_variable(b, S)
+        else
+            MOI.supports_add_constrained_variables(b, S)
         end
         v_node = b.variable_node[(S,)]
         if bridging_cost(b.graph, v_node) <= bridging_cost(b.graph, c_node)

--- a/test/Bridges/debug.jl
+++ b/test/Bridges/debug.jl
@@ -70,54 +70,59 @@ function test_print_active_bridges()
  * Unsupported objective: MOI.ScalarQuadraticFunction{Float64}
  |  bridged by:
  |   MOIB.Objective.SlackBridge{Float64, MOI.ScalarQuadraticFunction{Float64}, MOI.ScalarQuadraticFunction{Float64}}
- |  introduces:
+ |  may introduce:
  |   * Unsupported objective: MOI.VariableIndex
  |   |  bridged by:
  |   |   MOIB.Objective.FunctionizeBridge{Float64}
- |   |  introduces:
+ |   |  may introduce:
  |   |   * Supported objective: MOI.ScalarAffineFunction{Float64}
+ |   * Unsupported constraint: MOI.ScalarQuadraticFunction{Float64}-in-MOI.GreaterThan{Float64}
+ |   |  bridged by:
+ |   |   MOIB.Constraint.QuadtoSOCBridge{Float64}
+ |   |  may introduce:
+ |   |   * Supported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.RotatedSecondOrderCone
  |   * Unsupported constraint: MOI.ScalarQuadraticFunction{Float64}-in-MOI.LessThan{Float64}
  |   |  bridged by:
  |   |   MOIB.Constraint.QuadtoSOCBridge{Float64}
- |   |  introduces:
+ |   |  may introduce:
  |   |   * Supported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.RotatedSecondOrderCone
  |   * Unsupported variable: MOI.Reals
  |   |  bridged by:
  |   |    MOIB.Variable.FreeBridge{Float64}
- |   |  introduces:
+ |   |  may introduce:
  |   |   * Supported variable: MOI.Nonnegatives
  * Unsupported constraint: MOI.ScalarAffineFunction{Float64}-in-MOI.EqualTo{Float64}
  |  bridged by:
  |   MOIB.Constraint.VectorizeBridge{Float64, MOI.VectorAffineFunction{Float64}, MOI.Zeros, MOI.ScalarAffineFunction{Float64}}
- |  introduces:
+ |  may introduce:
  |   * Supported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.Zeros
  * Unsupported constraint: MOI.ScalarAffineFunction{Float64}-in-MOI.Interval{Float64}
  |  bridged by:
  |   MOIB.Constraint.SplitIntervalBridge{Float64, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}, MOI.GreaterThan{Float64}, MOI.LessThan{Float64}}
- |  introduces:
+ |  may introduce:
  |   * Unsupported constraint: MOI.ScalarAffineFunction{Float64}-in-MOI.GreaterThan{Float64}
  |   |  bridged by:
  |   |   MOIB.Constraint.VectorizeBridge{Float64, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives, MOI.ScalarAffineFunction{Float64}}
- |   |  introduces:
+ |   |  may introduce:
  |   |   * Supported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.Nonnegatives
  |   * Unsupported constraint: MOI.ScalarAffineFunction{Float64}-in-MOI.LessThan{Float64}
  |   |  bridged by:
  |   |   MOIB.Constraint.VectorizeBridge{Float64, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives, MOI.ScalarAffineFunction{Float64}}
- |   |  introduces:
+ |   |  may introduce:
  |   |   * Unsupported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.Nonpositives
  |   |   |  bridged by:
  |   |   |   MOIB.Constraint.NonposToNonnegBridge{Float64, MOI.VectorAffineFunction{Float64}, MOI.VectorAffineFunction{Float64}}
- |   |   |  introduces:
+ |   |   |  may introduce:
  |   |   |   * Supported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.Nonnegatives
  * Unsupported constraint: MOI.ScalarQuadraticFunction{Float64}-in-MOI.LessThan{Float64}
  |  bridged by:
  |   MOIB.Constraint.QuadtoSOCBridge{Float64}
- |  introduces:
+ |  may introduce:
  |   * Supported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.RotatedSecondOrderCone
  * Unsupported variable: MOI.Nonpositives
  |  bridged by:
  |    MOIB.Variable.NonposToNonnegBridge{Float64}
- |  introduces:
+ |  may introduce:
  |   * Supported variable: MOI.Nonnegatives
 """
     # Prints to stdout, but just check it doesn't error.
@@ -162,7 +167,7 @@ function test_print_active_bridges_parameter()
  * Unsupported variable: MOI.Parameter{Float64}
  |  bridged by:
  |    MOIB.Variable.ParameterToEqualToBridge{Float64}
- |  introduces:
+ |  may introduce:
  |   * Supported variable: MOI.EqualTo{Float64}
 """
     return

--- a/test/Bridges/debug.jl
+++ b/test/Bridges/debug.jl
@@ -270,6 +270,10 @@ function test_print_active_bridges_variable_unsupported()
         MOI.UnsupportedConstraint{MOI.VariableIndex,MOI.ZeroOne},
         MOI.Bridges.print_active_bridges(model, MOI.ZeroOne),
     )
+    @test_throws(
+        MOI.UnsupportedConstraint{MOI.VectorOfVariables,MOI.ExponentialCone},
+        MOI.Bridges.print_active_bridges(model, MOI.ExponentialCone),
+    )
     return
 end
 

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -972,7 +972,6 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
             """
 Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported and cannot be bridged into a supported objective function by adding only supported constrained variables and constraints. See details below:
  [1] constrained variables in `MOI.Reals` are not supported because no added bridge supports bridging it.
-   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
  (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because no added bridge supports bridging it.
  (2) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
  |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported because:
@@ -997,7 +996,6 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
             """
 Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported and cannot be bridged into a supported objective function by adding only supported constrained variables and constraints. See details below:
  [1] constrained variables in `MOI.Reals` are not supported because no added bridge supports bridging it.
-   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
  (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because:
    Cannot use `$(MOI.Bridges.Constraint.QuadtoSOCBridge{T})` because:
    (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
@@ -1021,7 +1019,6 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
             """
 Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported and cannot be bridged into a supported objective function by adding only supported constrained variables and constraints. See details below:
  [1] constrained variables in `MOI.Reals` are not supported because no added bridge supports bridging it.
-   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
  [2] constrained variables in `MOI.RotatedSecondOrderCone` are not supported because no added bridge supports bridging it.
    Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
  (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because:
@@ -1052,7 +1049,6 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
             """
 Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported and cannot be bridged into a supported objective function by adding only supported constrained variables and constraints. See details below:
  [1] constrained variables in `MOI.Reals` are not supported because no added bridge supports bridging it.
-   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
  (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because:
    Cannot use `$(MOI.Bridges.Constraint.QuadtoSOCBridge{T})` because:
    (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -971,10 +971,13 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
               MOI.Utilities.replace_acronym(
             """
 Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported and cannot be bridged into a supported objective function by adding only supported constrained variables and constraints. See details below:
+ [1] constrained variables in `MOI.Reals` are not supported because no added bridge supports bridging it.
+   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
  (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because no added bridge supports bridging it.
  (2) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because no added bridge supports bridging it.
  |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported because:
    Cannot use `$(MOI.Bridges.Objective.SlackBridge{T,MOI.ScalarQuadraticFunction{T},MOI.ScalarQuadraticFunction{T}})` because:
+   [1] constrained variables in `MOI.Reals` are not supported
    (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported
    (2) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
    |2| objective function of type `MOI.VariableIndex` is not supported
@@ -993,6 +996,8 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
               MOI.Utilities.replace_acronym(
             """
 Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported and cannot be bridged into a supported objective function by adding only supported constrained variables and constraints. See details below:
+ [1] constrained variables in `MOI.Reals` are not supported because no added bridge supports bridging it.
+   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
  (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because:
    Cannot use `$(MOI.Bridges.Constraint.QuadtoSOCBridge{T})` because:
    (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
@@ -1002,6 +1007,7 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
    (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
  |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported because:
    Cannot use `$(MOI.Bridges.Objective.SlackBridge{T,MOI.ScalarQuadraticFunction{T},MOI.ScalarQuadraticFunction{T}})` because:
+   [1] constrained variables in `MOI.Reals` are not supported
    (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported
    (3) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
 """,
@@ -1014,14 +1020,16 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
               MOI.Utilities.replace_acronym(
             """
 Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported and cannot be bridged into a supported objective function by adding only supported constrained variables and constraints. See details below:
- [1] constrained variables in `MOI.RotatedSecondOrderCone` are not supported because no added bridge supports bridging it.
+ [1] constrained variables in `MOI.Reals` are not supported because no added bridge supports bridging it.
+   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
+ [2] constrained variables in `MOI.RotatedSecondOrderCone` are not supported because no added bridge supports bridging it.
    Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
  (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because:
    Cannot use `$(MOI.Bridges.Constraint.QuadtoSOCBridge{T})` because:
    (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
  (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported because:
    Cannot use `$(MOI.Bridges.Constraint.VectorSlackBridge{T,MOI.VectorAffineFunction{T},MOI.RotatedSecondOrderCone})` because:
-   [1] constrained variables in `MOI.RotatedSecondOrderCone` are not supported
+   [2] constrained variables in `MOI.RotatedSecondOrderCone` are not supported
    (3) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported
  (3) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are not supported because no added bridge supports bridging it.
  (4) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported because:
@@ -1029,6 +1037,7 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
    (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
  |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported because:
    Cannot use `$(MOI.Bridges.Objective.SlackBridge{T,MOI.ScalarQuadraticFunction{T},MOI.ScalarQuadraticFunction{T}})` because:
+   [1] constrained variables in `MOI.Reals` are not supported
    (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported
    (4) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
 """,
@@ -1042,6 +1051,8 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
               MOI.Utilities.replace_acronym(
             """
 Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported and cannot be bridged into a supported objective function by adding only supported constrained variables and constraints. See details below:
+ [1] constrained variables in `MOI.Reals` are not supported because no added bridge supports bridging it.
+   Cannot add free variables and then constrain them because free variables are bridged but no functionize bridge was added.
  (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported because:
    Cannot use `$(MOI.Bridges.Constraint.QuadtoSOCBridge{T})` because:
    (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
@@ -1054,6 +1065,7 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
    (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are not supported
  |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported because:
    Cannot use `$(MOI.Bridges.Objective.SlackBridge{T,MOI.ScalarQuadraticFunction{T},MOI.ScalarQuadraticFunction{T}})` because:
+   [1] constrained variables in `MOI.Reals` are not supported
    (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are not supported
    (5) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are not supported
 """,
@@ -1062,19 +1074,24 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
             bridged,
             MOI.Bridges.Constraint.ScalarizeBridge{T},
         )
+        MOI.Bridges.add_bridge(
+            bridged,
+            MOI.Bridges.Variable.FreeBridge{T},
+        )
         @test debug_string(MOI.Bridges.debug_supports, attr) ==
               "Objective function of type `MOI.ScalarQuadraticFunction{$T}` is supported.\n"
         @test sprint(MOI.Bridges.print_graph, bridged) ==
               MOI.Utilities.replace_acronym(
             """
-Bridge graph with 1 variable nodes, 5 constraint nodes and 2 objective nodes.
- [1] constrained variables in `MOI.RotatedSecondOrderCone` are bridged (distance 2) by $(MOI.Bridges.Variable.RSOCtoPSDBridge{T}).
+Bridge graph with 2 variable nodes, 5 constraint nodes and 2 objective nodes.
+ [1] constrained variables in `MOI.Reals` are bridged (distance 1) by $(MOI.Bridges.Variable.FreeBridge{T}).
+ [2] constrained variables in `MOI.RotatedSecondOrderCone` are bridged (distance 2) by $(MOI.Bridges.Variable.RSOCtoPSDBridge{T}).
  (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are bridged (distance 5) by $(MOI.Bridges.Constraint.QuadtoSOCBridge{T}).
  (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are bridged (distance 4) by $(MOI.Bridges.Constraint.VectorSlackBridge{T,MOI.VectorAffineFunction{T},MOI.RotatedSecondOrderCone}).
  (3) `MOI.VariableIndex`-in-`MOI.EqualTo{$T}` constraints are bridged (distance 1) by $(MOI.Bridges.Constraint.ScalarFunctionizeBridge{T,MOI.EqualTo{T}}).
  (4) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are bridged (distance 1) by $(MOI.Bridges.Constraint.ScalarizeBridge{T,MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}).
  (5) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are bridged (distance 5) by $(MOI.Bridges.Constraint.QuadtoSOCBridge{T}).
- |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is bridged (distance 12) by $(MOI.Bridges.Objective.SlackBridge{T,MOI.ScalarQuadraticFunction{T},MOI.ScalarQuadraticFunction{T}}).
+ |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is bridged (distance 13) by $(MOI.Bridges.Objective.SlackBridge{T,MOI.ScalarQuadraticFunction{T},MOI.ScalarQuadraticFunction{T}}).
  |2| objective function of type `MOI.VariableIndex` is bridged (distance 1) by $(MOI.Bridges.Objective.FunctionizeBridge{T}).
 """,
         )

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -1074,10 +1074,7 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
             bridged,
             MOI.Bridges.Constraint.ScalarizeBridge{T},
         )
-        MOI.Bridges.add_bridge(
-            bridged,
-            MOI.Bridges.Variable.FreeBridge{T},
-        )
+        MOI.Bridges.add_bridge(bridged, MOI.Bridges.Variable.FreeBridge{T})
         @test debug_string(MOI.Bridges.debug_supports, attr) ==
               "Objective function of type `MOI.ScalarQuadraticFunction{$T}` is supported.\n"
         @test sprint(MOI.Bridges.print_graph, bridged) ==

--- a/test/Bridges/utilities.jl
+++ b/test/Bridges/utilities.jl
@@ -14,6 +14,9 @@ end
 
 function _warn_incomplete_list_num_constraints(BT, list_num_constraints)
     for (S,) in MOI.Bridges.added_constrained_variable_types(BT)
+        if S == MOI.Reals
+            continue
+        end
         F = MOI.Utilities.variable_function_type(S)
         if !any(c -> c[1] == F && c[2] == S, list_num_constraints)
             error(


### PR DESCRIPTION
Working on https://github.com/jump-dev/JuMP.jl/issues/3301

But it required a little more work than I initially expected. 

To test out different functions and sets, we need to do it with the type information only. 

This mostly works, except that some bridges _may_ add some constraints depending on runtime values, whereas we must now report the union of all possible things added. This could be confusing, because it may say some things are added when the real model won't have them, but it clarifies that a solver must support all possible runtime constraints to use a bridge.

The main example of this is the objective slack bridge, which adds a `>=` or `<=` constraint, depending on the objective sense.

We also need bridges to report that they add `x in Reals` if they add variables.

TODO:

 - [x] more tests