### PR TITLE
Fix incorrect usage of Utilities.operate!

### DIFF
--- a/src/Bridges/Constraint/bridges/count_belongs.jl
+++ b/src/Bridges/Constraint/bridges/count_belongs.jl
@@ -312,7 +312,7 @@ function MOI.Bridges.final_touch(
             end
         end
     end
-    MOI.Utilities.operate!(-, T, f, scalars[1])
+    f = MOI.Utilities.operate!(-, T, f, scalars[1])
     push!(
         bridge.equal_to,
         MOI.Utilities.normalize_and_add_constraint(

--- a/src/Bridges/Constraint/bridges/count_distinct.jl
+++ b/src/Bridges/Constraint/bridges/count_distinct.jl
@@ -354,7 +354,7 @@ function MOI.Bridges.final_touch(
         )
     end
     count_f = MOI.ScalarAffineFunction(count_terms, zero(T))
-    MOI.Utilities.operate!(-, T, count_f, scalars[1])
+    count_f = MOI.Utilities.operate!(-, T, count_f, scalars[1])
     push!(
         bridge.equal_to,
         MOI.Utilities.normalize_and_add_constraint(

--- a/src/Bridges/Constraint/bridges/count_distinct_reif.jl
+++ b/src/Bridges/Constraint/bridges/count_distinct_reif.jl
@@ -377,9 +377,9 @@ function MOI.Bridges.final_touch(
     MOI.add_constraint(model, z[2], MOI.ZeroOne())
     # ∑y - n - δ⁺ + δ⁻ = 0
     f_0 = MOI.ScalarAffineFunction(count_terms, zero(T))
-    MOI.Utilities.operate!(-, T, f_0, scalars[2])
-    MOI.Utilities.operate!(-, T, f_0, z[3])
-    MOI.Utilities.operate!(+, T, f_0, z[4])
+    f_0 = MOI.Utilities.operate!(-, T, f_0, scalars[2])
+    f_0 = MOI.Utilities.operate!(-, T, f_0, z[3])
+    f_0 = MOI.Utilities.operate!(+, T, f_0, z[4])
     push!(
         bridge.equal_to,
         MOI.Utilities.normalize_and_add_constraint(

--- a/src/Bridges/Constraint/bridges/norm_to_power.jl
+++ b/src/Bridges/Constraint/bridges/norm_to_power.jl
@@ -58,7 +58,7 @@ function bridge_constraint(
     for ri in r
         f = MOI.Utilities.operate!(+, T, f, ri)
     end
-    MOI.Utilities.operate!(-, T, f, fi_s[1])
+    f = MOI.Utilities.operate!(-, T, f, fi_s[1])
     equal_ci = MOI.add_constraint(model, f, MOI.EqualTo(zero(T)))
     return NormToPowerBridge{T,F}(power_ci, r, equal_ci, s)
 end

--- a/src/Bridges/Constraint/bridges/quad_to_soc.jl
+++ b/src/Bridges/Constraint/bridges/quad_to_soc.jl
@@ -414,11 +414,11 @@ function MOI.get(
     for i in 3:MOI.output_dimension(f)
         term = MOI.Utilities.operate(*, T, fs[i], fs[i])
         term = MOI.Utilities.operate!(/, T, term, 2 * one(T))
-        MOI.Utilities.operate!(+, T, q, term)
+        q = MOI.Utilities.operate!(+, T, q, term)
     end
-    MOI.Utilities.operate!(-, T, q, fs[2])
+    q = MOI.Utilities.operate!(-, T, q, fs[2])
     if !b.less_than
-        MOI.Utilities.operate!(-, T, q)
+        q = MOI.Utilities.operate!(-, T, q)
     end
     q.constant += b.set_constant
     return q


### PR DESCRIPTION
`operate!` may modify its argument, but it may also return a new object. These usages were buggy and incorrect. (Although, correct for now, but will break with {Vector,Scalar}NonlinearFunction