### PR TITLE
[Utilities] simplify various operate_ methods

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1283,7 +1283,8 @@ function map_terms!(
     op,
     func::Union{MOI.ScalarAffineFunction,MOI.VectorAffineFunction},
 )
-    return map!(op, func.terms, func.terms)
+    map!(op, func.terms, func.terms)
+    return
 end
 
 function map_terms!(
@@ -1291,7 +1292,8 @@ function map_terms!(
     func::Union{MOI.ScalarQuadraticFunction,MOI.VectorQuadraticFunction},
 )
     map!(op, func.affine_terms, func.affine_terms)
-    return map!(op, func.quadratic_terms, func.quadratic_terms)
+    map!(op, func.quadratic_terms, func.quadratic_terms)
+    return
 end
 
 ###################################### +/- #####################################

--- a/src/Utilities/mutable_arithmetics.jl
+++ b/src/Utilities/mutable_arithmetics.jl
@@ -149,21 +149,11 @@ function MA.operate!(
     return f
 end
 
-function MA.operate!(::typeof(-), f::MOI.ScalarQuadraticFunction)
-    for (i, term) in enumerate(f.quadratic_terms)
-        f.quadratic_terms[i] = operate_term(-, term)
-    end
-    for (i, term) in enumerate(f.affine_terms)
-        f.affine_terms[i] = operate_term(-, term)
-    end
-    f.constant = -f.constant
-    return f
-end
-
-function MA.operate!(::typeof(-), f::MOI.ScalarAffineFunction)
-    for (i, term) in enumerate(f.terms)
-        f.terms[i] = operate_term(-, term)
-    end
+function MA.operate!(
+    ::typeof(-),
+    f::Union{MOI.ScalarAffineFunction,MOI.ScalarQuadraticFunction},
+)
+    map_terms!(Base.Fix1(operate_term, -), f)
     f.constant = -f.constant
     return f
 end

--- a/src/Utilities/mutable_arithmetics.jl
+++ b/src/Utilities/mutable_arithmetics.jl
@@ -150,14 +150,20 @@ function MA.operate!(
 end
 
 function MA.operate!(::typeof(-), f::MOI.ScalarQuadraticFunction)
-    operate_terms!(-, f.quadratic_terms)
-    operate_terms!(-, f.affine_terms)
+    for (i, term) in enumerate(f.quadratic_terms)
+        f.quadratic_terms[i] = operate_term(-, term)
+    end
+    for (i, term) in enumerate(f.affine_terms)
+        f.affine_terms[i] = operate_term(-, term)
+    end
     f.constant = -f.constant
     return f
 end
 
 function MA.operate!(::typeof(-), f::MOI.ScalarAffineFunction)
-    operate_terms!(-, f.terms)
+    for (i, term) in enumerate(f.terms)
+        f.terms[i] = operate_term(-, term)
+    end
     f.constant = -f.constant
     return f
 end

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -271,7 +271,7 @@ function operate(
         MOI.ScalarQuadraticFunction{T},
         MOI.VectorAffineFunction{T},
         MOI.VectorQuadraticFunction{T},
-    }
+    },
 ) where {T}
     return operate_coefficients(-, f)
 end

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -789,7 +789,7 @@ end
 function operate!(
     ::typeof(+),
     ::Type{T},
-    f::MOI.VectorAffineFunction{T},
+    f::Union{MOI.VectorAffineFunction{T},MOI.VectorQuadraticFunction{T}},
     g::AbstractVector{T},
 ) where {T}
     @assert MOI.output_dimension(f) == length(g)
@@ -820,17 +820,6 @@ function operate!(
 ) where {T}
     append!(f.terms, g.terms)
     f.constants .+= g.constants
-    return f
-end
-
-function operate!(
-    ::typeof(+),
-    ::Type{T},
-    f::MOI.VectorQuadraticFunction{T},
-    g::AbstractVector{T},
-) where {T}
-    @assert MOI.output_dimension(f) == length(g)
-    f.constants .+= g
     return f
 end
 
@@ -916,7 +905,7 @@ end
 function operate!(
     ::typeof(-),
     ::Type{T},
-    f::MOI.VectorAffineFunction{T},
+    f::Union{MOI.VectorAffineFunction{T},MOI.VectorQuadraticFunction{T}},
     g::AbstractVector{T},
 ) where {T}
     @assert MOI.output_dimension(f) == length(g)
@@ -947,17 +936,6 @@ function operate!(
 ) where {T}
     append!(f.terms, operate_terms(-, g.terms))
     f.constants .-= g.constants
-    return f
-end
-
-function operate!(
-    ::typeof(-),
-    ::Type{T},
-    f::MOI.VectorQuadraticFunction{T},
-    g::AbstractVector{T},
-) where {T}
-    @assert MOI.output_dimension(f) == length(g)
-    f.constants .-= g
     return f
 end
 

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -1056,7 +1056,7 @@ Compute `op(args...)`, where at least one element of `args` is one of
     e. `operate_term(::typeof(*), ::Diagonal, ::VectorTerm)`
  4. `/`
     a. `operate_term(::typeof(/), ::Term, ::T)`
- 5. User-provided function
+ 5. User-defined function
     a. `operate_term(::Function, ::Term)`
 """
 function operate_term end
@@ -1212,7 +1212,7 @@ Compute `op(args...)`, where at least one element of `args` is a vector of
     a. `operate_term(::typeof(-), ::Vector{<:Term})`
  3. `*`
     a. `operate_term(::typeof(*), ::Diagonal, ::Vector{<:VectorTerm})`
- 4. User-defiend function
+ 4. User-defined function
     a. `operate_term(::Function, ::Vector{<:Term})`
 """
 function operate_terms end

--- a/test/Utilities/test_operate!.jl
+++ b/test/Utilities/test_operate!.jl
@@ -409,6 +409,20 @@ function test_operate_term_4a()
     return
 end
 
+function test_operate_term_5a()
+    x = MOI.VariableIndex(1)
+    for f in (
+        MOI.ScalarAffineTerm(1.0, x),
+        MOI.ScalarQuadraticTerm(1.0, x, x),
+        MOI.VectorAffineTerm(3, MOI.ScalarAffineTerm(1.0, x)),
+        MOI.VectorQuadraticTerm(3, MOI.ScalarQuadraticTerm(1.0, x, x)),
+    )
+        @test MOI.Utilities.operate_term(t -> -(t), f) ==
+              MOI.Utilities.operate_term(-, f)
+    end
+    return
+end
+
 function test_operate_terms_1a()
     x = MOI.VariableIndex(1)
     for term in (


### PR DESCRIPTION
https://github.com/jump-dev/MathOptInterface.jl/pull/2208 moved a bunch of methods around and added tests, but I didn't change any behavior or merge the functionality of different methods.

This PR adds a generic `operate_term` method (which was really `operate_coefficient`), and then leverages that to simplify a number of other methods, in some cases (like univariate -) removing the specialized methods all together.

I've also "deprecated" (in documentation only) `operate_terms!` which was only used in three places in mutable arithmetics. We should aim for fewer simpler methods, instead of a potpourri of methods that we've added for special cases.