### PR TITLE
Add missing @require in tests

### DIFF
--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -580,11 +580,7 @@ function test_model_copy_to_UnsupportedConstraint(
     model::MOI.ModelLike,
     ::Config{T},
 ) where {T}
-    @requires MOI.supports_constraint(
-        model,
-        MOI.VariableIndex,
-        MOI.EqualTo{T},
-    )
+    @requires MOI.supports_constraint(model, MOI.VariableIndex, MOI.EqualTo{T})
     @test !MOI.supports_constraint(
         model,
         MOI.VariableIndex,
@@ -613,11 +609,7 @@ function test_model_copy_to_UnsupportedAttribute(
     model::MOI.ModelLike,
     ::Config{T},
 ) where {T}
-    @requires MOI.supports_constraint(
-        model,
-        MOI.VariableIndex,
-        MOI.EqualTo{T},
-    )
+    @requires MOI.supports_constraint(model, MOI.VariableIndex, MOI.EqualTo{T})
     # ModelAttribute
     @test !MOI.supports(model, UnknownModelAttribute())
     @test_throws(

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -580,6 +580,11 @@ function test_model_copy_to_UnsupportedConstraint(
     model::MOI.ModelLike,
     ::Config{T},
 ) where {T}
+    @requires MOI.supports_constraint(
+        model,
+        MOI.VariableIndex,
+        MOI.EqualTo{T},
+    )
     @test !MOI.supports_constraint(
         model,
         MOI.VariableIndex,
@@ -608,6 +613,11 @@ function test_model_copy_to_UnsupportedAttribute(
     model::MOI.ModelLike,
     ::Config{T},
 ) where {T}
+    @requires MOI.supports_constraint(
+        model,
+        MOI.VariableIndex,
+        MOI.EqualTo{T},
+    )
     # ModelAttribute
     @test !MOI.supports(model, UnknownModelAttribute())
     @test_throws(
@@ -747,6 +757,11 @@ function test_model_ScalarFunctionConstantNotZero(
     config::Config{T},
 ) where {T}
     @requires _supports(config, MOI.ScalarFunctionConstantNotZero)
+    @requires MOI.supports_constraint(
+        model,
+        MOI.ScalarAffineFunction{T},
+        MOI.EqualTo{T},
+    )
     function _error(S, value)
         F = MOI.ScalarAffineFunction{T}
         return MOI.ScalarFunctionConstantNotZero{T,F,S}(value)


### PR DESCRIPTION
Manopt.jl only supports variables in manifolds, see https://github.com/JuliaManifolds/Manopt.jl/pull/266