### PR TITLE
[FileFormats.MOF] update to v1.4

### DIFF
--- a/docs/src/developer/checklists.md
+++ b/docs/src/developer/checklists.md
@@ -33,7 +33,7 @@ Use this checklist when adding a new set to the MathOptInterface repository.
        along with an `## Example` block containing a `jldoctest`
  - [ ] Add the docstring to `docs/src/reference/standard_form.md`
  - [ ] Add the set to the relevant table in `docs/src/manual/standard_form.md`
- 
+
 ## Tests
 
  - [ ] Define a new `_set(::Type{S})` method in `src/Test/test_basic_constraint.jl`
@@ -50,4 +50,33 @@ Use this checklist when adding a new set to the MathOptInterface repository.
  - [ ] Implement `dual_set(::S)` and `dual_set_type(::Type{S})`
  - [ ] Add new tests to the `Test` submodule exercising your new set
  - [ ] Add new bridges to convert your set into more commonly used sets
+```
+
+## Updating MathOptFormat
+
+Use this checklist when updating the version of MathOptFormat.
+
+```
+## Basic
+
+ - [ ] The file at `src/FileFormats/MOF/mof.X.Y.schema.json` is updated
+ - [ ] The constants `SCHEMA_PATH`, `VERSION`, and `SUPPORTED_VERSIONS` are
+       updated in `src/FileFormats/MOF/MOF.jl`
+
+## New sets
+
+ - [ ] New sets are added to the `@model` in `src/FileFormats/MOF/MOF.jl`
+ - [ ] New sets are added to the `@enum` in `src/FileFormats/MOF/read.jl`
+ - [ ] `set_to_moi` is defined for each set in `src/FileFormats/MOF/read.jl`
+ - [ ] `head_name` is defined for each set in `src/FileFormats/MOF/write.jl`
+ - [ ] A new unit test calling `_test_model_equality` is aded to
+       `test/FileFormats/MOF/MOF.jl`
+
+## Tests
+
+ - [ ] The version field in `test/FileFormats/MOF/nlp.mof.json` is updated
+
+## Documentation
+
+ - [ ] The version fields are updated in `docs/src/submodules/FileFormats/overview.md`
 ```

--- a/docs/src/submodules/FileFormats/overview.md
+++ b/docs/src/submodules/FileFormats/overview.md
@@ -94,7 +94,7 @@ julia> print(read("file.mof.json", String))
   "name": "MathOptFormat Model",
   "version": {
     "major": 1,
-    "minor": 3
+    "minor": 4
   },
   "variables": [
     {
@@ -230,7 +230,7 @@ julia> good_model = JSON.parse("""
        {
          "version": {
            "major": 1,
-           "minor": 3
+           "minor": 4
          },
          "variables": [{"name": "x"}],
          "objective": {"sense": "feasibility"},
@@ -249,7 +249,7 @@ julia> bad_model = JSON.parse("""
        {
          "version": {
            "major": 1,
-           "minor": 3
+           "minor": 4
          },
          "variables": [{"NaMe": "x"}],
          "objective": {"sense": "feasibility"},

--- a/src/FileFormats/MOF/MOF.jl
+++ b/src/FileFormats/MOF/MOF.jl
@@ -11,10 +11,10 @@ import OrderedCollections
 import JSON
 import MathOptInterface as MOI
 
-const SCHEMA_PATH = joinpath(@__DIR__, "mof.1.3.schema.json")
-const VERSION = v"1.3"
+const SCHEMA_PATH = joinpath(@__DIR__, "mof.1.4.schema.json")
+const VERSION = v"1.4"
 const SUPPORTED_VERSIONS =
-    (v"1.3", v"1.2", v"1.1", v"1.0", v"0.6", v"0.5", v"0.4")
+    (v"1.4", v"1.3", v"1.2", v"1.1", v"1.0", v"0.6", v"0.5", v"0.4")
 
 const OrderedObject = OrderedCollections.OrderedDict{String,Any}
 const UnorderedObject = Dict{String,Any}
@@ -55,6 +55,7 @@ MOI.Utilities.@model(
         MOI.DualExponentialCone,
         MOI.NormOneCone,
         MOI.NormInfinityCone,
+        MOI.NormCone,
         MOI.NormSpectralCone,
         MOI.NormNuclearCone,
         MOI.RelativeEntropyCone,
@@ -63,6 +64,7 @@ MOI.Utilities.@model(
         MOI.LogDetConeTriangle,
         MOI.LogDetConeSquare,
         MOI.PositiveSemidefiniteConeTriangle,
+        MOI.ScaledPositiveSemidefiniteConeTriangle,
         MOI.PositiveSemidefiniteConeSquare,
         MOI.HermitianPositiveSemidefiniteConeTriangle,
         MOI.AllDifferent,

--- a/src/FileFormats/MOF/mof.1.4.schema.json
+++ b/src/FileFormats/MOF/mof.1.4.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/schema#",
-    "$id": "https://jump.dev/MathOptFormat/schemas/mof.1.3.schema.json",
+    "$id": "https://jump.dev/MathOptFormat/schemas/mof.1.4.schema.json",
     "title": "The schema for MathOptFormat",
     "type": "object",
     "required": ["version", "variables", "objective", "constraints"],
@@ -11,7 +11,7 @@
             "required": ["minor", "major"],
             "properties": {
                 "minor": {
-                    "enum": [0, 1, 2, 3]
+                    "enum": [0, 1, 2, 3, 4]
                 },
                 "major": {
                     "const": 1
@@ -765,6 +765,19 @@
                     }
                 }
             }, {
+                "description": "The (vectorized) cone of symmetric positive semidefinite matrices, with `side_dimension` rows and columns, such that the off-diagonal entries are scaled by √2. The entries of the upper-right triangular part of the matrix are given column by column (or equivalently, the entries of the lower-left triangular part are given row by row).",
+                "examples": ["{\"type\": \"ScaledPositiveSemidefiniteConeTriangle\", \"side_dimension\": 2}"],
+                "required": ["side_dimension"],
+                "properties": {
+                    "type": {
+                        "const": "ScaledPositiveSemidefiniteConeTriangle"
+                    },
+                    "side_dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                }
+            }, {
                 "description": "The cone of symmetric positive semidefinite matrices, with side length `side_dimension`. The entries of the matrix are given column by column (or equivalently, row by row). The matrix is both constrained to be symmetric and to be positive semidefinite. That is, if the functions in entries `(i, j)` and `(j, i)` are different, then a constraint will be added to make sure that the entries are equal.",
                 "examples": ["{\"type\": \"PositiveSemidefiniteConeSquare\", \"side_dimension\": 2}"],
                 "required": ["side_dimension"],
@@ -1120,6 +1133,22 @@
                     "side_dimension": {
                         "type": "integer",
                         "minimum": 1
+                    }
+                }
+            }, {
+                "description": "The p-norm cone (t, x) ∈ {R^d : t ≥ (Σᵢ|xᵢ|^p)^(1/p)}.",
+                "examples": ["{\"type\": \"NormCone\", \"dimension\": 3, \"p\": 1.5}"],
+                "required": ["dimension", "p"],
+                "properties": {
+                    "type": {
+                        "const": "NormCone"
+                    },
+                    "dimension": {
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "p": {
+                        "type": "number"
                     }
                 }
             }]

--- a/src/FileFormats/MOF/read.jl
+++ b/src/FileFormats/MOF/read.jl
@@ -373,6 +373,7 @@ end
     GeometricMeanCone,
     NormOneCone,
     NormInfinityCone,
+    NormCone,
     RelativeEntropyCone,
     NormSpectralCone,
     NormNuclearCone,
@@ -381,6 +382,7 @@ end
     LogDetConeTriangle,
     LogDetConeSquare,
     PositiveSemidefiniteConeTriangle,
+    ScaledPositiveSemidefiniteConeTriangle,
     PositiveSemidefiniteConeSquare,
     HermitianPositiveSemidefiniteConeTriangle,
     ExponentialCone,
@@ -497,6 +499,10 @@ function set_to_moi(::Val{:NormInfinityCone}, object::Object)
     return MOI.NormInfinityCone(object["dimension"])
 end
 
+function set_to_moi(::Val{:NormCone}, object::Object)
+    return MOI.NormCone(object["p"], object["dimension"])
+end
+
 function set_to_moi(::Val{:RelativeEntropyCone}, object::Object)
     return MOI.RelativeEntropyCone(object["dimension"])
 end
@@ -527,6 +533,13 @@ end
 
 function set_to_moi(::Val{:PositiveSemidefiniteConeTriangle}, object::Object)
     return MOI.PositiveSemidefiniteConeTriangle(object["side_dimension"])
+end
+
+function set_to_moi(
+    ::Val{:ScaledPositiveSemidefiniteConeTriangle},
+    object::Object,
+)
+    return MOI.ScaledPositiveSemidefiniteConeTriangle(object["side_dimension"])
 end
 
 function set_to_moi(::Val{:PositiveSemidefiniteConeSquare}, object::Object)

--- a/src/FileFormats/MOF/write.jl
+++ b/src/FileFormats/MOF/write.jl
@@ -289,6 +289,7 @@ head_name(::Type{MOI.ExponentialCone}) = "ExponentialCone"
 head_name(::Type{MOI.DualExponentialCone}) = "DualExponentialCone"
 head_name(::Type{MOI.NormOneCone}) = "NormOneCone"
 head_name(::Type{MOI.NormInfinityCone}) = "NormInfinityCone"
+head_name(::Type{MOI.NormCone}) = "NormCone"
 head_name(::Type{MOI.RelativeEntropyCone}) = "RelativeEntropyCone"
 head_name(::Type{MOI.NormSpectralCone}) = "NormSpectralCone"
 head_name(::Type{MOI.NormNuclearCone}) = "NormNuclearCone"
@@ -298,6 +299,9 @@ head_name(::Type{MOI.LogDetConeTriangle}) = "LogDetConeTriangle"
 head_name(::Type{MOI.LogDetConeSquare}) = "LogDetConeSquare"
 function head_name(::Type{MOI.PositiveSemidefiniteConeTriangle})
     return "PositiveSemidefiniteConeTriangle"
+end
+function head_name(::Type{MOI.ScaledPositiveSemidefiniteConeTriangle})
+    return "ScaledPositiveSemidefiniteConeTriangle"
 end
 function head_name(::Type{MOI.PositiveSemidefiniteConeSquare})
     return "PositiveSemidefiniteConeSquare"

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -770,6 +770,18 @@ c1: [x1, x2, x3] in PositiveSemidefiniteConeTriangle(2)
     )
 end
 
+function test_ScaledPositiveSemidefiniteConeTriangle()
+    return _test_model_equality(
+        """
+variables: x1, x2, x3
+minobjective: x1
+c1: [x1, x2, x3] in ScaledPositiveSemidefiniteConeTriangle(2)
+""",
+        ["x1", "x2", "x3"],
+        ["c1"],
+    )
+end
+
 function test_PositiveSemidefiniteConeSquare()
     return _test_model_equality(
         """
@@ -881,6 +893,18 @@ function test_NormInfinityCone()
 variables: x, y
 minobjective: x
 c1: [x, y] in NormInfinityCone(2)
+""",
+        ["x", "y"],
+        ["c1"],
+    )
+end
+
+function test_NormCone()
+    return _test_model_equality(
+        """
+variables: x, y
+minobjective: x
+c1: [x, y] in NormCone(1.5, 2)
 """,
         ["x", "y"],
         ["c1"],

--- a/test/FileFormats/MOF/nlp.mof.json
+++ b/test/FileFormats/MOF/nlp.mof.json
@@ -2,7 +2,7 @@
   "name": "MathOptFormat Model",
   "version": {
     "major": 1,
-    "minor": 3
+    "minor": 4
   },
   "variables": [
     {


### PR DESCRIPTION
x-ref https://github.com/jump-dev/MathOptFormat/pull/28

## Basic

 - [x] The file at `src/FileFormats/MOF/mof.X.Y.schema.json` is updated
 - [x] The constants `SCHEMA_PATH`, `VERSION`, and `SUPPORTED_VERSIONS` are
       updated in `src/FileFormats/MOF/MOF.jl`

## New sets

 - [x] New sets are added to the `@model` in `src/FileFormats/MOF/MOF.jl`
 - [x] New sets are added to the `@enum` in `src/FileFormats/MOF/read.jl`
 - [x] `set_to_moi` is defined for each set in `src/FileFormats/MOF/read.jl`
 - [x] `head_name` is defined for each set in `src/FileFormats/MOF/write.jl`
 - [x] A new unit test calling `_test_model_equality` is aded to
       `test/FileFormats/MOF/MOF.jl`

## Tests

 - [x] The version field in `test/FileFormats/MOF/nlp.mof.json` is updated

## Documentation

 - [x] The version fields are updated in `docs/src/submodules/FileFormats/overview.md`