### PR TITLE
[Bridges] add IntegerToZeroOneBridge

### DIFF
--- a/docs/src/submodules/Bridges/list_of_bridges.md
+++ b/docs/src/submodules/Bridges/list_of_bridges.md
@@ -63,6 +63,7 @@ Bridges.Constraint.IndicatorLessToGreaterThanBridge
 Bridges.Constraint.IndicatorSOS1Bridge
 Bridges.Constraint.SemiToBinaryBridge
 Bridges.Constraint.ZeroOneBridge
+Bridges.Constraint.IntegerToZeroOneBridge
 Bridges.Constraint.NumberConversionBridge
 Bridges.Constraint.AllDifferentToCountDistinctBridge
 Bridges.Constraint.ReifiedAllDifferentToCountDistinctBridge

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -35,6 +35,7 @@ include("bridges/geomean.jl")
 include("bridges/indicator_activate_on_zero.jl")
 include("bridges/indicator_flipsign.jl")
 include("bridges/indicator_sos.jl")
+include("bridges/integer_to_zeroone.jl")
 include("bridges/interval.jl")
 include("bridges/ltgt_to_interval.jl")
 include("bridges/norm_infinity.jl")
@@ -124,6 +125,7 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(bridged_model, IndicatorGreaterToLessThanBridge{T})
     MOI.Bridges.add_bridge(bridged_model, SemiToBinaryBridge{T})
     MOI.Bridges.add_bridge(bridged_model, ZeroOneBridge{T})
+    MOI.Bridges.add_bridge(bridged_model, IntegerToZeroOneBridge{T})
     # Do not add by default
     # MOI.Bridges.add_bridge(bridged_model, NumberConversionBridge{T})
     # Constraint programming bridges

--- a/src/Bridges/Constraint/bridges/integer_to_zeroone.jl
+++ b/src/Bridges/Constraint/bridges/integer_to_zeroone.jl
@@ -1,0 +1,174 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+"""
+    IntegerToZeroOneBridge{T} <: Bridges.Constraint.AbstractBridge
+
+`IntegerToZeroOneBridge` implements the following reformulation:
+
+  * ``x \\in \\mathbf{Z}`` into ``y_i \\in \\{0, 1\\}``,
+    ``x == lb + \\sum 2^{i-1} y_i``.
+
+## Source node
+
+`IntegerToZeroOneBridge` supports:
+
+  * `VariableIndex` in [`MOI.Integer`](@ref)
+
+## Target nodes
+
+`IntegerToZeroOneBridge` creates:
+
+  * [`MOI.VariableIndex`](@ref) in [`MOI.ZeroOne`](@ref)
+  * [`MOI.ScalarAffineFunction{T}`](@ref) in [`MOI.EqualTo{T}`](@ref)
+"""
+mutable struct IntegerToZeroOneBridge{T} <: AbstractBridge
+    x::MOI.VariableIndex
+    y::Vector{MOI.VariableIndex}
+    ci::MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}
+    last_bounds::Union{Nothing,NTuple{2,T}}
+
+    function IntegerToZeroOneBridge{T}(x::MOI.VariableIndex) where {T}
+        return new{T}(
+            x,
+            MOI.VariableIndex[],
+            MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}(0),
+            nothing,
+        )
+    end
+end
+
+const IntegerToZeroOne{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{IntegerToZeroOneBridge{T},OT}
+
+function bridge_constraint(
+    ::Type{IntegerToZeroOneBridge{T}},
+    ::MOI.ModelLike,
+    x::MOI.VariableIndex,
+    ::MOI.Integer,
+) where {T}
+    # !!! info
+    #     Postpone creation until final_touch.
+    return IntegerToZeroOneBridge{T}(x)
+end
+
+function MOI.supports_constraint(
+    ::Type{IntegerToZeroOneBridge{T}},
+    ::Type{MOI.VariableIndex},
+    ::Type{MOI.Integer},
+) where {T}
+    return true
+end
+
+function MOI.Bridges.added_constrained_variable_types(
+    ::Type{<:IntegerToZeroOneBridge},
+)
+    return Tuple{Type}[(MOI.ZeroOne,)]
+end
+
+function MOI.Bridges.added_constraint_types(
+    ::Type{IntegerToZeroOneBridge{T}},
+) where {T}
+    return Tuple{Type,Type}[(MOI.ScalarAffineFunction{T}, MOI.EqualTo{T})]
+end
+
+function concrete_bridge_type(
+    ::Type{IntegerToZeroOneBridge{T}},
+    ::Type{MOI.VariableIndex},
+    ::Type{MOI.Integer},
+) where {T}
+    return IntegerToZeroOneBridge{T}
+end
+
+function MOI.get(
+    ::MOI.ModelLike,
+    ::MOI.ConstraintFunction,
+    bridge::IntegerToZeroOneBridge,
+)
+    return bridge.x
+end
+
+function MOI.get(
+    ::MOI.ModelLike,
+    ::MOI.ConstraintSet,
+    ::IntegerToZeroOneBridge,
+)
+    return MOI.Integer()
+end
+
+function MOI.delete(model::MOI.ModelLike, bridge::IntegerToZeroOneBridge)
+    MOI.delete(model, bridge.ci)
+    MOI.delete(model, bridge.y)
+    return
+end
+
+function MOI.get(
+    bridge::IntegerToZeroOneBridge,
+    ::MOI.NumberOfVariables,
+)::Int64
+    return length(bridge.y)
+end
+
+function MOI.get(bridge::IntegerToZeroOneBridge, ::MOI.ListOfVariableIndices)
+    return copy(bridge.y)
+end
+
+function MOI.get(
+    bridge::IntegerToZeroOneBridge,
+    ::MOI.NumberOfConstraints{MOI.VariableIndex,MOI.ZeroOne},
+)::Int64
+    return length(bridge.y)
+end
+
+function MOI.get(
+    bridge::IntegerToZeroOneBridge,
+    ::MOI.ListOfConstraintIndices{MOI.VariableIndex,MOI.ZeroOne},
+)
+    return map(bridge.y) do y
+        return MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(y.value)
+    end
+end
+
+function MOI.get(
+    bridge::IntegerToZeroOneBridge{T},
+    ::MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
+)::Int64 where {T}
+    return 1
+end
+
+function MOI.get(
+    bridge::IntegerToZeroOneBridge{T},
+    ::MOI.ListOfConstraintIndices{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}},
+) where {T}
+    return [bridge.ci]
+end
+
+MOI.Bridges.needs_final_touch(::IntegerToZeroOneBridge) = true
+
+function MOI.Bridges.final_touch(
+    bridge::IntegerToZeroOneBridge{T},
+    model::MOI.ModelLike,
+) where {T}
+    ret = MOI.Utilities.get_bounds(model, T, bridge.x)
+    if ret === bridge.last_bounds
+        return nothing  # final_touch already called
+    elseif ret[1] == typemin(T) || ret[2] == typemax(T)
+        error(
+            "Unable to use IntegerToZeroOneBridge because the variable " *
+            "$(bridge.x) has a non-finite domain",
+        )
+    end
+    f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(T(1), bridge.x)], T(0))
+    lb, ub = ceil(Int, ret[1]), floor(Int, ret[2])
+    for i in 1:(floor(Int, log2(ub - lb)) + 1)
+        y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+        push!(bridge.y, y)
+        push!(f.terms, MOI.ScalarAffineTerm(-(T(2)^(i-1)), y))
+    end
+    bridge.ci = MOI.add_constraint(model, f, MOI.EqualTo{T}(lb))
+    bridge.last_bounds = ret
+    return
+end

--- a/src/Bridges/Constraint/bridges/integer_to_zeroone.jl
+++ b/src/Bridges/Constraint/bridges/integer_to_zeroone.jl
@@ -91,11 +91,7 @@ function MOI.get(
     return bridge.x
 end
 
-function MOI.get(
-    ::MOI.ModelLike,
-    ::MOI.ConstraintSet,
-    ::IntegerToZeroOneBridge,
-)
+function MOI.get(::MOI.ModelLike, ::MOI.ConstraintSet, ::IntegerToZeroOneBridge)
     return MOI.Integer()
 end
 
@@ -105,10 +101,7 @@ function MOI.delete(model::MOI.ModelLike, bridge::IntegerToZeroOneBridge)
     return
 end
 
-function MOI.get(
-    bridge::IntegerToZeroOneBridge,
-    ::MOI.NumberOfVariables,
-)::Int64
+function MOI.get(bridge::IntegerToZeroOneBridge, ::MOI.NumberOfVariables)::Int64
     return length(bridge.y)
 end
 
@@ -163,10 +156,11 @@ function MOI.Bridges.final_touch(
     end
     f = MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(T(1), bridge.x)], T(0))
     lb, ub = ceil(Int, ret[1]), floor(Int, ret[2])
-    for i in 1:(floor(Int, log2(ub - lb)) + 1)
+    N = floor(Int, log2(ub - lb)) + 1
+    for i in 1:N
         y, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
         push!(bridge.y, y)
-        push!(f.terms, MOI.ScalarAffineTerm(-(T(2)^(i-1)), y))
+        push!(f.terms, MOI.ScalarAffineTerm(-(T(2)^(i - 1)), y))
     end
     bridge.ci = MOI.add_constraint(model, f, MOI.EqualTo{T}(lb))
     bridge.last_bounds = ret

--- a/src/Bridges/Constraint/bridges/integer_to_zeroone.jl
+++ b/src/Bridges/Constraint/bridges/integer_to_zeroone.jl
@@ -24,6 +24,13 @@
 
   * [`MOI.VariableIndex`](@ref) in [`MOI.ZeroOne`](@ref)
   * [`MOI.ScalarAffineFunction{T}`](@ref) in [`MOI.EqualTo{T}`](@ref)
+
+## Developer note
+
+This bridge is implemented as a constraint bridge instead of a variable bridge
+because we don't want to substitute the linear combination of `y` for every
+instance of `x`. Doing so would be expensive and greatly reduce the sparsity of
+the constraints.
 """
 mutable struct IntegerToZeroOneBridge{T} <: AbstractBridge
     x::MOI.VariableIndex

--- a/test/Bridges/Constraint/integer_to_zeroone.jl
+++ b/test/Bridges/Constraint/integer_to_zeroone.jl
@@ -25,16 +25,18 @@ function test_runtests()
     MOI.Bridges.runtests(
         MOI.Bridges.Constraint.IntegerToZeroOneBridge,
         """
-        variables: x
+        variables: x, z
         x in Integer()
         x in Interval(1.0, 3.0)
+        z in ZeroOne()
         """,
         """
-        variables: x, y1, y2
+        variables: x, z, y1, y2
         y1 in ZeroOne()
         y2 in ZeroOne()
         x + -1.0 * y1 + -2.0 * y2 == 1.0
         x in Interval(1.0, 3.0)
+        z in ZeroOne()
         """,
     )
     MOI.Bridges.runtests(

--- a/test/Bridges/Constraint/integer_to_zeroone.jl
+++ b/test/Bridges/Constraint/integer_to_zeroone.jl
@@ -85,7 +85,7 @@ function test_finite_domain_error()
     return
 end
 
-function test_finite_domain_error()
+function test_final_touch_twice()
     inner = MOI.Utilities.Model{Int}()
     model = MOI.Bridges.Constraint.IntegerToZeroOne{Int}(inner)
     x, _ = MOI.add_constrained_variable(model, MOI.Integer())

--- a/test/Bridges/Constraint/integer_to_zeroone.jl
+++ b/test/Bridges/Constraint/integer_to_zeroone.jl
@@ -1,0 +1,100 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestConstraintIntegerToZeroOne
+
+using Test
+
+import MathOptInterface as MOI
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function test_runtests()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.IntegerToZeroOneBridge,
+        """
+        variables: x
+        x in Integer()
+        x in Interval(1.0, 3.0)
+        """,
+        """
+        variables: x, y1, y2
+        y1 in ZeroOne()
+        y2 in ZeroOne()
+        x + -1.0 * y1 + -2.0 * y2 == 1.0
+        x in Interval(1.0, 3.0)
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.IntegerToZeroOneBridge,
+        """
+        variables: x
+        x in Integer()
+        x in Interval(-1.0, 2.0)
+        """,
+        """
+        variables: x, y1, y2
+        y1 in ZeroOne()
+        y2 in ZeroOne()
+        x + -1.0 * y1 + -2.0 * y2 == -1.0
+        x in Interval(-1.0, 2.0)
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.IntegerToZeroOneBridge,
+        """
+        variables: x
+        x in Integer()
+        x in Interval(-2.0, 2.0)
+        """,
+        """
+        variables: x, y1, y2, y3
+        y1 in ZeroOne()
+        y2 in ZeroOne()
+        y3 in ZeroOne()
+        x + -1.0 * y1 + -2.0 * y2 + -4.0 * y3 == -2.0
+        x in Interval(-2.0, 2.0)
+        """,
+    )
+    return
+end
+
+function test_finite_domain_error()
+    inner = MOI.Utilities.Model{Int}()
+    model = MOI.Bridges.Constraint.IntegerToZeroOne{Int}(inner)
+    x, _ = MOI.add_constrained_variable(model, MOI.Integer())
+    @test_throws(
+        ErrorException(
+            "Unable to use IntegerToZeroOneBridge because the variable " *
+            "$(x) has a non-finite domain",
+        ),
+        MOI.Bridges.final_touch(model),
+    )
+    return
+end
+
+function test_finite_domain_error()
+    inner = MOI.Utilities.Model{Int}()
+    model = MOI.Bridges.Constraint.IntegerToZeroOne{Int}(inner)
+    x, _ = MOI.add_constrained_variable(model, MOI.Integer())
+    MOI.add_constraint(model, x, MOI.Interval(1, 3))
+    MOI.Bridges.final_touch(model)
+    MOI.Bridges.final_touch(model)
+    return
+end
+
+end  # module
+
+TestConstraintIntegerToZeroOne.runtests()


### PR DESCRIPTION
Closes #2202

## Basic

 - [x] Create a new file in `src/Bridges/XXX/bridges`
 - [x] Define the bridge, following existing examples. The name of the bridge
       struct must end in `Bridge`
 - [x] Check if your bridge can be a subtype of [`MOI.Bridges.Constraint.SetMapBridge`](@ref)
 - [x] Define a new `const` that is a `SingleBridgeOptimizer` wrapping the
       new bridge. The name of the const must be the name of the bridge, less
       the `Bridge` suffix
 - [x] `include` the file in `src/Bridges/XXX/bridges/XXX.jl`
 - [x] If the bridge should be enabled by default, add the bridge to
       `add_all_bridges` at the bottom of `src/Bridges/XXX/XXX.jl`

## Tests

 - [x] Create a new file in the appropriate subdirectory of `tests/Bridges/XXX`
 - [x] Use `MOI.Bridges.runtests` to test various inputs and outputs of the
       bridge
 - [x] If, after opening the pull request to add the bridge, some lines are not
       covered by the tests, add additional bridge-specific tests to cover the
       untested lines.

## Documentation

 - [x] Add a docstring which uses the same template as existing bridges.
 - [x] Add the docstring to `docs/src/submodules/Bridges/list_of_bridges.md`

## Final touch

If the bridge depends on run-time values of other variables and constraints in
the model:

 - [x] Implement `MOI.Utilities.needs_final_touch(::Bridge)`
 - [x] Implement `MOI.Utilities.final_touch(::Bridge, ::MOI.ModelLike)`
 - [x] Ensure that `final_touch` can be called multiple times in a row