### PR TITLE
Prep for v1.16.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.15.1"
+version = "1.16.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.16.0 (May 15, 2023)
+## v1.16.0 (May 16, 2023)
 
 ### Added
 
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    compiler (#2161) (#2163)
  - Fixed a correctness bug in [`Bridges.Constraint.HermitianToSymmetricPSDBridge`](@ref)
    (#2171)
+ - Fixed `convert(::VariableIndex, ::ScalarAffineFunction)` when the function
+   has terms with `0`coefficients (#2173)
 
 ### Other
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,34 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.16.0 (May 15, 2023)
+
+### Added
+
+ - Added support for MathOptFormat v1.3 and v1.4 (#2158) (#2169)
+ - Added new method to the nonlinear API (#2162) (#2164)
+    - [`MOI.eval_hessian_constraint`](@ref)
+    - [`MOI.eval_hessian_objective`](@ref)
+    - [`MOI.hessian_constraint_structure`](@ref)
+    - [`MOI.hessian_objective_structure`](@ref)
+ - Added new sets
+    - [`MOI.NormCone`](@ref) (#2119)
+    - [`MOI.ScaledPositiveSemidefiniteConeTriangle`](@ref) (#2154)
+
+### Fixed
+
+ - Fixed support for Julia v1.9 to work around a bug in the upstream Julia
+   compiler (#2161) (#2163)
+ - Fixed a correctness bug in [`MOI.Bridges.Constraint.HermitianToSymmetricPSDBridge`](@ref)
+   (#2171)
+
+### Other
+
+ - Fixed `solver-tests.yml` (#2157)
+ - Updated documentation links to developer chatroom (#2160)
+ - Added various tests for bridges (#2156)
+ - Added checklists to the developer documentation (#2167) (#2168)
+
 ## v1.15.1 (April 25, 2023)
 
 ### Fixed

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -13,19 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Added support for MathOptFormat v1.3 and v1.4 (#2158) (#2169)
  - Added new method to the nonlinear API (#2162) (#2164)
-    - [`MOI.eval_hessian_constraint`](@ref)
-    - [`MOI.eval_hessian_objective`](@ref)
-    - [`MOI.hessian_constraint_structure`](@ref)
-    - [`MOI.hessian_objective_structure`](@ref)
+    - [`eval_hessian_constraint`](@ref)
+    - [`eval_hessian_objective`](@ref)
+    - [`hessian_constraint_structure`](@ref)
+    - [`hessian_objective_structure`](@ref)
  - Added new sets
-    - [`MOI.NormCone`](@ref) (#2119)
-    - [`MOI.ScaledPositiveSemidefiniteConeTriangle`](@ref) (#2154)
+    - [`NormCone`](@ref) (#2119)
+    - [`ScaledPositiveSemidefiniteConeTriangle`](@ref) (#2154)
 
 ### Fixed
 
  - Fixed support for Julia v1.9 to work around a bug in the upstream Julia
    compiler (#2161) (#2163)
- - Fixed a correctness bug in [`MOI.Bridges.Constraint.HermitianToSymmetricPSDBridge`](@ref)
+ - Fixed a correctness bug in [`Bridges.Constraint.HermitianToSymmetricPSDBridge`](@ref)
    (#2171)
 
 ### Other


### PR DESCRIPTION
## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] The `solver-tests.yml` GitHub action does not have unexpected failures.
         https://github.com/jump-dev/MathOptInterface.jl/actions/runs/4974400735

## TODO

 - [x] https://github.com/jump-dev/MathOptInterface.jl/pull/2173 fix for MosekTools failure