### PR TITLE
Fix convert(::VariableIndex, ::ScalarAffineFunction) with zero coefficients

### DIFF
--- a/.github/workflows/solver-tests.yml
+++ b/.github/workflows/solver-tests.yml
@@ -60,6 +60,7 @@ jobs:
         shell: julia --color=yes {0}
         run: |
           import Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
           Pkg.develop(ENV["PACKAGE"])
           Pkg.test(ENV["PACKAGE"])
   test-cplex:
@@ -95,6 +96,7 @@ jobs:
           SECRET_CPLEX_URL_2210: ${{ secrets.SECRET_CPLEX_URL_2210 }}
         run: |
           import Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
           Pkg.develop(ENV["PACKAGE"])
           Pkg.test(ENV["PACKAGE"])
   # TODO(odow): enable testing Xpress

--- a/.github/workflows/solver-tests.yml
+++ b/.github/workflows/solver-tests.yml
@@ -60,7 +60,7 @@ jobs:
         shell: julia --color=yes {0}
         run: |
           import Pkg
-          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.develop(Pkg.PackageSpec(; path = pwd()))
           Pkg.develop(ENV["PACKAGE"])
           Pkg.test(ENV["PACKAGE"])
   test-cplex:
@@ -96,7 +96,7 @@ jobs:
           SECRET_CPLEX_URL_2210: ${{ secrets.SECRET_CPLEX_URL_2210 }}
         run: |
           import Pkg
-          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.develop(Pkg.PackageSpec(; path = pwd()))
           Pkg.develop(ENV["PACKAGE"])
           Pkg.test(ENV["PACKAGE"])
   # TODO(odow): enable testing Xpress

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -701,14 +701,21 @@ end
 # VariableIndex
 
 function Base.convert(::Type{VariableIndex}, f::ScalarAffineFunction)
-    if (
-        !iszero(f.constant) ||
-        !isone(length(f.terms)) ||
-        !isone(f.terms[1].coefficient)
-    )
+    if !iszero(f.constant)
         throw(InexactError(:convert, VariableIndex, f))
     end
-    return f.terms[1].variable
+    scalar_term = nothing
+    for term in f.terms
+        if isone(term.coefficient) && scalar_term === nothing
+            scalar_term = term
+        elseif !iszero(term.coefficient)
+            throw(InexactError(:convert, VariableIndex, f))
+        end
+    end
+    if scalar_term === nothing
+        throw(InexactError(:convert, VariableIndex, f))
+    end
+    return scalar_term.variable::VariableIndex
 end
 
 function Base.convert(

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -49,6 +49,29 @@ function test_functions_copy_VectorOfVariables()
     @test f.variables[2] == y
 end
 
+function test_functions_convert_to_variable_index()
+    model = MOI.Utilities.Model{Float64}()
+    x = MOI.add_variable(model)
+    y = MOI.add_variable(model)
+    for f in (
+        1.0 * x,
+        1.0 * x + 0.0,
+        1.0 * x + 0.0 * y + 0.0,
+        0.0 * y + 1.0 * x + 0.0,
+    )
+        @test convert(MOI.VariableIndex, f) === x
+    end
+    for f in (
+        1.0 * x + 0.5,
+        0.5 * x + 0.0,
+        1.0 * x + 1.0 * y + 0.0,
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{Float64}[], 0.0),
+    )
+        @test_throws InexactError convert(MOI.VariableIndex, f)
+    end
+    return
+end
+
 function test_functions_convert_VariableIndex()
     model = MOI.Utilities.Model{Float64}()
     x = MOI.add_variable(model)


### PR DESCRIPTION
Showed up in https://github.com/jump-dev/MathOptInterface.jl/pull/2172

MosekTools fails tests because of:

<img width="971" alt="image" src="https://github.com/jump-dev/MathOptInterface.jl/assets/8177701/d810fba7-4fb9-425c-8e7a-8add3e46c1e8">

It's pretty reasonable that we should skip zero terms when converting.

Check that it fixes Mosek
 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/4974798432