### PR TITLE
[FileFormats.NL] fix nested scalar affine and quadratic functions

### DIFF
--- a/src/FileFormats/NL/NLExpr.jl
+++ b/src/FileFormats/NL/NLExpr.jl
@@ -409,6 +409,18 @@ function _process_expr!(expr::_NLExpr, arg::Expr)
     return error("Unsupported expression: $(arg)")
 end
 
+function _process_expr!(
+    expr::_NLExpr,
+    arg::Union{MOI.ScalarAffineFunction,MOI.ScalarQuadraticFunction},
+)
+    # This method gets called recursively from the arguments to
+    # ScalarNonlinearFunction, so we cannot add the linear parts to
+    # `expr.linear_terms`.
+    f = convert(MOI.ScalarNonlinearFunction, arg)
+    _process_expr!(expr, f)
+    return
+end
+
 function _process_expr!(expr::_NLExpr, arg::MOI.ScalarNonlinearFunction)
     if length(arg.args) == 1
         f = get(_UNARY_SPECIAL_CASES, arg.head, nothing)

--- a/test/FileFormats/NL/NL.jl
+++ b/test/FileFormats/NL/NL.jl
@@ -167,6 +167,24 @@ function test_nlexpr_scalarnonlinearfunction_ternary_multiplication()
     return
 end
 
+function test_nlexpr_scalarnonlinearfunction_inner_functions()
+    x = MOI.VariableIndex(1)
+    f = 1.0 * x + 1.0
+    g = 2.0 * x * x + 3.0 * x + 4.0
+    f = MOI.ScalarNonlinearFunction(:*, Any[2.0, x, f, g])
+    ex = Expr(
+        :call,
+        :*,
+        2.0,
+        x,
+        :(1.0 * $x + 1.0),
+        :(2.0 * $x * $x + 3.0 * $x + 4.0),
+    )
+    expr = NL._NLExpr(ex)
+    _test_nlexpr(f, expr.nonlinear_terms, Dict(x => 0), 0.0)
+    return
+end
+
 function test_nlexpr_unary_addition()
     x = MOI.VariableIndex(1)
     return _test_nlexpr(:(+$x), [x], Dict(x => 0), 0.0)


### PR DESCRIPTION
Missed a case from https://github.com/jump-dev/MathOptInterface.jl/pull/2228