### PR TITLE
[FileFormats.LP] fix reading off-diagonals of quadratic functions

### DIFF
--- a/src/FileFormats/LP/LP.jl
+++ b/src/FileFormats/LP/LP.jl
@@ -596,11 +596,12 @@ function _parse_function(
             push!(f.terms, term::MOI.ScalarAffineTerm{Float64})
         elseif term isa MOI.ScalarQuadraticTerm{Float64}
             push!(cache.quad_terms, term::MOI.ScalarQuadraticTerm{Float64})
-            if tokens[offset-1] == "]"
+            if tokens[offset-1] in ("]", "]/2")
+                scale = tokens[offset-1] == "]/2" ? 0.5 : 1
                 for (i, term) in enumerate(cache.quad_terms)
                     x, y = term.variable_1, term.variable_2
-                    scale = (x == y ? 2 : 1) * term.coefficient
-                    cache.quad_terms[i] = MOI.ScalarQuadraticTerm(scale, x, y)
+                    coef = scale * (x == y ? 2 : 1) * term.coefficient
+                    cache.quad_terms[i] = MOI.ScalarQuadraticTerm(coef, x, y)
                 end
             end
         else


### PR DESCRIPTION
Closes #2181.

This was my fault in https://github.com/jump-dev/MathOptInterface.jl/pull/1974. I guess I didn't understand the convention well enough. 

It's literally the coefficients as written multiplied by 0.5. Not what MOI does and assume that you're passing one of the off-diagonals. (This is another motivation for changing the definition of ScalarQuadraticFunction in MOI v2 https://github.com/jump-dev/MathOptInterface.jl/issues/2180)

Docs: https://www.ibm.com/docs/en/icos/12.8.0.0?topic=representation-quadratic-terms-in-lp-file-format