### PR TITLE
Add VectorNonlinearFunction

### DIFF
--- a/docs/src/manual/standard_form.md
+++ b/docs/src/manual/standard_form.md
@@ -41,6 +41,7 @@ The function types implemented in MathOptInterface.jl are:
 | [`VectorAffineFunction`](@ref) | ``A x + b``, where ``A`` is a matrix and ``b`` is a vector. |
 | [`ScalarQuadraticFunction`](@ref) | ``\frac{1}{2} x^T Q x + a^T x + b``, where ``Q`` is a symmetric matrix, ``a`` is a vector, and ``b`` is a constant. |
 | [`VectorQuadraticFunction`](@ref) | A vector of scalar-valued quadratic functions. |
+| [`VectorNonlinearFunction`](@ref) | ``f(x)``, where ``f`` is a vector-valued nonlinear function. |
 
 Extensions for nonlinear programming are present but not yet well documented.
 

--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -37,6 +37,7 @@ VectorAffineTerm
 VectorAffineFunction
 VectorQuadraticTerm
 VectorQuadraticFunction
+VectorNonlinearFunction
 ```
 
 ## Sets

--- a/src/Bridges/Constraint/bridges/scalarize.jl
+++ b/src/Bridges/Constraint/bridges/scalarize.jl
@@ -263,7 +263,7 @@ end
 
 function MOI.set(
     model::MOI.ModelLike,
-   ::MOI.ConstraintFunction,
+    ::MOI.ConstraintFunction,
     bridge::ScalarizeBridge{T,F,S},
     func,
 ) where {T,F,S}

--- a/src/Bridges/Constraint/bridges/scalarize.jl
+++ b/src/Bridges/Constraint/bridges/scalarize.jl
@@ -263,7 +263,7 @@ end
 
 function MOI.set(
     model::MOI.ModelLike,
-    attr::MOI.ConstraintFunction,
+   ::MOI.ConstraintFunction,
     bridge::ScalarizeBridge{T,F,S},
     func,
 ) where {T,F,S}

--- a/src/Bridges/Constraint/bridges/scalarize.jl
+++ b/src/Bridges/Constraint/bridges/scalarize.jl
@@ -263,7 +263,7 @@ end
 
 function MOI.set(
     model::MOI.ModelLike,
-    ::MOI.ConstraintFunction,
+    attr::MOI.ConstraintFunction,
     bridge::ScalarizeBridge{T,F,S},
     func,
 ) where {T,F,S}

--- a/src/Bridges/Constraint/bridges/vectorize.jl
+++ b/src/Bridges/Constraint/bridges/vectorize.jl
@@ -67,14 +67,6 @@ function MOI.supports_constraint(
     return true
 end
 
-function MOI.supports_constraint(
-    ::Type{VectorizeBridge{T}},
-    ::Type{MOI.ScalarNonlinearFunction},
-    ::Type{<:MOI.Utilities.ScalarLinearSet{T}},
-) where {T}
-    return false
-end
-
 function MOI.Bridges.added_constrained_variable_types(::Type{<:VectorizeBridge})
     return Tuple{Type}[]
 end

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -77,6 +77,18 @@ function _function(
     )
 end
 
+function _function(
+    ::Type{T},
+    ::Type{MOI.VectorNonlinearFunction},
+    x::Vector{MOI.VariableIndex},
+) where {T}
+    f = MOI.ScalarNonlinearFunction(
+        :+,
+        Any[MOI.ScalarNonlinearFunction(:^, Any[xi, 2]) for xi in x],
+    )
+    return MOI.VectorNonlinearFunction(Any[f; x])
+end
+
 # Default fallback.
 _set(::Any, ::Type{S}) where {S} = _set(S)
 
@@ -334,7 +346,13 @@ for s in [
             :ScalarNonlinearFunction,
         )
     else
-        (:VectorOfVariables, :VectorAffineFunction, :VectorQuadraticFunction)
+        (
+            :VectorOfVariables,
+            :VectorAffineFunction,
+            :VectorQuadraticFunction,
+            # TODO(odow): re-add this at a later date
+            # :VectorNonlinearFunction,
+        )
     end
     for f in functions
         func = Symbol("test_basic_$(f)_$(s)")

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -86,7 +86,7 @@ function _function(
         :+,
         Any[MOI.ScalarNonlinearFunction(:^, Any[xi, 2]) for xi in x],
     )
-    return MOI.VectorNonlinearFunction(Any[f; x])
+    return MOI.VectorNonlinearFunction([f; x])
 end
 
 # Default fallback.

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -350,8 +350,7 @@ for s in [
             :VectorOfVariables,
             :VectorAffineFunction,
             :VectorQuadraticFunction,
-            # TODO(odow): re-add this at a later date
-            # :VectorNonlinearFunction,
+            :VectorNonlinearFunction,
         )
     end
     for f in functions

--- a/src/Test/test_multiobjective.jl
+++ b/src/Test/test_multiobjective.jl
@@ -228,3 +228,82 @@ function test_multiobjective_vector_quadratic_function_delete_vector(
     @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ new_f
     return
 end
+
+function test_multiobjective_vector_nonlinear(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorNonlinearFunction
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.GreaterThan(T(0)))
+    f = MOI.VectorNonlinearFunction(
+        Any[MOI.ScalarNonlinearFunction(:^, Any[x[1], 2]), x[2]],
+    )  # [x[1]^2, x[2]
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    return
+end
+
+function test_multiobjective_vector_nonlinear_delete(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorNonlinearFunction
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.GreaterThan(T(0)))
+    f = MOI.VectorNonlinearFunction(
+        Any[MOI.ScalarNonlinearFunction(:^, Any[x[1], 2]), x[2]],
+    )  # [x[1]^2, x[2]
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    @test_throws MOI.DeleteNotAllowed MOI.delete(model, x[1])
+    return
+end
+
+function test_multiobjective_vector_nonlinear_delete_vector(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorNonlinearFunction
+    @requires MOI.supports(model, MOI.ObjectiveFunction{F}())
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.GreaterThan(T(0)))
+    f = MOI.VectorNonlinearFunction(
+        Any[MOI.ScalarNonlinearFunction(:^, Any[x[1], 2]), x[2]],
+    )  # [x[1]^2, x[2]
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{F}(), f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, MOI.ObjectiveFunction{F}()) ≈ f
+    @test_throws MOI.DeleteNotAllowed MOI.delete(model, x)
+    return
+end
+
+function test_multiobjective_vector_nonlinear_modify(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VectorNonlinearFunction
+    attr = MOI.ObjectiveFunction{F}()
+    @requires MOI.supports(model, attr)
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint.(model, x, MOI.GreaterThan(T(0)))
+    f = MOI.VectorNonlinearFunction(
+        Any[MOI.ScalarNonlinearFunction(:^, Any[x[1], 2]), x[2]],
+    )  # [x[1]^2, x[2]
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, attr, f)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
+    @test MOI.get(model, attr) ≈ f
+    @test_throws(
+        MOI.ModifyObjectiveNotAllowed,
+        MOI.modify(model, attr, MOI.VectorConstantChange(T[1, 2])),
+    )
+    return
+end

--- a/src/Test/test_multiobjective.jl
+++ b/src/Test/test_multiobjective.jl
@@ -239,7 +239,7 @@ function test_multiobjective_vector_nonlinear(
     MOI.add_constraint.(model, x, MOI.GreaterThan(T(0)))
     f = MOI.VectorNonlinearFunction(
         Any[MOI.ScalarNonlinearFunction(:^, Any[x[1], 2]), x[2]],
-    )  # [x[1]^2, x[2]
+    )  # [x[1]^2, x[2]]
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{F}(), f)
     @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
@@ -257,7 +257,7 @@ function test_multiobjective_vector_nonlinear_delete(
     MOI.add_constraint.(model, x, MOI.GreaterThan(T(0)))
     f = MOI.VectorNonlinearFunction(
         Any[MOI.ScalarNonlinearFunction(:^, Any[x[1], 2]), x[2]],
-    )  # [x[1]^2, x[2]
+    )  # [x[1]^2, x[2]]
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{F}(), f)
     @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
@@ -276,7 +276,7 @@ function test_multiobjective_vector_nonlinear_delete_vector(
     MOI.add_constraint.(model, x, MOI.GreaterThan(T(0)))
     f = MOI.VectorNonlinearFunction(
         Any[MOI.ScalarNonlinearFunction(:^, Any[x[1], 2]), x[2]],
-    )  # [x[1]^2, x[2]
+    )  # [x[1]^2, x[2]]
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{F}(), f)
     @test MOI.get(model, MOI.ObjectiveFunctionType()) == F
@@ -296,7 +296,7 @@ function test_multiobjective_vector_nonlinear_modify(
     MOI.add_constraint.(model, x, MOI.GreaterThan(T(0)))
     f = MOI.VectorNonlinearFunction(
         Any[MOI.ScalarNonlinearFunction(:^, Any[x[1], 2]), x[2]],
-    )  # [x[1]^2, x[2]
+    )  # [x[1]^2, x[2]]
     MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(model, attr, f)
     @test MOI.get(model, MOI.ObjectiveFunctionType()) == F

--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -1673,3 +1673,93 @@ function setup_test(
         model.eval_objective_value = obj_flag
     end
 end
+
+function test_nonlinear_vector_complements(
+    model::MOI.ModelLike,
+    config::MOI.Test.Config{T},
+) where {T}
+    @requires T == Float64
+    @requires _supports(config, MOI.optimize!)
+    F = MOI.ScalarNonlinearFunction
+    @requires MOI.supports_constraint(model, F, MOI.Complements)
+    x = MOI.add_variables(model, 4)
+    MOI.add_constraint.(model, x, MOI.Interval(T(0), T(10)))
+    MOI.set.(model, MOI.VariablePrimalStart(), x, T(1))
+    # f = [
+    #     -1 * x3^2 + -1 * x4 + 2.0
+    #     x3^3 + -1.0 * 2x4^2 + 2.0
+    #     x1^5 + -1.0 * x2 + 2.0 * x3 + -2.0 * x4 + -2.0
+    #     x1 + 2.0 * x2^3 + -2.0 * x3 + 4.0 * x4 + -6.0
+    #     x...
+    # ]
+    f = MOI.VectorNonlinearFunction([
+        MOI.ScalarNonlinearFunction(
+            :+,
+            Any[
+                MOI.ScalarNonlinearFunction(:*, Any[-T(1), x[3], x[3]]),
+                MOI.ScalarNonlinearFunction(:*, Any[-T(1), x[4]]),
+                T(2),
+            ],
+        ),
+        MOI.ScalarNonlinearFunction(
+            :+,
+            Any[
+                MOI.ScalarNonlinearFunction(:^, Any[x[3], 3]),
+                MOI.ScalarNonlinearFunction(:*, Any[-T(2), x[4], x[4]]),
+                T(2),
+            ],
+        ),
+        MOI.ScalarNonlinearFunction(
+            :+,
+            Any[
+                MOI.ScalarNonlinearFunction(:^, Any[x[1], 5]),
+                MOI.ScalarAffineFunction{T}(
+                    MOI.ScalarAffineTerm.(T[-1, 2, -2], x[2:4]),
+                    -T(2),
+                ),
+            ],
+        ),
+        MOI.ScalarNonlinearFunction(
+            :+,
+            Any[
+                MOI.ScalarNonlinearFunction(:*, Any[T(2), x[2], x[2], x[2]]),
+                MOI.ScalarAffineFunction{T}(
+                    MOI.ScalarAffineTerm.(T[1, -2, 4], [x[1], x[3], x[4]]),
+                    -T(6),
+                ),
+            ],
+        ),
+        x[1],
+        x[2],
+        x[3],
+        x[4],
+    ])
+    MOI.add_constraint(model, f, MOI.Complements(8))
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+    @test ≈(
+        MOI.get.(model, MOI.VariablePrimal(), x),
+        T[1.2847523, 0.9729165, 0.9093762, 1.1730350],
+        config,
+    )
+    return
+end
+
+function setup_test(
+    ::typeof(test_nonlinear_vector_complements),
+    model::MOIU.MockOptimizer,
+    config::Config{T},
+) where {T}
+    if T != Float64
+        return  # Skip for non-Float64 solvers
+    end
+    MOI.Utilities.set_mock_optimize!(
+        model,
+        mock -> MOI.Utilities.mock_optimize!(
+            mock,
+            config.optimal_status,
+            T[1.2847523, 0.9729165, 0.9093762, 1.1730350],
+        ),
+    )
+    return
+end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -819,7 +819,7 @@ function Base.getindex(
     it::ScalarFunctionIterator{MOI.VectorNonlinearFunction},
     output_index::Integer,
 )
-    return convert(MOI.ScalarNonlinearFunction, it.f.rows[output_index])
+    return it.f.rows[output_index]
 end
 
 function Base.getindex(
@@ -2156,8 +2156,8 @@ function vectorize(
     return MOI.VectorQuadraticFunction(quadratic_terms, affine_terms, constant)
 end
 
-function vectorize(x::AbstractVector)
-    return MOI.VectorNonlinearFunction(collect(x))
+function vectorize(x::AbstractVector{MOI.ScalarNonlinearFunction})
+    return MOI.VectorNonlinearFunction(x)
 end
 
 scalarize(f::AbstractVector, ::Bool = false) = f

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -191,7 +191,7 @@ for a similar function where `value_fn` returns an
 function eval_variables(
     value_fn::F,
     model::MOI.ModelLike,
-    f::MOI.AbstractFunction,
+    f::Union{MOI.AbstractFunction,Real,AbstractVector{<:Real}},
 ) where {F}
     return eval_variables(value_fn, f)
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -507,10 +507,8 @@ function substitute_variables(
     f::MOI.ScalarNonlinearFunction,
 ) where {F<:Function}
     # TODO(odow): this uses recursion. We should remove at some point.
-    new_args = map(
-        Base.Fix1(_unstable_substitute_variables, variable_map),
-        f.args,
-    )
+    new_args =
+        map(Base.Fix1(_unstable_substitute_variables, variable_map), f.args)
     return MOI.ScalarNonlinearFunction(f.head, convert(Vector{Any}, new_args))
 end
 
@@ -553,10 +551,8 @@ function substitute_variables(
     variable_map::F,
     f::MOI.GenericVectorFunction{T},
 ) where {T,F<:Function}
-    new_rows = map(
-        Base.Fix1(_unstable_substitute_variables, variable_map),
-        f.rows,
-    )
+    new_rows =
+        map(Base.Fix1(_unstable_substitute_variables, variable_map), f.rows)
     return MOI.GenericVectorFunction{T}(convert(Vector{T}, new_rows))
 end
 

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -350,7 +350,7 @@ function map_indices(
     index_map::F,
     f::MOI.VectorNonlinearFunction,
 ) where {F<:Function}
-    return VectorNonlinearFunction(
+    return MOI.VectorNonlinearFunction(
         convert(Vector{Any}, map_indices(index_map, f.rows)),
     )
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -350,9 +350,7 @@ function map_indices(
     index_map::F,
     f::MOI.VectorNonlinearFunction,
 ) where {F<:Function}
-    return MOI.VectorNonlinearFunction(
-        convert(Vector{Any}, map_indices(index_map, f.rows)),
-    )
+    return MOI.VectorNonlinearFunction(map_indices(index_map, f.rows))
 end
 
 map_indices(::F, change::MOI.ScalarConstantChange) where {F<:Function} = change
@@ -553,9 +551,9 @@ function substitute_variables(
     variable_map::F,
     f::MOI.VectorNonlinearFunction,
 ) where {F<:Function}
-    new_rows =
-        map(Base.Fix1(_unstable_substitute_variables, variable_map), f.rows)
-    return MOI.VectorNonlinearFunction(convert(Vector{Any}, new_rows))
+    return MOI.VectorNonlinearFunction(
+        map(Base.Fix1(_unstable_substitute_variables, variable_map), f.rows),
+    )
 end
 
 """

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -119,8 +119,6 @@ for a similar function where `value_fn` returns an
 """
 function eval_variables end
 
-eval_variables(::Function, x::Union{Real,AbstractVector{<:Real}}) = x
-
 function eval_variables(value_fn::Function, t::MOI.ScalarAffineTerm)
     return t.coefficient * value_fn(t.variable)
 end
@@ -1010,7 +1008,6 @@ function canonical(f::MOI.AbstractFunction)
 end
 
 canonicalize!(f::Union{MOI.VectorOfVariables,MOI.VariableIndex}) = f
-canonicalize!(f::Union{Real,AbstractVector{<:Real}}) = f
 
 """
     canonicalize!(f::Union{ScalarAffineFunction, VectorAffineFunction})

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -551,11 +551,11 @@ end
 
 function substitute_variables(
     variable_map::F,
-    f::VectorNonlinearFunction,
+    f::MOI.VectorNonlinearFunction,
 ) where {F<:Function}
     new_rows =
         map(Base.Fix1(_unstable_substitute_variables, variable_map), f.rows)
-    return VectorNonlinearFunction(convert(Vector{Any}, new_rows))
+    return MOI.VectorNonlinearFunction(convert(Vector{Any}, new_rows))
 end
 
 """

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -119,6 +119,8 @@ for a similar function where `value_fn` returns an
 """
 function eval_variables end
 
+eval_variables(::Function, x::Union{Real,AbstractVector{<:Real}}) = x
+
 function eval_variables(value_fn::Function, t::MOI.ScalarAffineTerm)
     return t.coefficient * value_fn(t.variable)
 end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -802,10 +802,10 @@ function Base.getindex(
 end
 
 function Base.getindex(
-    it::ScalarFunctionIterator{<:MOI.GenericVectorFunction},
+    it::ScalarFunctionIterator{F},
     output_index::Integer,
-)
-    return it.f.rows[output_index]
+) where {F<:MOI.GenericVectorFunction}
+    return convert(scalar_type(F), it.f.rows[output_index])
 end
 
 function Base.getindex(

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -819,7 +819,7 @@ const LessThanIndicatorZero{T} =
     ),
     (MOI.ScalarNonlinearFunction,),
     (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),
-    (MOI.VectorOfVariables,),
+    (MOI.VectorOfVariables, MOI.VectorNonlinearFunction),
     (MOI.VectorAffineFunction, MOI.VectorQuadraticFunction)
 )
 

--- a/src/Utilities/objective_container.jl
+++ b/src/Utilities/objective_container.jl
@@ -21,6 +21,7 @@ mutable struct ObjectiveContainer{T} <: MOI.ModelLike
     vector_variables::Union{Nothing,MOI.VectorOfVariables}
     vector_affine::Union{Nothing,MOI.VectorAffineFunction{T}}
     vector_quadratic::Union{Nothing,MOI.VectorQuadraticFunction{T}}
+    vector_nonlinear::Union{Nothing,MOI.VectorNonlinearFunction}
     function ObjectiveContainer{T}() where {T}
         o = new{T}()
         MOI.empty!(o)
@@ -39,6 +40,7 @@ function MOI.empty!(o::ObjectiveContainer{T}) where {T}
     o.vector_variables = nothing
     o.vector_affine = nothing
     o.vector_quadratic = nothing
+    o.vector_nonlinear = nothing
     return
 end
 
@@ -85,6 +87,8 @@ function MOI.get(
         return MOI.VectorAffineFunction{T}
     elseif o.vector_quadratic !== nothing
         return MOI.VectorQuadraticFunction{T}
+    elseif o.vector_nonlinear !== nothing
+        return MOI.VectorNonlinearFunction
     end
     # The default if no objective is set.
     return MOI.ScalarAffineFunction{T}
@@ -105,6 +109,7 @@ function MOI.supports(
             MOI.VectorOfVariables,
             MOI.VectorAffineFunction{T},
             MOI.VectorQuadraticFunction{T},
+            MOI.VectorNonlinearFunction,
         },
     },
 ) where {T}
@@ -129,6 +134,8 @@ function MOI.get(
         return convert(F, o.vector_affine)
     elseif o.vector_quadratic !== nothing
         return convert(F, o.vector_quadratic)
+    elseif o.vector_nonlinear !== nothing
+        return convert(F, o.vector_nonlinear)
     end
     # The default if no objective is set.
     return convert(F, zero(MOI.ScalarAffineFunction{T}))
@@ -218,6 +225,17 @@ function MOI.set(
     return
 end
 
+function MOI.set(
+    o::ObjectiveContainer,
+    ::MOI.ObjectiveFunction{MOI.VectorNonlinearFunction},
+    f::MOI.VectorNonlinearFunction,
+)
+    _empty_keeping_sense(o)
+    o.is_function_set = true
+    o.vector_nonlinear = copy(f)
+    return
+end
+
 ###
 ### MOI.ListOfModelAttributesSet
 ###
@@ -263,6 +281,14 @@ function MOI.modify(
         o.vector_quadratic = modify_function!(o.vector_quadratic, change)
     elseif o.vector_affine !== nothing
         o.vector_affine = modify_function!(o.vector_affine, change)
+    elseif o.vector_nonlinear !== nothing
+        throw(
+            MOI.ModifyObjectiveNotAllowed(
+                change,
+                "Cannot modify objective when there is a " *
+                "`VectorNonlinearFunction` objective",
+            ),
+        )
     else
         # If no objective is set, modify a ScalarAffineFunction by default.
         f = zero(MOI.ScalarAffineFunction{T})
@@ -302,6 +328,14 @@ function MOI.delete(o::ObjectiveContainer, x::MOI.VariableIndex)
         o.vector_affine = remove_variable(o.vector_affine, x)
     elseif o.vector_quadratic !== nothing
         o.vector_quadratic = remove_variable(o.vector_quadratic, x)
+    elseif o.vector_nonlinear !== nothing
+        throw(
+            MOI.DeleteNotAllowed(
+                x,
+                "Cannot delete variable when there is a " *
+                "`VectorNonlinearFunction` objective",
+            ),
+        )
     end
     return
 end
@@ -333,6 +367,14 @@ function MOI.delete(o::ObjectiveContainer, x::Vector{MOI.VariableIndex})
         o.vector_affine = filter_variables(keep, o.vector_affine)
     elseif o.vector_quadratic !== nothing
         o.vector_quadratic = filter_variables(keep, o.vector_quadratic)
+    elseif o.vector_nonlinear !== nothing
+        throw(
+            MOI.DeleteNotAllowed(
+                first(x),
+                "Cannot delete variable when there is a " *
+                "`VectorNonlinearFunction` objective",
+            ),
+        )
     end
     return
 end

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -1737,6 +1737,17 @@ function operate_output_index!(
     return f
 end
 
+function operate_output_index!(
+    op::Union{typeof(+),typeof(-)},
+    ::Type{T},
+    output_index::Integer,
+    f::MOI.GenericVectorFunction,
+    g::Union{T,MOI.AbstractScalarFunction},
+) where {T}
+    f.rows[output_index] = operate!(op, T, f.rows[output_index], g)
+    return f
+end
+
 """
     operate_coefficient(
         op::Function,

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -296,7 +296,7 @@ function operate(
         MOI.VectorQuadraticFunction{T},
         MOI.VectorNonlinearFunction,
     },
-) where {T}
+) where {T<:Number}
     args = Any[
         operate(+, T, fi, gi) for (fi, gi) in zip(scalarize(f), scalarize(g))
     ]
@@ -313,7 +313,7 @@ function operate(
         MOI.VectorQuadraticFunction{T},
     },
     g::MOI.VectorNonlinearFunction,
-) where {T}
+) where {T<:Number}
     args = Any[
         operate(+, T, fi, gi) for (fi, gi) in zip(scalarize(f), scalarize(g))
     ]
@@ -378,7 +378,7 @@ function operate(
     ::typeof(-),
     ::Type{T},
     f::MOI.VectorNonlinearFunction,
-) where {T}
+) where {T<:Number}
     return MOI.VectorNonlinearFunction(Any[operate(-, T, fi) for fi in f.rows])
 end
 
@@ -601,7 +601,7 @@ function operate(
         MOI.VectorQuadraticFunction{T},
         MOI.VectorNonlinearFunction,
     },
-) where {T}
+) where {T<:Number}
     args = Any[
         operate(-, T, fi, gi) for (fi, gi) in zip(scalarize(f), scalarize(g))
     ]
@@ -618,7 +618,7 @@ function operate(
         MOI.VectorQuadraticFunction{T},
     },
     g::MOI.VectorNonlinearFunction,
-) where {T}
+) where {T<:Number}
     args = Any[
         operate(-, T, fi, gi) for (fi, gi) in zip(scalarize(f), scalarize(g))
     ]
@@ -675,7 +675,7 @@ function operate(
     ::Type{T},
     f::T,
     g::MOI.VectorNonlinearFunction,
-) where {T}
+) where {T<:Number}
     return MOI.VectorNonlinearFunction(Any[operate(*, T, f, h) for h in g.rows])
 end
 
@@ -711,7 +711,7 @@ function operate(
     ::Type{T},
     f::MOI.VectorNonlinearFunction,
     g::T,
-) where {T}
+) where {T<:Number}
     return MOI.VectorNonlinearFunction(Any[operate(*, T, h, g) for h in f.rows])
 end
 
@@ -892,7 +892,7 @@ function operate(
     ::Type{T},
     f::MOI.VectorNonlinearFunction,
     g::T,
-) where {T}
+) where {T<:Number}
     return MOI.VectorNonlinearFunction(Any[operate(/, T, h, g) for h in f.rows])
 end
 
@@ -978,7 +978,7 @@ function operate(
         MOI.VectorQuadraticFunction{T},
         MOI.VectorNonlinearFunction,
     }...,
-) where {T}
+) where {T<:Number}
     out = Any[]
     for a in args
         if a isa T
@@ -1743,7 +1743,7 @@ function operate_output_index!(
     output_index::Integer,
     f::MOI.GenericVectorFunction,
     g::Union{T,MOI.AbstractScalarFunction},
-) where {T}
+) where {T<:Number}
     f.rows[output_index] = operate!(op, T, f.rows[output_index], g)
     return f
 end

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -1741,7 +1741,7 @@ function operate_output_index!(
     op::Union{typeof(+),typeof(-)},
     ::Type{T},
     output_index::Integer,
-    f::MOI.GenericVectorFunction,
+    f::MOI.VectorNonlinearFunction,
     g::Union{T,MOI.AbstractScalarFunction},
 ) where {T<:Number}
     f.rows[output_index] = operate!(op, T, f.rows[output_index], g)

--- a/src/Utilities/parser.jl
+++ b/src/Utilities/parser.jl
@@ -115,6 +115,8 @@ function _parse_function(ex, ::Type{T} = Float64) where {T}
     else
         if isexpr(ex, :call, 2) && ex.args[1] == :ScalarNonlinearFunction
             return ex
+        elseif isexpr(ex, :call, 2) && ex.args[1] == :VectorNonlinearFunction
+            return ex
         end
         # For simplicity, only accept Expr(:call, :+, ...); no recursive
         # expressions
@@ -241,6 +243,8 @@ _parsed_to_moi(model, s::Number) = s
 function _parsed_to_moi(model, s::Expr)
     if isexpr(s, :call, 2) && s.args[1] == :ScalarNonlinearFunction
         return _parsed_scalar_to_moi(model, s.args[2])
+    elseif isexpr(s, :call, 2) && s.args[1] == :VectorNonlinearFunction
+        return _parsed_vector_to_moi(model, s.args[2])
     end
     args = Any[_parsed_to_moi(model, arg) for arg in s.args[2:end]]
     return MOI.ScalarNonlinearFunction(s.args[1], args)
@@ -249,6 +253,11 @@ end
 function _parsed_scalar_to_moi(model, s::Expr)
     args = Any[_parsed_to_moi(model, arg) for arg in s.args[2:end]]
     return MOI.ScalarNonlinearFunction(s.args[1], args)
+end
+
+function _parsed_vector_to_moi(model, s::Expr)
+    args = Any[_parsed_to_moi(model, arg) for arg in s.args]
+    return MOI.VectorNonlinearFunction(args)
 end
 
 for typename in [

--- a/src/Utilities/promote_operation.jl
+++ b/src/Utilities/promote_operation.jl
@@ -236,7 +236,7 @@ function promote_operation(
     ::Type{T},
     ::Type{T},
     ::Type{F},
-) where {T,F<:MOI.GenericVectorFunction}
+) where {T<:Number,F<:MOI.GenericVectorFunction}
     return vector_type(promote_operation(*, T, T, scalar_type(F)))
 end
 

--- a/src/Utilities/promote_operation.jl
+++ b/src/Utilities/promote_operation.jl
@@ -17,7 +17,7 @@ of the arguments `args` are `ArgsTypes`.
 One assumption is that the element type `T` is invariant under each operation.
 That is, `op(::T, ::T)::T` where `op` is a `+`, `-`, `*`, and `/`.
 
-There are five methods for which we implement `Utilities.promote_operation`:
+There are six methods for which we implement `Utilities.promote_operation`:
 
  1. `+`
     a. `promote_operation(::typeof(+), ::Type{T}, ::Type{F1}, ::Type{F2})`
@@ -38,10 +38,10 @@ There are five methods for which we implement `Utilities.promote_operation`:
     a. `promote_operation(::typeof(imag), ::Type{T}, ::Type{F})`
        where `F` is `VariableIndex` or `VectorOfVariables`
 
-In each case, `F` (or `F1` and `F2`) is one of the nine supported types, with
+In each case, `F` (or `F1` and `F2`) is one of the ten supported types, with
 a restriction that the mathematical operation makes sense, for example, we don't
 define `promote_operation(-, T, F1, F2)` where `F1` is a scalar-valued function
-and  `F2` is a vector-valued function. The nine supported types are:
+and  `F2` is a vector-valued function. The ten supported types are:
 
  1. ::T
  2. ::VariableIndex
@@ -52,6 +52,7 @@ and  `F2` is a vector-valued function. The nine supported types are:
  7. ::VectorOfVariables
  8. ::VectorAffineFunction{T}
  9. ::VectorQuadraticFunction{T}
+ 10. ::VectorNonlinearFunction
 """
 function promote_operation end
 
@@ -122,12 +123,14 @@ function promote_operation(
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
+        MOI.GenericVectorFunction,
     },
     F2<:Union{
         AbstractVector{T},
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
+        MOI.GenericVectorFunction,
     },
 }
     S = promote_operation(op, T, scalar_type(F1), scalar_type(F2))
@@ -169,6 +172,14 @@ function promote_operation(
     ::Type{MOI.VectorOfVariables},
 ) where {T<:Number}
     return MOI.VectorAffineFunction{T}
+end
+
+function promote_operation(
+    ::typeof(-),
+    ::Type{T},
+    ::Type{F},
+) where {T,F<:MOI.GenericVectorFunction}
+    return vector_type(promote_operation(-, T, scalar_type(F)))
 end
 
 ### Method 3a
@@ -220,6 +231,15 @@ function promote_operation(
     return MOI.VectorAffineFunction{T}
 end
 
+function promote_operation(
+    ::typeof(*),
+    ::Type{T},
+    ::Type{T},
+    ::Type{F},
+) where {T,F<:MOI.GenericVectorFunction}
+    return vector_type(promote_operation(*, T, T, scalar_type(F)))
+end
+
 ### Method 3b
 
 function promote_operation(
@@ -258,6 +278,15 @@ function promote_operation(
     ::Type{T},
 ) where {T<:Number}
     return MOI.VectorAffineFunction{T}
+end
+
+function promote_operation(
+    ::typeof(*),
+    ::Type{T},
+    ::Type{F},
+    ::Type{T},
+) where {T,F<:MOI.GenericVectorFunction}
+    return vector_type(promote_operation(*, T, scalar_type(F), T))
 end
 
 ### Method 3c
@@ -331,6 +360,15 @@ function promote_operation(
     return MOI.VectorAffineFunction{T}
 end
 
+function promote_operation(
+    ::typeof(/),
+    ::Type{T},
+    ::Type{F},
+    ::Type{T},
+) where {T,F<:MOI.GenericVectorFunction}
+    return vector_type(promote_operation(/, T, scalar_type(F), T))
+end
+
 ### Method 5a
 
 function promote_operation(
@@ -385,6 +423,27 @@ function promote_operation(
     }...,
 ) where {T<:Number}
     return MOI.VectorQuadraticFunction{T}
+end
+
+function promote_operation(
+    ::typeof(vcat),
+    ::Type{T},
+    ::Type{
+        <:Union{
+            T,
+            MOI.VariableIndex,
+            MOI.ScalarAffineFunction{T},
+            MOI.ScalarQuadraticFunction{T},
+            MOI.ScalarNonlinearFunction,
+            AbstractVector{T},
+            MOI.VectorOfVariables,
+            MOI.VectorAffineFunction{T},
+            MOI.VectorQuadraticFunction{T},
+            MOI.VectorNonlinearFunction,
+        },
+    }...,
+) where {T}
+    return MOI.VectorNonlinearFunction
 end
 
 ### Method 6a

--- a/src/Utilities/promote_operation.jl
+++ b/src/Utilities/promote_operation.jl
@@ -123,14 +123,14 @@ function promote_operation(
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
-        MOI.GenericVectorFunction,
+        MOI.VectorNonlinearFunction,
     },
     F2<:Union{
         AbstractVector{T},
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
-        MOI.GenericVectorFunction,
+        MOI.VectorNonlinearFunction,
     },
 }
     S = promote_operation(op, T, scalar_type(F1), scalar_type(F2))
@@ -177,9 +177,9 @@ end
 function promote_operation(
     ::typeof(-),
     ::Type{T},
-    ::Type{F},
-) where {T,F<:MOI.GenericVectorFunction}
-    return vector_type(promote_operation(-, T, scalar_type(F)))
+    ::Type{MOI.VectorNonlinearFunction},
+) where {T<:Number}
+    return vector_type(promote_operation(-, T, MOI.ScalarNonlinearFunction))
 end
 
 ### Method 3a
@@ -235,9 +235,9 @@ function promote_operation(
     ::typeof(*),
     ::Type{T},
     ::Type{T},
-    ::Type{F},
-) where {T<:Number,F<:MOI.GenericVectorFunction}
-    return vector_type(promote_operation(*, T, T, scalar_type(F)))
+    ::Type{MOI.VectorNonlinearFunction},
+) where {T<:Number}
+    return vector_type(promote_operation(*, T, T, MOI.ScalarNonlinearFunction))
 end
 
 ### Method 3b
@@ -283,10 +283,10 @@ end
 function promote_operation(
     ::typeof(*),
     ::Type{T},
-    ::Type{F},
+    ::Type{MOI.VectorNonlinearFunction},
     ::Type{T},
-) where {T,F<:MOI.GenericVectorFunction}
-    return vector_type(promote_operation(*, T, scalar_type(F), T))
+) where {T<:Number}
+    return vector_type(promote_operation(*, T, MOI.ScalarNonlinearFunction, T))
 end
 
 ### Method 3c
@@ -363,10 +363,10 @@ end
 function promote_operation(
     ::typeof(/),
     ::Type{T},
-    ::Type{F},
+    ::Type{MOI.VectorNonlinearFunction},
     ::Type{T},
-) where {T,F<:MOI.GenericVectorFunction}
-    return vector_type(promote_operation(/, T, scalar_type(F), T))
+) where {T}
+    return vector_type(promote_operation(/, T, MOI.ScalarNonlinearFunction, T))
 end
 
 ### Method 5a

--- a/src/Utilities/promote_operation.jl
+++ b/src/Utilities/promote_operation.jl
@@ -442,7 +442,7 @@ function promote_operation(
             MOI.VectorNonlinearFunction,
         },
     }...,
-) where {T}
+) where {T<:Number}
     return MOI.VectorNonlinearFunction
 end
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -666,14 +666,17 @@ function Base.copy(f::VectorQuadraticFunction)
 end
 
 """
-    VectorNonlinearFunction(args::Vector{Any})
+    VectorNonlinearFunction(args::Vector{ScalarNonlinearFunction})
 
-The vector-valued nonlinear function composed of a vector of scalar functions.
+The vector-valued nonlinear function composed of a vector of
+[`ScalarNonlinearFunction`](@ref).
 
 ## `args`
 
 The vector `args` contains the scalar elements of the nonlinear function. Each
-element must be one of the following:
+element must be a [`ScalarNonlinearFunction`](@ref), but if you pass a
+`Vector{Any}`, the elements can be automatically converted from one of the
+following:
 
  * A constant value of type `T<:Real`
  * A [`VariableIndex`](@ref)
@@ -703,6 +706,8 @@ julia> MOI.VectorNonlinearFunction([g, x])
 │+(MOI.VariableIndex(1))          │
 └                                 ┘
 ```
+
+Note the automatic conversion from `x` to `+(x)`.
 """
 struct VectorNonlinearFunction <: AbstractVectorFunction
     rows::Vector{ScalarNonlinearFunction}

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -716,10 +716,7 @@ end
 
 Base.copy(f::VectorNonlinearFunction) = VectorNonlinearFunction(copy(f.rows))
 
-function Base.:(==)(
-    f::VectorNonlinearFunction,
-    g::VectorNonlinearFunction,
-)
+function Base.:(==)(f::VectorNonlinearFunction, g::VectorNonlinearFunction)
     return f.rows == g.rows
 end
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -697,15 +697,15 @@ julia> g = MOI.ScalarNonlinearFunction(
        )
 ^(sin(MOI.VariableIndex(1)), 2.0)
 
-julia> MOI.VectorNonlinearFunction(Any[g, x])
+julia> MOI.VectorNonlinearFunction([g, x])
 ┌                                 ┐
 │^(sin(MOI.VariableIndex(1)), 2.0)│
-│MOI.VariableIndex(1)             │
+│+(MOI.VariableIndex(1))          │
 └                                 ┘
 ```
 """
 struct VectorNonlinearFunction <: AbstractVectorFunction
-    rows::Vector{Any}
+    rows::Vector{ScalarNonlinearFunction}
 end
 
 output_dimension(f::VectorNonlinearFunction) = length(f.rows)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1172,6 +1172,10 @@ end
 
 # ScalarNonlinearFunction
 
+function Base.convert(::Type{ScalarNonlinearFunction}, x::VariableIndex)
+    return ScalarNonlinearFunction(:+, Any[x])
+end
+
 function Base.convert(::Type{ScalarNonlinearFunction}, term::ScalarAffineTerm)
     return ScalarNonlinearFunction(:*, Any[term.coefficient, term.variable])
 end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -406,33 +406,6 @@ All subtypes of `AbstractVectorFunction` must implement:
 """
 abstract type AbstractVectorFunction <: AbstractFunction end
 
-struct GenericVectorFunction{T} <: AbstractVectorFunction
-    rows::Vector{T}
-end
-
-output_dimension(f::GenericVectorFunction) = length(f.rows)
-
-function constant(f::GenericVectorFunction, ::Type{T}) where {T}
-    return zeros(T, output_dimension(f))
-end
-
-Base.copy(f::GenericVectorFunction) = GenericVectorFunction(copy(f.rows))
-
-function Base.:(==)(
-    f::GenericVectorFunction{T},
-    g::GenericVectorFunction{T},
-) where {T}
-    return f.rows == g.rows
-end
-
-function Base.isapprox(
-    x::GenericVectorFunction{T},
-    y::GenericVectorFunction{T};
-    kwargs...,
-) where {T}
-    return all(isapprox(xi, yi; kwargs...) for (xi, yi) in zip(x.rows, y.rows))
-end
-
 """
     VectorOfVariables(variables::Vector{VariableIndex}) <: AbstractVectorFunction
 
@@ -731,7 +704,32 @@ julia> MOI.VectorNonlinearFunction(Any[g, x])
 └                                 ┘
 ```
 """
-const VectorNonlinearFunction = GenericVectorFunction{Any}
+struct VectorNonlinearFunction <: AbstractVectorFunction
+    rows::Vector{Any}
+end
+
+output_dimension(f::VectorNonlinearFunction) = length(f.rows)
+
+function constant(f::VectorNonlinearFunction, ::Type{T}) where {T}
+    return zeros(T, output_dimension(f))
+end
+
+Base.copy(f::VectorNonlinearFunction) = VectorNonlinearFunction(copy(f.rows))
+
+function Base.:(==)(
+    f::VectorNonlinearFunction,
+    g::VectorNonlinearFunction,
+)
+    return f.rows == g.rows
+end
+
+function Base.isapprox(
+    x::VectorNonlinearFunction,
+    y::VectorNonlinearFunction;
+    kwargs...,
+)
+    return all(isapprox(xi, yi; kwargs...) for (xi, yi) in zip(x.rows, y.rows))
+end
 
 # Function modifications
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1172,6 +1172,10 @@ end
 
 # ScalarNonlinearFunction
 
+function Base.convert(::Type{ScalarNonlinearFunction}, x::Real)
+    return ScalarNonlinearFunction(:+, Any[x])
+end
+
 function Base.convert(::Type{ScalarNonlinearFunction}, x::VariableIndex)
     return ScalarNonlinearFunction(:+, Any[x])
 end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -13,7 +13,6 @@ components if `f` is an [`AbstractVectorFunction`](@ref).
 function output_dimension end
 
 output_dimension(::AbstractScalarFunction) = 1
-output_dimension(x::AbstractVector) = length(x)
 
 """
     constant(f::AbstractFunction[, ::Type{T}]) where {T}
@@ -432,13 +431,6 @@ function Base.isapprox(
     kwargs...,
 ) where {T}
     return all(isapprox(xi, yi; kwargs...) for (xi, yi) in zip(x.rows, y.rows))
-end
-
-function Base.convert(
-    ::Type{GenericVectorFunction{T}},
-    rows::Vector{T},
-) where {T}
-    return GenericVectorFunction(rows)
 end
 
 """

--- a/test/Bridges/Constraint/flip_sign.jl
+++ b/test/Bridges/Constraint/flip_sign.jl
@@ -425,6 +425,17 @@ function test_runtests()
         [-2.1 * x + 1.0] in Nonnegatives(1)
         """,
     )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.NonposToNonnegBridge,
+        """
+        variables: x
+        VectorNonlinearFunction([2.1 * x - 1.0]) in Nonpositives(1)
+        """,
+        """
+        variables: x
+        VectorNonlinearFunction([-(2.1 * x - 1.0)]) in Nonnegatives(1)
+        """,
+    )
     return
 end
 

--- a/test/Bridges/Constraint/scalarize.jl
+++ b/test/Bridges/Constraint/scalarize.jl
@@ -223,6 +223,21 @@ function test_runtests()
         4.0 * x == 5.0
         """,
     )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ScalarizeBridge,
+        """
+        variables: x
+        VectorNonlinearFunction([2.0 * x - 1.0]) in Nonnegatives(1)
+        VectorNonlinearFunction([3.0 * x + 1.0]) in Nonpositives(1)
+        VectorNonlinearFunction([4.0 * x - 5.0]) in Zeros(1)
+        """,
+        """
+        variables: x
+        ScalarNonlinearFunction(2.0 * x - 1.0) >= 0.0
+        ScalarNonlinearFunction(3.0 * x + 1.0) <= 0.0
+        ScalarNonlinearFunction(4.0 * x - 5.0) == 0.0
+        """,
+    )
     return
 end
 

--- a/test/Bridges/Constraint/scalarize.jl
+++ b/test/Bridges/Constraint/scalarize.jl
@@ -241,6 +241,29 @@ function test_runtests()
     return
 end
 
+function test_VectorNonlinearFunction_mixed_type()
+    # We can't use the standard runtests because ScalarNonlinearFunction does
+    # not preserve f(x) ≈ (f(x) - g(x)) + g(x)
+    inner = MOI.Utilities.Model{Float64}()
+    model = MOI.Bridges.Constraint.Scalarize{Float64}(inner)
+    x = MOI.add_variable(model)
+    f = MOI.ScalarNonlinearFunction(:log, Any[x])
+    g = MOI.VectorNonlinearFunction(Any[1.0, x, 2.0 * x - 1.0, f])
+    c = MOI.add_constraint(model, g, MOI.Nonnegatives(4))
+    F, S = MOI.ScalarNonlinearFunction, MOI.GreaterThan{Float64}
+    indices = MOI.get(inner, MOI.ListOfConstraintIndices{F,S}())
+    @test length(indices) == 4
+    inner_variables = MOI.get(inner, MOI.ListOfVariableIndices())
+    @test length(inner_variables) == 1
+    y = inner_variables[1]
+    out = convert.(MOI.ScalarNonlinearFunction, Any[1.0, y, 2.0 * y - 1.0])
+    push!(out, MOI.ScalarNonlinearFunction(:log, Any[y]))
+    for (input, output) in zip(indices, out)
+        @test ≈(MOI.get(inner, MOI.ConstraintFunction(), input), output)
+    end
+    return
+end
+
 end  # module
 
 TestConstraintScalarize.runtests()

--- a/test/Bridges/Constraint/vectorize.jl
+++ b/test/Bridges/Constraint/vectorize.jl
@@ -248,7 +248,7 @@ MOI.Utilities.@model(
     (MOI.ScalarAffineFunction,),
     (),
     ()
- )
+)
 
 function test_unsupported_ScalarNonlinearFunction()
     model = MOI.instantiate(Model2179{Float64}; with_bridge_type = Float64)

--- a/test/Bridges/Constraint/vectorize.jl
+++ b/test/Bridges/Constraint/vectorize.jl
@@ -239,26 +239,26 @@ function test_runtests()
 end
 
 MOI.Utilities.@model(
-     Model2179,
-     (),
-     (MOI.GreaterThan, MOI.LessThan),
-     (),
-     (),
-     (),
-     (MOI.ScalarAffineFunction,),
-     (),
-     ()
+    Model2179,
+    (),
+    (MOI.GreaterThan, MOI.LessThan),
+    (),
+    (),
+    (),
+    (MOI.ScalarAffineFunction,),
+    (),
+    ()
  )
 
- function test_unsupported_ScalarNonlinearFunction()
-     model = MOI.instantiate(Model2179{Float64}; with_bridge_type = Float64)
-     MOI.supports_constraint(
-         model,
-         MOI.ScalarNonlinearFunction,
-         MOI.GreaterThan{Float64},
-     )
-     return
- end
+function test_unsupported_ScalarNonlinearFunction()
+    model = MOI.instantiate(Model2179{Float64}; with_bridge_type = Float64)
+    MOI.supports_constraint(
+        model,
+        MOI.ScalarNonlinearFunction,
+        MOI.GreaterThan{Float64},
+    )
+    return
+end
 
 function test_VectorNonlinearFunction()
     # We can't use the standard runtests because ScalarNonlinearFunction does

--- a/test/Bridges/Constraint/vectorize.jl
+++ b/test/Bridges/Constraint/vectorize.jl
@@ -238,24 +238,27 @@ function test_runtests()
     return
 end
 
-MOI.Utilities.@model(
-    Model2179,
-    (),
-    (MOI.GreaterThan, MOI.LessThan),
-    (),
-    (),
-    (),
-    (MOI.ScalarAffineFunction,),
-    (),
-    ()
-)
-
-function test_unsupported_ScalarNonlinearFunction()
-    model = MOI.instantiate(Model2179{Float64}; with_bridge_type = Float64)
-    MOI.supports_constraint(
-        model,
-        MOI.ScalarNonlinearFunction,
-        MOI.GreaterThan{Float64},
+function test_VectorNonlinearFunction()
+    # We can't use the standard runtests because ScalarNonlinearFunction does
+    # not preserve f(x) ≈ (f(x) - g(x)) + g(x)
+    inner = MOI.Utilities.Model{Float64}()
+    model = MOI.Bridges.Constraint.Vectorize{Float64}(inner)
+    x = MOI.add_variable(model)
+    f = MOI.ScalarNonlinearFunction(:log, Any[x])
+    c = MOI.add_constraint(model, f, MOI.EqualTo(1.0))
+    F, S = MOI.VectorNonlinearFunction, MOI.Zeros
+    indices = MOI.get(inner, MOI.ListOfConstraintIndices{F,S}())
+    @test length(indices) == 1
+    inner_variables = MOI.get(inner, MOI.ListOfVariableIndices())
+    @test length(inner_variables) == 1
+    y = inner_variables[1]
+    g = MOI.ScalarNonlinearFunction(
+        :-,
+        Any[MOI.ScalarNonlinearFunction(:log, Any[x]), 1.0],
+    )
+    @test ≈(
+        MOI.get(inner, MOI.ConstraintFunction(), indices[1]),
+        MOI.VectorNonlinearFunction(Any[g]),
     )
     return
 end

--- a/test/Bridges/Constraint/vectorize.jl
+++ b/test/Bridges/Constraint/vectorize.jl
@@ -238,6 +238,28 @@ function test_runtests()
     return
 end
 
+MOI.Utilities.@model(
+     Model2179,
+     (),
+     (MOI.GreaterThan, MOI.LessThan),
+     (),
+     (),
+     (),
+     (MOI.ScalarAffineFunction,),
+     (),
+     ()
+ )
+
+ function test_unsupported_ScalarNonlinearFunction()
+     model = MOI.instantiate(Model2179{Float64}; with_bridge_type = Float64)
+     MOI.supports_constraint(
+         model,
+         MOI.ScalarNonlinearFunction,
+         MOI.GreaterThan{Float64},
+     )
+     return
+ end
+
 function test_VectorNonlinearFunction()
     # We can't use the standard runtests because ScalarNonlinearFunction does
     # not preserve f(x) ≈ (f(x) - g(x)) + g(x)

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -345,7 +345,7 @@ function test_substitute_variables_vector_nonlinear_function()
             MOI.ScalarNonlinearFunction(:+, Any[1.5*x]),
             MOI.ScalarNonlinearFunction(
                 :+,
-                Any[MOI.ScalarNonlinearFunction(:*, Any[2.0, 1.5 * x])],
+                Any[MOI.ScalarNonlinearFunction(:*, Any[2.0, 1.5*x])],
             ),
             MOI.ScalarNonlinearFunction(:log, Any[1.5*x]),
         ]),

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -265,7 +265,7 @@ function test_eval_variables_vector_nonlinear_function()
     model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     x = MOI.add_variable(model)
     f = MOI.ScalarNonlinearFunction(:log, Any[x])
-    g = MOI.VectorNonlinearFunction(Any[1.0, x, 2.0 * x, f])
+    g = MOI.VectorNonlinearFunction(Any[1.0, x, 2.0*x, f])
     @test ≈(
         MOI.Utilities.eval_variables(xi -> 0.5, model, g),
         [1.0, 0.5, 1.0, log(0.5)],
@@ -337,11 +337,11 @@ function test_substitute_variables_vector_nonlinear_function()
     model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     x = MOI.add_variable(model)
     f = MOI.ScalarNonlinearFunction(:log, Any[x])
-    g = MOI.VectorNonlinearFunction(Any[1.0, x, 2.0 * x, f])
-    h = MOI.ScalarNonlinearFunction(:log, Any[1.5 * x])
+    g = MOI.VectorNonlinearFunction(Any[1.0, x, 2.0*x, f])
+    h = MOI.ScalarNonlinearFunction(:log, Any[1.5*x])
     @test ≈(
         MOI.Utilities.substitute_variables(x -> 1.5 * x, g),
-        MOI.VectorNonlinearFunction(Any[1.0, 1.5 * x, 3.0 * x, h]),
+        MOI.VectorNonlinearFunction(Any[1.0, 1.5*x, 3.0*x, h]),
     )
     return
 end
@@ -349,7 +349,7 @@ end
 function test_canonicalize_vector_nonlinear_function()
     model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     x = MOI.add_variable(model)
-    f = MOI.ScalarNonlinearFunction(:log, Any[1.0 * x + 2.0 * x])
+    f = MOI.ScalarNonlinearFunction(:log, Any[1.0*x+2.0*x])
     fi = 1.0 * x + 1.0 * x
     @test length(fi.terms) == 2
     g = MOI.VectorNonlinearFunction(Any[1.0, x, fi, f])
@@ -363,15 +363,15 @@ end
 function test_eachscalar_vector_nonlinear_function()
     model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     x = MOI.add_variable(model)
-    f = MOI.ScalarNonlinearFunction(:log, Any[1.0 * x + 2.0 * x])
-    g = MOI.VectorNonlinearFunction(Any[1.0, x, 2.0 * x, f])
+    f = MOI.ScalarNonlinearFunction(:log, Any[1.0*x+2.0*x])
+    g = MOI.VectorNonlinearFunction(Any[1.0, x, 2.0*x, f])
     scalars = MOI.Utilities.eachscalar(g)
     @test eltype(scalars) == MOI.ScalarNonlinearFunction
     @test ≈(scalars[1], MOI.ScalarNonlinearFunction(:+, Any[1.0]))
     @test ≈(scalars[2], MOI.ScalarNonlinearFunction(:+, Any[x]))
     @test ≈(scalars[3], convert(MOI.ScalarNonlinearFunction, 2.0 * x))
     @test ≈(scalars[4], f)
-    @test ≈(scalars[2:3], MOI.VectorNonlinearFunction(Any[x, 2.0 * x]))
+    @test ≈(scalars[2:3], MOI.VectorNonlinearFunction(Any[x, 2.0*x]))
     return
 end
 

--- a/test/Utilities/test_operate!.jl
+++ b/test/Utilities/test_operate!.jl
@@ -599,7 +599,7 @@ function test_operate_output_index_1a()
         (1.0, 1.0, 1.0),
         :log => (0, 0, 0),
     )
-    for i in 2:5
+    for i in 2:6
         for j in 1:i
             if (i, j) == (2, 1)
                 continue

--- a/test/Utilities/test_operate!.jl
+++ b/test/Utilities/test_operate!.jl
@@ -597,6 +597,7 @@ function test_operate_output_index_1a()
         (0.0, 1.0, 0.0),
         (0.0, 0.0, 1.0),
         (1.0, 1.0, 1.0),
+        :log => (0, 0, 0),
     )
     for i in 2:5
         for j in 1:i

--- a/test/Utilities/test_operate!.jl
+++ b/test/Utilities/test_operate!.jl
@@ -56,6 +56,10 @@ function _test_function(pair::Pair{Symbol,<:Any})
     end
 end
 
+function _test_function(pairs::Vector{<:Any})
+    return MOI.VectorNonlinearFunction(Any[_test_function(f) for f in pairs])
+end
+
 function test_operate_1a()
     for coef in (
         (0, 0, 0),
@@ -69,6 +73,7 @@ function test_operate_1a()
         [(0, 1, 0)],
         [(0, 0, 1)],
         [(1, 1, 1)],
+        [:log => (0, 0, 0)],
     )
         f = _test_function(coef)
         @test MOI.Utilities.operate(+, Int, f) == f
@@ -90,6 +95,7 @@ function test_operate_1b()
         [(0, 1, 0)],
         [(0, 0, 1)],
         [(1, 1, 1)],
+        [:log => (0, 0, 0)],
     )
     special_cases = Dict((0, 0, 0) => (0, 1, 0))
     for i in 1:6, j in 1:6
@@ -104,13 +110,30 @@ function test_operate_1b()
         @test MOI.Utilities.operate(+, Int, fi, fj) ≈ fk
         @test MOI.Utilities.operate!(+, Int, fi, fj) ≈ fk
     end
-    for i in 7:11, j in 7:11
+    for i in 7:12, j in 7:12
         fi, fj = _test_function(F[i]), _test_function(F[j])
-        k = map(zip(F[i], F[j])) do (x, y)
-            return get(special_cases, x, x) .+ get(special_cases, y, y)
+        if i == 12 || j == 12
+            args = Any[]
+            for (fi_, fj_) in zip(F[i], F[j])
+                push!(
+                    args,
+                    MOI.Utilities.operate(
+                        +,
+                        Int,
+                        _test_function(fi_),
+                        _test_function(fj_),
+                    ),
+                )
+            end
+            fk = MOI.VectorNonlinearFunction(args)
+        else
+            k = map(zip(F[i], F[j])) do (x, y)
+                return get(special_cases, x, x) .+ get(special_cases, y, y)
+            end
+            fk = _test_function(k)
         end
-        @test MOI.Utilities.operate(+, Int, fi, fj) ≈ _test_function(k)
-        @test MOI.Utilities.operate!(+, Int, fi, fj) ≈ _test_function(k)
+        @test MOI.Utilities.operate(+, Int, fi, fj) ≈ fk
+        @test MOI.Utilities.operate!(+, Int, fi, fj) ≈ fk
     end
     return
 end
@@ -161,6 +184,7 @@ function test_operate_2a()
         [(0, 1, 0)] => [(0, -1, 0)],
         [(0, 0, 1)] => [(0, 0, -1)],
         [(1, 1, 1)] => [(-1, -1, -1)],
+        [(:log => (0, 0, 0))] => [(:- => (:log => (0, 0, 0)))],
     )
         @test MOI.Utilities.operate(-, T, _test_function(f)) ≈ _test_function(g)
         @test MOI.Utilities.operate!(-, T, _test_function(f)) ≈
@@ -192,6 +216,7 @@ function test_operate_2b()
         [(0, 1, 0)],
         [(0, 0, 1)],
         [(1, 1, 1)],
+        [:log => (0, 0, 0)],
     )
     special_cases = Dict((0, 0, 0) => (0, 1, 0))
     for i in 1:6, j in 1:6
@@ -213,15 +238,32 @@ function test_operate_2b()
         @test MOI.Utilities.operate(-, Int, fi, fj) ≈ fk
         @test MOI.Utilities.operate!(-, Int, fi, fj) ≈ fk
     end
-    for i in 7:11, j in 7:11
-        F2 = [2 .* fi for fi in F[i]]
-        fi, fj = _test_function(F2), _test_function(F[j])
-        k = map(zip(F2, F[j])) do (x, y)
-            return get(special_cases, x, x) .- get(special_cases, y, y)
-        end
-        fk = _test_function(k)
-        if (i, j) in ((7, 7), (7, 9))
-            fk = MOI.VectorAffineFunction(MOI.VectorAffineTerm{Int}[], [0])
+    for i in 7:12, j in 7:12
+        fi, fj = _test_function(F[i]), _test_function(F[j])
+        if i == 12 || j == 12
+            args = Any[]
+            for (fi_, fj_) in zip(F[i], F[j])
+                push!(
+                    args,
+                    MOI.Utilities.operate(
+                        -,
+                        Int,
+                        _test_function(fi_),
+                        _test_function(fj_),
+                    ),
+                )
+            end
+            fk = MOI.VectorNonlinearFunction(args)
+        else
+            F2 = [2 .* fi for fi in F[i]]
+            fi, fj = _test_function(F2), _test_function(F[j])
+            k = map(zip(F2, F[j])) do (x, y)
+                return get(special_cases, x, x) .- get(special_cases, y, y)
+            end
+            fk = _test_function(k)
+            if (i, j) in ((7, 7), (7, 9))
+                fk = MOI.VectorAffineFunction(MOI.VectorAffineTerm{Int}[], [0])
+            end
         end
         @test MOI.Utilities.operate(-, Int, fi, fj) ≈ fk
         @test MOI.Utilities.operate!(-, Int, fi, fj) ≈ fk
@@ -243,6 +285,7 @@ function test_operate_3a()
         [(0, 1, 0)] => [(0, 3, 0)],
         [(0, 0, 1)] => [(0, 0, 3)],
         [(1, 1, 1)] => [(3, 3, 3)],
+        [(:log => (0, 0, 0))] => [(:* => [(3, 0, 0), (:log => (0, 0, 0))])],
     )
         f = _test_function(f)
         @test MOI.Utilities.operate(*, T, 3, f) ≈ _test_function(g)
@@ -265,6 +308,7 @@ function test_operate_3b()
         [(0, 1, 0)] => [(0, 3, 0)],
         [(0, 0, 1)] => [(0, 0, 3)],
         [(1, 1, 1)] => [(3, 3, 3)],
+        [(:log => (0, 0, 0))] => [(:* => [(:log => (0, 0, 0)), (3, 0, 0)])],
     )
         f = _test_function(f)
         @test MOI.Utilities.operate(*, T, f, 3) ≈ _test_function(g)
@@ -296,6 +340,8 @@ function test_operate_4a()
         [(0.0, 1.0, 0.0)] => [(0.0, 0.5, 0.0)],
         [(0.0, 0.0, 1.0)] => [(0.0, 0.0, 0.5)],
         [(1.0, 1.0, 1.0)] => [(0.5, 0.5, 0.5)],
+        [(:log => (0, 0, 0))] =>
+            [(:/ => [(:log => (0, 0, 0)), (2.0, 0.0, 0.0)])],
     )
         f = _test_function(f)
         @test MOI.Utilities.operate(/, T, f, 2.0) ≈ _test_function(g)
@@ -312,11 +358,13 @@ function test_operate_5a()
         (0.0, 1.0, 0.0),
         (0.0, 0.0, 1.0),
         (1.0, 1.0, 1.0),
+        (:log => (0, 0, 0)),
         [(0.0, 0.0, 0.0)],
         [(1.0, 0.0, 0.0)],
         [(0.0, 1.0, 0.0)],
         [(0.0, 0.0, 1.0)],
         [(1.0, 1.0, 1.0)],
+        [:log => (0, 0, 0)],
     )
     for f in F, g in F
         h = vcat(f, g)

--- a/test/Utilities/test_promote_operation.jl
+++ b/test/Utilities/test_promote_operation.jl
@@ -33,6 +33,7 @@ function test_promote_operation_1a()
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
     )
     special_cases = Dict(
         (1, 2) => 3,
@@ -46,7 +47,7 @@ function test_promote_operation_1a()
         k = get(special_cases, (i, j), max(i, j))
         @test MOI.Utilities.promote_operation(+, T, F[i], F[j]) == F[k]
     end
-    for i in 6:9, j in 6:9
+    for i in 6:10, j in 6:10
         k = get(special_cases, (i, j), max(i, j))
         @test MOI.Utilities.promote_operation(+, T, F[i], F[j]) == F[k]
     end
@@ -65,9 +66,10 @@ function test_promote_operation_2a()
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
     )
     special_cases = Dict(2 => 3, 7 => 8)
-    for i in 1:8
+    for i in 1:10
         j = get(special_cases, i, i)
         @test MOI.Utilities.promote_operation(-, T, F[i]) == F[j]
     end
@@ -86,6 +88,7 @@ function test_promote_operation_2b()
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
     )
     special_cases = Dict(
         (1, 2) => 3,
@@ -99,7 +102,7 @@ function test_promote_operation_2b()
         k = get(special_cases, (i, j), max(i, j))
         @test MOI.Utilities.promote_operation(-, T, F[i], F[j]) == F[k]
     end
-    for i in 6:9, j in 6:9
+    for i in 6:10, j in 6:10
         k = get(special_cases, (i, j), max(i, j))
         @test MOI.Utilities.promote_operation(-, T, F[i], F[j]) == F[k]
     end
@@ -118,9 +121,10 @@ function test_promote_operation_3a()
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
     )
     special_cases = Dict(2 => 3, 7 => 8)
-    for i in 1:9
+    for i in 1:10
         j = get(special_cases, i, i)
         @test MOI.Utilities.promote_operation(*, T, T, F[i]) == F[j]
     end
@@ -139,9 +143,10 @@ function test_promote_operation_3b()
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
     )
     special_cases = Dict(2 => 3, 7 => 8)
-    for i in 1:9
+    for i in 1:10
         j = get(special_cases, i, i)
         @test MOI.Utilities.promote_operation(*, T, F[i], T) == F[j]
     end
@@ -160,9 +165,10 @@ function test_promote_operation_4a()
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
     )
     special_cases = Dict(2 => 3, 7 => 8)
-    for i in 1:9
+    for i in 1:10
         j = get(special_cases, i, i)
         @test MOI.Utilities.promote_operation(/, T, F[i], T) == F[j]
     end
@@ -176,23 +182,25 @@ function test_promote_operation_5a()
         MOI.VariableIndex,
         MOI.ScalarAffineFunction{T},
         MOI.ScalarQuadraticFunction{T},
+        MOI.ScalarNonlinearFunction,
         Vector{T},
         MOI.VectorOfVariables,
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
     )
     special_cases = Dict(
-        (1, 2) => 7,
-        (2, 1) => 7,
-        (1, 6) => 7,
-        (6, 1) => 7,
-        (2, 5) => 7,
-        (5, 2) => 7,
-        (5, 6) => 7,
-        (6, 5) => 7,
+        (1, 2) => 8,
+        (2, 1) => 8,
+        (1, 7) => 8,
+        (7, 1) => 8,
+        (2, 6) => 8,
+        (6, 2) => 8,
+        (6, 7) => 8,
+        (7, 6) => 8,
     )
-    for i in 1:8, j in 1:8
-        k = max(i <= 4 ? i + 4 : i, j <= 4 ? j + 4 : j)
+    for i in 1:10, j in 1:10
+        k = max(i <= 5 ? i + 5 : i, j <= 5 ? j + 5 : j)
         k = get(special_cases, (i, j), k)
         @test MOI.Utilities.promote_operation(vcat, T, F[i], F[j]) == F[k]
     end


### PR DESCRIPTION
Resurrecting `VectorNonlinearFunction` from the depths of https://github.com/jump-dev/MathOptInterface.jl/pull/2059.

There are two main motivating problems for this:

 1. `VectorNonlinearFunction-in-Complements` constrains for nonlinear complementarity problems
     - https://github.com/chkwon/PATHSolver.jl/pull/82
 2. `ObjectiveFunction{VectorNonlinearFunction}` for nonlinear multi-objective problems
     - https://github.com/jump-dev/MultiObjectiveAlgorithms.jl/pull/68

Documentation

https://jump.dev/MathOptInterface.jl/previews/PR2201/reference/standard_form/#MathOptInterface.VectorNonlinearFunction

I also removed this from #2059 because there we a lot of issues with the bridges, but I have a better handle on what to do now, and we can easily run `solver-tests` to catch the culprits.

https://github.com/jump-dev/MathOptInterface.jl/actions/runs/5218217869