### PR TITLE
[Bridges] fix deleting variable in bridged objective

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -587,7 +587,7 @@ function MOI.delete(b::AbstractBridgeOptimizer, vi::MOI.VariableIndex)
     F = MOI.get(b, MOI.ObjectiveFunctionType())
     if is_objective_bridged(b) && F == MOI.VectorOfVariables
         f = MOI.get(b, MOI.ObjectiveFunction{MOI.VectorOfVariables}())
-        if any(isequal(v1), f.variables)
+        if any(isequal(vi), f.variables)
             g = MOI.VectorOfVariables(filter(!isequal(vi), f.variables))
             MOI.set(b, MOI.ObjectiveFunction{MOI.VectorOfVariables}(), g)
         end

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -546,14 +546,14 @@ function _delete_variables_in_variables_constraints(
 end
 
 function MOI.delete(b::AbstractBridgeOptimizer, vis::Vector{MOI.VariableIndex})
-    if Constraint.has_bridges(Constraint.bridges(b))
-        _delete_variables_in_variables_constraints(b, vis)
-    end
     if is_objective_bridged(b)
         F = MOI.get(b, MOI.ObjectiveFunctionType())
         f = MOI.get(b, MOI.ObjectiveFunction{F}())
-        g = MOI.Utilities. filter_variables(v -> !Base.Fix2(in, vis), f)
+        g = MOI.Utilities.filter_variables(v -> !Base.Fix2(in, vis), f)
         MOI.set(b, MOI.ObjectiveFunction{typeof(g)}(), g)
+    end
+    if Constraint.has_bridges(Constraint.bridges(b))
+        _delete_variables_in_variables_constraints(b, vis)
     end
     if any(vi -> is_bridged(b, vi), vis)
         for vi in vis
@@ -581,14 +581,14 @@ function MOI.delete(b::AbstractBridgeOptimizer, vis::Vector{MOI.VariableIndex})
 end
 
 function MOI.delete(b::AbstractBridgeOptimizer, vi::MOI.VariableIndex)
-    if Constraint.has_bridges(Constraint.bridges(b))
-        _delete_variables_in_variables_constraints(b, [vi])
-    end
     if is_objective_bridged(b)
         F = MOI.get(b, MOI.ObjectiveFunctionType())
         f = MOI.get(b, MOI.ObjectiveFunction{F}())
         g = MOI.Utilities.remove_variable(f, vi)
         MOI.set(b, MOI.ObjectiveFunction{typeof(g)}(), g)
+    end
+    if Constraint.has_bridges(Constraint.bridges(b))
+        _delete_variables_in_variables_constraints(b, [vi])
     end
     if is_bridged(b, vi)
         MOI.throw_if_not_valid(b, vi)

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -549,6 +549,12 @@ function MOI.delete(b::AbstractBridgeOptimizer, vis::Vector{MOI.VariableIndex})
     if Constraint.has_bridges(Constraint.bridges(b))
         _delete_variables_in_variables_constraints(b, vis)
     end
+    if is_objective_bridged(b)
+        F = MOI.get(b, MOI.ObjectiveFunctionType())
+        f = MOI.get(b, MOI.ObjectiveFunction{F}())
+        g = MOI.Utilities. filter_variables(v -> !Base.Fix2(in, vis), f)
+        MOI.set(b, MOI.ObjectiveFunction{typeof(g)}(), g)
+    end
     if any(vi -> is_bridged(b, vi), vis)
         for vi in vis
             MOI.throw_if_not_valid(b, vi)
@@ -577,6 +583,12 @@ end
 function MOI.delete(b::AbstractBridgeOptimizer, vi::MOI.VariableIndex)
     if Constraint.has_bridges(Constraint.bridges(b))
         _delete_variables_in_variables_constraints(b, [vi])
+    end
+    if is_objective_bridged(b)
+        F = MOI.get(b, MOI.ObjectiveFunctionType())
+        f = MOI.get(b, MOI.ObjectiveFunction{F}())
+        g = MOI.Utilities.remove_variable(f, vi)
+        MOI.set(b, MOI.ObjectiveFunction{typeof(g)}(), g)
     end
     if is_bridged(b, vi)
         MOI.throw_if_not_valid(b, vi)

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -551,7 +551,7 @@ function MOI.delete(b::AbstractBridgeOptimizer, vis::Vector{MOI.VariableIndex})
         f = MOI.get(b, MOI.ObjectiveFunction{MOI.VectorOfVariables}())
         discard = Base.Fix2(in, vis)
         if any(discard, f.variables)
-            g = MOI.VectorOfVariables([x for x in f.variables if !discard(x)])
+            g = MOI.VectorOfVariables(filter(!discard, f.variables))
             MOI.set(b, MOI.ObjectiveFunction{MOI.VectorOfVariables}(), g)
         end
     end
@@ -587,8 +587,8 @@ function MOI.delete(b::AbstractBridgeOptimizer, vi::MOI.VariableIndex)
     F = MOI.get(b, MOI.ObjectiveFunctionType())
     if is_objective_bridged(b) && F == MOI.VectorOfVariables
         f = MOI.get(b, MOI.ObjectiveFunction{MOI.VectorOfVariables}())
-        if any(Base.Fix1(==, vi), f.variables)
-            g = MOI.VectorOfVariables([x for x in f.variables if x != vi])
+        if any(isequal(v1), f.variables)
+            g = MOI.VectorOfVariables(filter(!isequal(vi), f.variables))
             MOI.set(b, MOI.ObjectiveFunction{MOI.VectorOfVariables}(), g)
         end
     end

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -955,6 +955,18 @@ function test_delete_constraint_vector()
     return
 end
 
+function test_deleting_variable_in_bridged_objective()
+    inner = MOI.Utilities.Model{Float64}()
+    model = MOI.Bridges.Objective.VectorFunctionize{Float64}(inner)
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    attr = MOI.ObjectiveFunction{MOI.VectorOfVariables}()
+    MOI.set(model, attr, MOI.VectorOfVariables(x))
+    MOI.delete(model, x[1])
+    @test MOI.get(model, attr) == MOI.VectorOfVariables([x[2]])
+    return
+end
+
 end  # module
 
 TestBridgeOptimizer.runtests()

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -967,6 +967,18 @@ function test_deleting_variable_in_bridged_objective()
     return
 end
 
+function test_deleting_variables_in_bridged_objective()
+    inner = MOI.Utilities.Model{Float64}()
+    model = MOI.Bridges.Objective.VectorFunctionize{Float64}(inner)
+    x = MOI.add_variables(model, 2)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    attr = MOI.ObjectiveFunction{MOI.VectorOfVariables}()
+    MOI.set(model, attr, MOI.VectorOfVariables(x))
+    MOI.delete(model, [x[1]])
+    @test MOI.get(model, attr) == MOI.VectorOfVariables([x[2]])
+    return
+end
+
 end  # module
 
 TestBridgeOptimizer.runtests()


### PR DESCRIPTION
This is a bit of a weird case: if you delete a variable that was an objective, does the type of the objective change, or do we remove one of the objective rows?

I obviously thought so when writing the tests

https://github.com/jump-dev/MathOptInterface.jl/blob/403bc583628682ea6f11b4343fa91b621f2862cf/src/Test/test_multiobjective.jl#L21-L35

but I missed the case that this could also be bridged.