### PR TITLE
Prep for v1.14.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.14.0"
+version = "1.14.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,17 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.14.1 (April 6, 2023)
+
+### Fixed
+
+ - Fixed a bug in [`Bridges.print_active_bridges`](@ref) (#2135)
+
+### Other
+
+ - Added a warning when an ambiguous string is passed to `exclude` in
+   [`Test.runtests`](@ref) (#2136)
+
 ## v1.14.0 (April 4, 2023)
 
 ### Added


### PR DESCRIPTION
This is needed before we can update JuMP's documentation: https://github.com/jump-dev/JuMP.jl/pull/3315.