### PR TITLE
Fix promote_operation for ScalarNonlinearFunction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - version: '1.6'
             os: ubuntu-latest
             arch: x64
-          - version: '1'
+          - version: '1.6'
             os: ubuntu-latest
             arch: x86
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - version: '1.6'
             os: ubuntu-latest
             arch: x64
-          - version: '1.6'
+          - version: '1'
             os: ubuntu-latest
             arch: x86
     steps:

--- a/src/Bridges/Constraint/bridges/vectorize.jl
+++ b/src/Bridges/Constraint/bridges/vectorize.jl
@@ -58,17 +58,18 @@ end
 
 function MOI.supports_constraint(
     ::Type{VectorizeBridge{T}},
-    ::Type{F},
+    ::Type{<:MOI.AbstractScalarFunction},
     ::Type{<:MOI.Utilities.ScalarLinearSet{T}},
-) where {
-    T,
-    F<:Union{
-        MOI.VariableIndex,
-        MOI.ScalarAffineFunction{T},
-        MOI.ScalarQuadraticFunction{T},
-    },
-}
+) where {T}
     return true
+end
+
+function MOI.supports_constraint(
+    ::Type{VectorizeBridge{T}},
+    ::Type{MOI.ScalarNonlinearFunction},
+    ::Type{<:MOI.Utilities.ScalarLinearSet{T}},
+) where {T}
+    return false
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:VectorizeBridge})

--- a/src/Bridges/Constraint/bridges/vectorize.jl
+++ b/src/Bridges/Constraint/bridges/vectorize.jl
@@ -58,9 +58,16 @@ end
 
 function MOI.supports_constraint(
     ::Type{VectorizeBridge{T}},
-    ::Type{<:MOI.AbstractScalarFunction},
+    ::Type{F},
     ::Type{<:MOI.Utilities.ScalarLinearSet{T}},
-) where {T}
+) where {
+    T,
+    F<:Union{
+        MOI.VariableIndex,
+        MOI.ScalarAffineFunction{T},
+        MOI.ScalarQuadraticFunction{T},
+    },
+}
     return true
 end
 

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1820,6 +1820,14 @@ function promote_operation(
     ::typeof(-),
     ::Type{T},
     ::Type{MOI.ScalarNonlinearFunction},
+) where {T}
+    return MOI.ScalarNonlinearFunction
+end
+
+function promote_operation(
+    ::typeof(-),
+    ::Type{T},
+    ::Type{MOI.ScalarNonlinearFunction},
     ::Type{T},
 ) where {T}
     return MOI.ScalarNonlinearFunction

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1824,33 +1824,6 @@ function promote_operation(
     return MOI.ScalarNonlinearFunction
 end
 
-function promote_operation(
-    ::typeof(-),
-    ::Type{T},
-    ::Type{MOI.ScalarNonlinearFunction},
-    ::Type{T},
-) where {T<:Number}
-    return MOI.ScalarNonlinearFunction
-end
-
-function promote_operation(
-    ::typeof(-),
-    ::Type{<:Number},
-    ::Type{MOI.ScalarNonlinearFunction},
-    ::Type{MOI.VariableIndex},
-)
-    return MOI.ScalarNonlinearFunction
-end
-
-function operate(
-    op::Union{typeof(+),typeof(-)},
-    ::Type{T},
-    f::MOI.ScalarNonlinearFunction,
-    g::ScalarQuadraticLike{T},
-) where {T}
-    return MOI.ScalarNonlinearFunction(Symbol(op), Any[f, g])
-end
-
 function operate(
     ::typeof(-),
     ::Type{T},
@@ -1863,6 +1836,39 @@ function operate(
         end
     end
     return MOI.ScalarNonlinearFunction(:-, Any[f])
+end
+
+function promote_operation(
+    ::Union{typeof(+),typeof(-),typeof(*),typeof(/)},
+    ::Type{T},
+    ::Type{MOI.ScalarNonlinearFunction},
+    ::Type{S},
+) where {
+    T<:Number,
+    S<:Union{
+        T,
+        MOI.VariableIndex,
+        MOI.ScalarAffineFunction{T},
+        MOI.ScalarQuadraticFunction{T},
+        MOI.ScalarNonlinearFunction,
+    }
+}
+    return MOI.ScalarNonlinearFunction
+end
+
+function operate(
+    op::Union{typeof(+),typeof(-),typeof(*),typeof(/)},
+    ::Type{T},
+    f::MOI.ScalarNonlinearFunction,
+    g::Union{
+        T,
+        MOI.VariableIndex,
+        MOI.ScalarAffineFunction{T},
+        MOI.ScalarQuadraticFunction{T},
+        MOI.ScalarNonlinearFunction,
+    }
+) where {T}
+    return MOI.ScalarNonlinearFunction(Symbol(op), Any[f, g])
 end
 
 ### Base methods

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1857,8 +1857,11 @@ function operate(
     ::Type{T},
     f::MOI.ScalarNonlinearFunction,
 ) where {T}
-    if f.head == :- && length(f.args) == 1 && f.args[1] isa MOI.ScalarNonlinearFunction
-        return f.args[1]
+    if f.head == :- && length(f.args) == 1
+        # A simplification for -(-(f)) into f, but only if f is an SNF.
+        if f.args[1] isa MOI.ScalarNonlinearFunction
+            return f.args[1]
+        end
     end
     return MOI.ScalarNonlinearFunction(:-, Any[f])
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1816,13 +1816,14 @@ end
 
 ### ScalarNonlinearFunction
 
-# Needed for LessToGreaterBridge
-function promote_operation(
-    ::Union{typeof(+),typeof(-)},
-    ::Type{<:Real},
-    ::Type{MOI.ScalarNonlinearFunction},
-)
-    return MOI.ScalarNonlinearFunction
+@static if Sys.WORD_SIZE == 64
+    function promote_operation(
+        ::Union{typeof(+),typeof(-)},
+        ::Type{<:Real},
+        ::Type{MOI.ScalarNonlinearFunction},
+    )
+        return MOI.ScalarNonlinearFunction
+    end
 end
 
 function promote_operation(

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1851,7 +1851,7 @@ function promote_operation(
         MOI.ScalarAffineFunction{T},
         MOI.ScalarQuadraticFunction{T},
         MOI.ScalarNonlinearFunction,
-    }
+    },
 }
     return MOI.ScalarNonlinearFunction
 end
@@ -1866,7 +1866,7 @@ function operate(
         MOI.ScalarAffineFunction{T},
         MOI.ScalarQuadraticFunction{T},
         MOI.ScalarNonlinearFunction,
-    }
+    },
 ) where {T}
     return MOI.ScalarNonlinearFunction(Symbol(op), Any[f, g])
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1816,11 +1816,12 @@ end
 
 ### ScalarNonlinearFunction
 
+# Needed for LessToGreaterBridge
 function promote_operation(
-    ::typeof(-),
-    ::Type{T},
+    ::Union{typeof(+),typeof(-)},
+    ::Type{<:Real},
     ::Type{MOI.ScalarNonlinearFunction},
-) where {T}
+)
     return MOI.ScalarNonlinearFunction
 end
 
@@ -1849,6 +1850,17 @@ function operate(
     g::ScalarQuadraticLike{T},
 ) where {T}
     return MOI.ScalarNonlinearFunction(Symbol(op), Any[f, g])
+end
+
+function operate(
+    ::typeof(-),
+    ::Type{T},
+    f::MOI.ScalarNonlinearFunction,
+) where {T}
+    if f.head == :- && length(f.args) == 1 && f.args[1] isa MOI.ScalarNonlinearFunction
+        return f.args[1]
+    end
+    return MOI.ScalarNonlinearFunction(:-, Any[f])
 end
 
 ### Base methods

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1816,22 +1816,11 @@ end
 
 ### ScalarNonlinearFunction
 
-@static if Sys.WORD_SIZE == 64
-    function promote_operation(
-        ::Union{typeof(+),typeof(-)},
-        ::Type{<:Real},
-        ::Type{MOI.ScalarNonlinearFunction},
-    )
-        return MOI.ScalarNonlinearFunction
-    end
-end
-
 function promote_operation(
-    ::typeof(-),
-    ::Type{T},
+    ::Union{typeof(+),typeof(-)},
+    ::Type{<:Number},
     ::Type{MOI.ScalarNonlinearFunction},
-    ::Type{T},
-) where {T}
+)
     return MOI.ScalarNonlinearFunction
 end
 
@@ -1839,8 +1828,17 @@ function promote_operation(
     ::typeof(-),
     ::Type{T},
     ::Type{MOI.ScalarNonlinearFunction},
+    ::Type{T},
+) where {T<:Number}
+    return MOI.ScalarNonlinearFunction
+end
+
+function promote_operation(
+    ::typeof(-),
+    ::Type{<:Number},
+    ::Type{MOI.ScalarNonlinearFunction},
     ::Type{MOI.VariableIndex},
-) where {T}
+)
     return MOI.ScalarNonlinearFunction
 end
 

--- a/test/Bridges/Constraint/flip_sign.jl
+++ b/test/Bridges/Constraint/flip_sign.jl
@@ -338,6 +338,17 @@ function test_runtests()
         """,
     )
     MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.GreaterToLessBridge,
+        """
+        variables: x
+        ScalarNonlinearFunction(1.5 * x) >= 1.0
+        """,
+        """
+        variables: x
+        ScalarNonlinearFunction(-(1.5 * x)) <= -1.0
+        """,
+    )
+    MOI.Bridges.runtests(
         MOI.Bridges.Constraint.LessToGreaterBridge,
         """
         variables: x
@@ -357,6 +368,17 @@ function test_runtests()
         """
         variables: x
         -1.5 * x >= -1.0
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.LessToGreaterBridge,
+        """
+        variables: x
+        ScalarNonlinearFunction(1.5 * x) <= 1.0
+        """,
+        """
+        variables: x
+        ScalarNonlinearFunction(-(1.5 * x)) >= -1.0
         """,
     )
     MOI.Bridges.runtests(

--- a/test/Bridges/Constraint/vectorize.jl
+++ b/test/Bridges/Constraint/vectorize.jl
@@ -238,6 +238,27 @@ function test_runtests()
     return
 end
 
+MOI.Utilities.@model(
+    Model2179,
+    (),
+    (MOI.GreaterThan, MOI.LessThan),
+    (),
+    (),
+    (),
+    (MOI.ScalarAffineFunction,),
+    (),
+    ()
+)
+
+function test_unsupported_ScalarNonnlinearFunction()
+    model = MOI.instantiate(Model2179{Float64}; with_bridge_type = Float64)
+    MOI.supports_constraint(
+        model,
+        MOI.ScalarNonlinearFunction,
+        MOI.GreaterThan{Float64},
+    )
+end
+
 end  # module
 
 TestConstraintVectorize.runtests()

--- a/test/Bridges/Constraint/vectorize.jl
+++ b/test/Bridges/Constraint/vectorize.jl
@@ -250,13 +250,14 @@ MOI.Utilities.@model(
     ()
 )
 
-function test_unsupported_ScalarNonnlinearFunction()
+function test_unsupported_ScalarNonlinearFunction()
     model = MOI.instantiate(Model2179{Float64}; with_bridge_type = Float64)
     MOI.supports_constraint(
         model,
         MOI.ScalarNonlinearFunction,
         MOI.GreaterThan{Float64},
     )
+    return
 end
 
 end  # module


### PR DESCRIPTION
I guess I didn't run `solver-tests.yml` on the ScalarNonlinearFunction PR recently.

 https://github.com/jump-dev/MathOptInterface.jl/actions/runs/5108546474