### PR TITLE
[Bridges] add SlackBridgePrimalDualStart

### DIFF
--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -199,6 +199,13 @@ end
 # Pretend that every model supports, and silently skip in set if unsupported
 MOI.supports(::MOI.ModelLike, ::SlackBridgePrimalDualStart) = true
 
+function MOI.supports(
+    ::MOI.Bridges.AbstractBridgeOptimizer,
+    ::SlackBridgePrimalDualStart,
+)
+    return true
+end
+
 function MOI.set(
     model::MOI.ModelLike,
     ::SlackBridgePrimalDualStart,

--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -197,14 +197,7 @@ function MOI.throw_set_error_fallback(
 end
 
 # Pretend that every model supports, and silently skip in set if unsupported
-MOI.supports(::MOI.ModelLike, ::SlackBridgePrimalDualStart) = true
-
-function MOI.supports(
-    ::MOI.Bridges.AbstractBridgeOptimizer,
-    ::SlackBridgePrimalDualStart,
-)
-    return true
-end
+MOI.supports_fallback(::MOI.ModelLike, ::SlackBridgePrimalDualStart) = true
 
 function MOI.set(
     model::MOI.ModelLike,

--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -174,3 +174,76 @@ function MOI.get(
     g = MOI.Utilities.remove_variable(f, bridge.slack)
     return MOI.Utilities.convert_approx(G, g)
 end
+
+"""
+    struct SlackBridgePrimalDualStart <: MOI.AbstractModelAttribute end
+
+[`Bridges.Objective.SlackBridge`](@ref) introduces a new constraint into the
+problem. However, because it is not a constraint bridge, it cannot intercept
+calls to set [`ConstraintDualStart`](@ref) or [`ConstraintPrimalStart`](@ref).
+
+As a work-around, set this attribute to `true` to set the primal and dual
+start for the new constraint. This attribute must be set after
+[`VariablePrimalStart`](@ref).
+"""
+struct SlackBridgePrimalDualStart <: MOI.AbstractModelAttribute end
+
+function MOI.throw_set_error_fallback(
+    ::MOI.ModelLike,
+    ::SlackBridgePrimalDualStart,
+    ::Bool,
+)
+    return # Silently ignore if the model does not support.
+end
+
+function MOI.supports(
+    ::MOI.ModelLike,
+    ::SlackBridgePrimalDualStart,
+    ::Type{<:SlackBridge},
+)
+    return true
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    ::SlackBridgePrimalDualStart,
+    b::SlackBridge{T},
+    value::Bool,
+) where {T}
+    @assert value
+    # ConstraintDual: if the objective function had a dual, it would be `-1` for
+    # the Lagrangian function to be the same.
+    if MOI.supports(model, MOI.ConstraintDualStart(), typeof(b.constraint))
+        MOI.set(model, MOI.ConstraintDualStart(), b.constraint, -one(T))
+    end
+    # ConstraintPrimal: we should set the slack of f(x) - y to be 0, and the
+    # start of y to be f(x).
+    if !MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex) ||
+       !MOI.supports(model, MOI.ConstraintPrimalStart(), typeof(b.constraint))
+        return
+    end
+    MOI.set(model, MOI.VariablePrimalStart(), b.slack, zero(T))
+    f = MOI.get(model, MOI.ConstraintFunction(), b.constraint)
+    f_val = MOI.Utilities.eval_variables(f) do v
+        return MOI.get(model, MOI.VariablePrimalStart(), v)
+    end
+    f_val -= MOI.constant(MOI.get(model, MOI.ConstraintSet(), b.constraint))
+    MOI.set(model, MOI.VariablePrimalStart(), b.slack, f_val)
+    MOI.set(model, MOI.ConstraintPrimalStart(), b.constraint, zero(T))
+    return
+end
+
+function MOI.set(
+    b::MOI.Bridges.AbstractBridgeOptimizer,
+    attr::SlackBridgePrimalDualStart,
+    value,
+)
+    if MOI.Bridges.is_objective_bridged(b)
+        obj_attr = MOI.ObjectiveFunction{function_type(bridges(b))}()
+        if MOI.Bridges.is_bridged(b, obj_attr)
+            bridge = MOI.Bridges.bridge(b, obj_attr)
+            MOI.set(MOI.Bridges.recursive_model(b), attr, bridge, value)
+        end
+    end
+    return
+end

--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -196,14 +196,8 @@ function MOI.throw_set_error_fallback(
     return # Silently ignore if the model does not support.
 end
 
-function MOI.supports(
-    ::MOI.ModelLike,
-    ::SlackBridgePrimalDualStart,
-    ::Type{<:SlackBridge},
-)
-    # Pretend that every model supports, and silently skip in set if unsupported
-    return true
-end
+# Pretend that every model supports, and silently skip in set if unsupported
+MOI.supports(::MOI.ModelLike, ::SlackBridgePrimalDualStart) = true
 
 function MOI.set(
     model::MOI.ModelLike,

--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -205,6 +205,12 @@ function MOI.set(
     b::SlackBridge{T},
     ::Nothing,
 ) where {T}
+    # !!! note
+    #     This attribute should silently skip if the `model` does not support it.
+    #     For other attributes, we set `supports(...) = false`, but this would
+    #     cause `copy_to` to throw an `UnsupportedAttributeError`, which we don't
+    #     want. The solution is to check `supports(model, ...)` in this method,
+    #     and bail if not supported.
     # ConstraintDual: if the objective function had a dual, it would be `-1` for
     # the Lagrangian function to be the same.
     if MOI.supports(model, MOI.ConstraintDualStart(), typeof(b.constraint))

--- a/test/Bridges/Objective/slack.jl
+++ b/test/Bridges/Objective/slack.jl
@@ -525,7 +525,9 @@ function test_SlackBridgePrimalDualStart()
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.set(model, MOI.VariablePrimalStart(), x, 2.0)
-    MOI.set(model, MOI.Bridges.Objective.SlackBridgePrimalDualStart(), nothing)
+    attr = MOI.Bridges.Objective.SlackBridgePrimalDualStart()
+    @test MOI.supports(model, attr)
+    MOI.set(model, attr, nothing)
     vars = MOI.get(inner, MOI.ListOfVariableIndices())
     primal_start = MOI.get.(inner, MOI.VariablePrimalStart(), vars)
     @test primal_start[1] ≈ 2.0
@@ -539,16 +541,19 @@ function test_SlackBridgePrimalDualStart()
 end
 
 function test_SlackBridgePrimalDualStart_unsupported()
+    attr = MOI.Bridges.Objective.SlackBridgePrimalDualStart()
     inner = MOI.Utilities.MockOptimizer(MOI.Utilities.Model{Float64}())
     # Check that setting on blank model doesn't error.
-    MOI.set(inner, MOI.Bridges.Objective.SlackBridgePrimalDualStart(), nothing)
+    @test MOI.supports(inner, attr)
+    MOI.set(inner, attr, nothing)
     model = MOI.Bridges.Objective.Slack{Float64}(inner)
+    @test MOI.supports(model, attr)
     x = MOI.add_variable(model)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.1, x)], -1.2)
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     # Unsupported. Should silently skip without error.
-    MOI.set(model, MOI.Bridges.Objective.SlackBridgePrimalDualStart(), nothing)
+    MOI.set(model, attr, nothing)
     return
 end
 

--- a/test/Bridges/Objective/slack.jl
+++ b/test/Bridges/Objective/slack.jl
@@ -525,7 +525,7 @@ function test_SlackBridgePrimalDualStart()
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
     MOI.set(model, MOI.VariablePrimalStart(), x, 2.0)
-    MOI.set(model, MOI.Bridges.Objective.SlackBridgePrimalDualStart(), true)
+    MOI.set(model, MOI.Bridges.Objective.SlackBridgePrimalDualStart(), nothing)
     vars = MOI.get(inner, MOI.ListOfVariableIndices())
     primal_start = MOI.get.(inner, MOI.VariablePrimalStart(), vars)
     @test primal_start[1] ≈ 2.0
@@ -541,16 +541,14 @@ end
 function test_SlackBridgePrimalDualStart_unsupported()
     inner = MOI.Utilities.MockOptimizer(MOI.Utilities.Model{Float64}())
     # Check that setting on blank model doesn't error.
-    MOI.set(model, MOI.Bridges.Objective.SlackBridgePrimalDualStart(), true)
+    MOI.set(inner, MOI.Bridges.Objective.SlackBridgePrimalDualStart(), nothing)
     model = MOI.Bridges.Objective.Slack{Float64}(inner)
     x = MOI.add_variable(model)
-    MOI.add_constraint(model, x, MOI.GreaterThan(2.0))
-    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.1, x)], -1.2)
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.1, x)], -1.2)
     MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
-    MOI.set(model, MOI.VariablePrimalStart(), x, 2.0)
     # Unsupported. Should silently skip without error.
-    MOI.set(model, MOI.Bridges.Objective.SlackBridgePrimalDualStart(), true)
+    MOI.set(model, MOI.Bridges.Objective.SlackBridgePrimalDualStart(), nothing)
     return
 end
 


### PR DESCRIPTION
x-ref https://github.com/jump-dev/JuMP.jl/pull/3271

@blegat, it seemed to me that we would never want to set this to something other than `-1` for the dual and `0` for the slack primal, so I opted to consolidate everything into a single attribute.

Does this seem right? Or am I missing something?