### PR TITLE
[Bridges] fix bug in print_active_bridges

### DIFF
--- a/src/Bridges/debug.jl
+++ b/src/Bridges/debug.jl
@@ -721,15 +721,25 @@ function print_active_bridges(
         _print_supported(io, "Supported variable: $S\n")
         return
     end
-    index = MOI.Bridges.bridge_index(b.graph, b.variable_node[(S,)])
-    B = b.variable_bridge_types[index]
-    BT = MOI.Bridges.Variable.concrete_bridge_type(B, S)
-    print(io, offset, " * ")
-    _print_unsupported(io, "Unsupported variable: $S\n")
-    println(io, offset, " |  bridged by:")
-    print(io, offset, " |    ")
-    MOI.Utilities.print_with_acronym(io, "$BT\n")
-    println(io, offset, " |  may introduce:")
-    _print_bridge(io, b, BT, offset)
+    if MOI.Bridges.is_variable_edge_best(b.graph, b.variable_node[(S,)])
+        index = MOI.Bridges.bridge_index(b.graph, b.variable_node[(S,)])
+        B = b.variable_bridge_types[index]
+        BT = MOI.Bridges.Variable.concrete_bridge_type(B, S)
+        print(io, offset, " * ")
+        _print_unsupported(io, "Unsupported variable: $S\n")
+        println(io, offset, " |  bridged by:")
+        print(io, offset, " |    ")
+        MOI.Utilities.print_with_acronym(io, "$BT\n")
+        println(io, offset, " |  may introduce:")
+        _print_bridge(io, b, BT, offset)
+    else
+        print(io, offset, " * ")
+        _print_unsupported(io, "Unsupported variable: $S\n")
+        println(io, offset, " |  adding as constraint:")
+        offset = offset * " |  "
+        MOI.Bridges.print_active_bridges(io, b, MOI.Reals, offset)
+        F = MOI.Utilities.variable_function_type(S)
+        MOI.Bridges.print_active_bridges(io, b, F, S, offset)
+    end
     return
 end

--- a/test/Bridges/debug.jl
+++ b/test/Bridges/debug.jl
@@ -290,7 +290,8 @@ MOI.Utilities.@model(
 )
 
 function test_print_active_bridges_variable_bridged_with_constraint()
-    model = MOI.Bridges.full_bridge_optimizer(ConstraintModel{Float64}(), Float64)
+    model =
+        MOI.Bridges.full_bridge_optimizer(ConstraintModel{Float64}(), Float64)
     content = """
      * Unsupported variable: MOI.AllDifferent
      |  adding as constraint:

--- a/test/Bridges/debug.jl
+++ b/test/Bridges/debug.jl
@@ -277,6 +277,42 @@ function test_print_active_bridges_variable_unsupported()
     return
 end
 
+MOI.Utilities.@model(
+    ConstraintModel,
+    (MOI.ZeroOne, MOI.Integer),
+    (MOI.GreaterThan, MOI.LessThan, MOI.EqualTo),
+    (),
+    (),
+    (),
+    (MOI.ScalarAffineFunction,),
+    (),
+    ()
+)
+
+function test_print_active_bridges_variable_bridged_with_constraint()
+    model = MOI.Bridges.full_bridge_optimizer(ConstraintModel{Float64}(), Float64)
+    content = """
+     * Unsupported variable: MOI.AllDifferent
+     |  adding as constraint:
+     |   * Supported variable: MOI.Reals
+     |   * Unsupported constraint: MOI.VectorOfVariables-in-MOI.AllDifferent
+     |   |  bridged by:
+     |   |   MOIB.Constraint.AllDifferentToCountDistinctBridge{Float64, MOI.VectorOfVariables}
+     |   |  may introduce:
+     |   |   * Unsupported constraint: MOI.VectorOfVariables-in-MOI.CountDistinct
+     |   |   |  bridged by:
+     |   |   |   MOIB.Constraint.CountDistinctToMILPBridge{Float64, MOI.VectorOfVariables}
+     |   |   |  may introduce:
+     |   |   |   * Supported constraint: MOI.ScalarAffineFunction{Float64}-in-MOI.EqualTo{Float64}
+     |   |   |   * Supported constraint: MOI.ScalarAffineFunction{Float64}-in-MOI.LessThan{Float64}
+     |   |   |   * Supported variable: MOI.ZeroOne
+     |   |   * Supported variable: MOI.EqualTo{Float64}
+    """
+    S = MOI.AllDifferent
+    @test sprint(MOI.Bridges.print_active_bridges, model, S) === content
+    return
+end
+
 end
 
 TestBridgesDebug.runtests()


### PR DESCRIPTION
I missed an edge case: if a variable is unsupported and is bridged by a constraint instead.

x-ref https://github.com/jump-dev/JuMP.jl/issues/3301