### PR TITLE
[Utilities] add eval_variables support for ScalarNonlinearFunction

### DIFF
--- a/src/Bridges/Constraint/bridges/quad_to_soc.jl
+++ b/src/Bridges/Constraint/bridges/quad_to_soc.jl
@@ -292,7 +292,8 @@ function MOI.set(
     # |        U * x        |
     # where we compute `x'Qx/2` and `U * x` using the starting values of the variable.
     soc = MOI.get(model, MOI.ConstraintFunction(), bridge.soc)
-    Ux = MOI.Utilities.eval_variables(MOI.Utilities.eachscalar(soc)[3:end]) do v
+    f = MOI.Utilities.eachscalar(soc)[3:end]
+    Ux = MOI.Utilities.eval_variables(model, f) do v
         return _primal_start_or_error(model, attr, v)
     end
     if bridge.less_than

--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -224,7 +224,7 @@ function MOI.set(
     end
     MOI.set(model, MOI.VariablePrimalStart(), b.slack, zero(T))
     f = MOI.get(model, MOI.ConstraintFunction(), b.constraint)
-    f_val = MOI.Utilities.eval_variables(f) do v
+    f_val = MOI.Utilities.eval_variables(model, f) do v
         return MOI.get(model, MOI.VariablePrimalStart(), v)
     end
     f_val -= MOI.constant(MOI.get(model, MOI.ConstraintSet(), b.constraint))

--- a/src/Nonlinear/operators.jl
+++ b/src/Nonlinear/operators.jl
@@ -936,10 +936,7 @@ function _evaluate_expr(
     if !_is_registered(registry, op, length(expr.args))
         udf = MOI.get(model, MOI.UserDefinedFunction(op, length(expr.args)))
         if udf === nothing
-            return error(
-                "Unable to evaluate nonlinear operator $op because it is not " *
-                "registered",
-            )
+            throw(MOI.UnsupportedNonlinearOperator(op))
         end
         args = map(expr.args) do arg
             return _evaluate_expr(registry, value_fn, model, arg)

--- a/src/Nonlinear/operators.jl
+++ b/src/Nonlinear/operators.jl
@@ -895,3 +895,75 @@ function eval_comparison_function(
         return lhs > rhs
     end
 end
+
+# This method is implmented here because it needs the OperatorRegistry type from
+# the Nonlinear, which doesn't exist when the Utilities submodule is defined.
+
+function MOI.Utilities.eval_variables(
+    value_fn::F,
+    model::MOI.ModelLike,
+    f::MOI.ScalarNonlinearFunction,
+) where {F}
+    registry = OperatorRegistry()
+    return _evaluate_expr(registry, value_fn, model, f)
+end
+
+function _evaluate_expr(
+    ::OperatorRegistry,
+    value_fn::Function,
+    model::MOI.ModelLike,
+    f::MOI.AbstractFunction,
+)
+    return MOI.Utilities.eval_variables(value_fn, model, f)
+end
+
+function _evaluate_expr(
+    ::OperatorRegistry,
+    ::Function,
+    ::MOI.ModelLike,
+    f::Number,
+)
+    return f
+end
+
+function _evaluate_expr(
+    registry::OperatorRegistry,
+    value_fn::Function,
+    model::MOI.ModelLike,
+    expr::MOI.ScalarNonlinearFunction,
+)
+    op = expr.head
+    if !_is_registered(registry, op, length(expr.args))
+        udf = MOI.get(model, MOI.UserDefinedFunction(op, length(expr.args)))
+        if udf === nothing
+            return error(
+                "Unable to evaluate nonlinear operator $op because it is not " *
+                "registered",
+            )
+        end
+        args = map(expr.args) do arg
+            return _evaluate_expr(registry, value_fn, model, arg)
+        end
+        return first(udf)(args...)
+    end
+    if length(expr.args) == 1 && haskey(registry.univariate_operator_to_id, op)
+        arg = _evaluate_expr(registry, value_fn, model, expr.args[1])
+        return eval_univariate_function(registry, op, arg)
+    elseif haskey(registry.multivariate_operator_to_id, op)
+        args = map(expr.args) do arg
+            return _evaluate_expr(registry, value_fn, model, arg)
+        end
+        return eval_multivariate_function(registry, op, args)
+    elseif haskey(registry.logic_operator_to_id, op)
+        @assert length(expr.args) == 2
+        x = _evaluate_expr(registry, value_fn, model, expr.args[1])
+        y = _evaluate_expr(registry, value_fn, model, expr.args[2])
+        return eval_logic_function(registry, op, x, y)
+    else
+        @assert haskey(registry.comparison_operator_to_id, op)
+        @assert length(expr.args) == 2
+        x = _evaluate_expr(registry, value_fn, model, expr.args[1])
+        y = _evaluate_expr(registry, value_fn, model, expr.args[2])
+        return eval_comparison_function(registry, op, x, y)
+    end
+end

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -192,74 +192,8 @@ function eval_variables(
     return eval_variables(value_fn, f)
 end
 
-function eval_variables(
-    value_fn::F,
-    model::MOI.ModelLike,
-    f::MOI.ScalarNonlinearFunction,
-) where {F}
-    registry = MOI.Nonlinear.OperatorRegistry()
-    return _evaluate_expr(registry, value_fn, model, f)
-end
-
-function _evaluate_expr(
-    ::MOI.Nonlinear.OperatorRegistry,
-    value_fn::Function,
-    model::MOI.ModelLike,
-    f::MOI.AbstractFunction,
-)
-    return eval_variables(value_fn, model, f)
-end
-
-function _evaluate_expr(
-    ::MOI.Nonlinear.OperatorRegistry,
-    ::Function,
-    ::MOI.ModelLike,
-    f::Number,
-)
-    return f
-end
-
-function _evaluate_expr(
-    registry::MOI.Nonlinear.OperatorRegistry,
-    value_fn::Function,
-    model::MOI.ModelLike,
-    expr::MOI.ScalarNonlinearFunction,
-)
-    op = expr.head
-    if !MOI.Nonlinear._is_registered(registry, op, length(expr.args))
-        udf = MOI.get(model, MOI.UserDefinedFunction(op, length(expr.args)))
-        if udf === nothing
-            return error(
-                "Unable to evaluate nonlinear operator $op because it is not " *
-                "registered",
-            )
-        end
-        args = map(expr.args) do arg
-            return _evaluate_expr(registry, value_fn, model, arg)
-        end
-        return first(udf)(args...)
-    end
-    if length(expr.args) == 1 && haskey(registry.univariate_operator_to_id, op)
-        arg = _evaluate_expr(registry, value_fn, model, expr.args[1])
-        return MOI.Nonlinear.eval_univariate_function(registry, op, arg)
-    elseif haskey(registry.multivariate_operator_to_id, op)
-        args = map(expr.args) do arg
-            return _evaluate_expr(registry, value_fn, model, arg)
-        end
-        return MOI.Nonlinear.eval_multivariate_function(registry, op, args)
-    elseif haskey(registry.logic_operator_to_id, op)
-        @assert length(expr.args) == 2
-        x = _evaluate_expr(registry, value_fn, model, expr.args[1])
-        y = _evaluate_expr(registry, value_fn, model, expr.args[2])
-        return MOI.Nonlinear.eval_logic_function(registry, op, x, y)
-    else
-        @assert haskey(registry.comparison_operator_to_id, op)
-        @assert length(expr.args) == 2
-        x = _evaluate_expr(registry, value_fn, model, expr.args[1])
-        y = _evaluate_expr(registry, value_fn, model, expr.args[2])
-        return MOI.Nonlinear.eval_comparison_function(registry, op, x, y)
-    end
-end
+# The `eval_variables(::F, ::MOI.ModelLike, ::MOI.ScalarNonlinearFunction)`
+# method is defined in the MOI.Nonlinear submodule.
 
 """
     map_indices(index_map::Function, attr::MOI.AnyAttribute, x::X)::X where {X}

--- a/src/Utilities/results.jl
+++ b/src/Utilities/results.jl
@@ -26,10 +26,9 @@ function get_fallback(model::MOI.ModelLike, attr::MOI.ObjectiveValue)
     MOI.check_result_index_bounds(model, attr)
     F = MOI.get(model, MOI.ObjectiveFunctionType())
     f = MOI.get(model, MOI.ObjectiveFunction{F}())
-    obj = eval_variables(
-        vi -> MOI.get(model, MOI.VariablePrimal(attr.result_index), vi),
-        f,
-    )
+    obj = eval_variables(model, f) do vi
+        return vi -> MOI.get(model, MOI.VariablePrimal(attr.result_index), vi)
+    end
     if is_ray(MOI.get(model, MOI.PrimalStatus()))
         # Dual infeasibiltiy certificates do not include the primal objective
         # constant.
@@ -187,7 +186,7 @@ function get_fallback(
 )
     MOI.check_result_index_bounds(model, attr)
     f = MOI.get(model, MOI.ConstraintFunction(), idx)
-    c = eval_variables(f) do vi
+    c = eval_variables(model, f) do vi
         return MOI.get(model, MOI.VariablePrimal(attr.result_index), vi)
     end
     if is_ray(MOI.get(model, MOI.PrimalStatus()))

--- a/src/Utilities/results.jl
+++ b/src/Utilities/results.jl
@@ -27,7 +27,7 @@ function get_fallback(model::MOI.ModelLike, attr::MOI.ObjectiveValue)
     F = MOI.get(model, MOI.ObjectiveFunctionType())
     f = MOI.get(model, MOI.ObjectiveFunction{F}())
     obj = eval_variables(model, f) do vi
-        return vi -> MOI.get(model, MOI.VariablePrimal(attr.result_index), vi)
+        return MOI.get(model, MOI.VariablePrimal(attr.result_index), vi)
     end
     if is_ray(MOI.get(model, MOI.PrimalStatus()))
         # Dual infeasibiltiy certificates do not include the primal objective

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -252,7 +252,7 @@ function test_eval_variables_scalar_nonlinear_function()
     x = MOI.add_variable(model)
     f = MOI.ScalarNonlinearFunction(:log, Any[x])
     @test MOI.Utilities.eval_variables(xi -> 0.5, model, f) ≈ log(0.5)
-    f = MOI.ScalarNonlinearFunction(:*, Any[x, 2.0 * x, 1.0 * x + 2.0])
+    f = MOI.ScalarNonlinearFunction(:*, Any[x, 2.0*x, 1.0*x+2.0])
     @test MOI.Utilities.eval_variables(xi -> 0.5, model, f) ≈
           0.5 * (2.0 * 0.5) * (1.0 * 0.5 + 2.0)
     f = MOI.ScalarNonlinearFunction(

--- a/test/Utilities/functions.jl
+++ b/test/Utilities/functions.jl
@@ -261,10 +261,25 @@ function test_eval_variables_scalar_nonlinear_function()
     )
     @test MOI.Utilities.eval_variables(xi -> 0.5, model, f) ≈ 0.0
     @test MOI.Utilities.eval_variables(xi -> 1.5, model, f) ≈ 1.5
+    f = MOI.ScalarNonlinearFunction(
+        :||,
+        Any[
+            MOI.ScalarNonlinearFunction(:<, Any[x, 0.0]),
+            MOI.ScalarNonlinearFunction(:>, Any[x, 1.0]),
+        ],
+    )
+    @test MOI.Utilities.eval_variables(xi -> 0.5, model, f) ≈ 0.0
+    @test MOI.Utilities.eval_variables(xi -> 1.5, model, f) ≈ 1.0
+    @test MOI.Utilities.eval_variables(xi -> -0.5, model, f) ≈ 1.0
     my_square(x, y) = (x - y)^2
     MOI.set(model, MOI.UserDefinedFunction(:my_square, 2), (my_square,))
     f = MOI.ScalarNonlinearFunction(:my_square, Any[x, 1.0])
     @test MOI.Utilities.eval_variables(xi -> 0.5, model, f) ≈ (0.5 - 1.0)^2
+    f = MOI.ScalarNonlinearFunction(:bad_f, Any[x, 1.0])
+    @test_throws(
+        MOI.UnsupportedNonlinearOperator(:bad_f),
+        MOI.Utilities.eval_variables(xi -> 0.5, model, f)
+    )
     return
 end
 


### PR DESCRIPTION
Related to https://github.com/jump-dev/MathOptInterface.jl/pull/2218

Blocker for https://github.com/jump-dev/MathOptInterface.jl/pull/2201

The implementation leaves a bit to be desired (it uses recursion, and every call needs to create an operator registry), but we can address that later.