### PR TITLE
[Bridges] add ScalarQuadraticToScalarNonlinearBridge

### DIFF
--- a/docs/src/submodules/Bridges/list_of_bridges.md
+++ b/docs/src/submodules/Bridges/list_of_bridges.md
@@ -28,6 +28,7 @@ Bridges.Constraint.ScalarSlackBridge
 Bridges.Constraint.VectorSlackBridge
 Bridges.Constraint.ScalarFunctionizeBridge
 Bridges.Constraint.VectorFunctionizeBridge
+Bridges.Constraint.ScalarQuadraticToScalarNonlinearBridge
 Bridges.Constraint.SplitComplexEqualToBridge
 Bridges.Constraint.SplitComplexZerosBridge
 Bridges.Constraint.SplitHyperRectangleBridge

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -83,6 +83,10 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(bridged_model, VectorSlackBridge{T})
     MOI.Bridges.add_bridge(bridged_model, ScalarFunctionizeBridge{T})
     MOI.Bridges.add_bridge(bridged_model, VectorFunctionizeBridge{T})
+    MOI.Bridges.add_bridge(
+        bridged_model,
+        ScalarQuadraticToScalarNonlinearBridge{T},
+    )
     MOI.Bridges.add_bridge(bridged_model, SplitHyperRectangleBridge{T})
     MOI.Bridges.add_bridge(bridged_model, SplitIntervalBridge{T})
     MOI.Bridges.add_bridge(bridged_model, SplitComplexEqualToBridge{T})

--- a/src/Bridges/Constraint/bridges/functionize.jl
+++ b/src/Bridges/Constraint/bridges/functionize.jl
@@ -415,15 +415,6 @@ end
 
 function MOI.get(
     model::MOI.ModelLike,
-    ::MOI.CanonicalConstraintFunction,
-    b::ScalarQuadraticToScalarNonlinearBridge,
-)
-    f = MOI.get(model, MOI.ConstraintFunction(), b.constraint)
-    return MOI.Utilities.canonical(f)
-end
-
-function MOI.get(
-    model::MOI.ModelLike,
     ::MOI.ConstraintFunction,
     b::ScalarQuadraticToScalarNonlinearBridge{T},
 ) where {T}

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -918,6 +918,27 @@ function Base.convert(
     return ScalarAffineTerm(convert(T, ret[1]), ret[2])
 end
 
+function _add_to_function(
+    f::ScalarAffineFunction{T},
+    arg::Union{Real,VariableIndex,ScalarAffineFunction},
+) where {T}
+    return Utilities.operate!(+, T, f, arg)
+end
+
+function _add_to_function(
+    f::ScalarAffineFunction{T},
+    arg::ScalarNonlinearFunction,
+) where {T}
+    if arg.head == :* && length(arg.args) == 2
+        push!(f.terms, convert(ScalarAffineTerm{T}, arg))
+    else
+        _add_to_function(f, convert(ScalarAffineFunction{T}, arg))
+    end
+    return f
+end
+
+_add_to_function(::ScalarAffineFunction, ::Any) = nothing
+
 # This is a very rough-and-ready conversion function that only works for very
 # basic expressions, such as those created by
 # `convert(ScalarNonlinearFunction, f)`.
@@ -925,20 +946,21 @@ function Base.convert(
     ::Type{ScalarAffineFunction{T}},
     f::ScalarNonlinearFunction,
 ) where {T}
+    if f.head == :* && length(f.args) == 2
+        term = convert(ScalarAffineTerm{T}, f)
+        return ScalarAffineFunction{T}([term], zero(T))
+    end
     if f.head != :+
         throw(InexactError(:convert, ScalarAffineFunction{T}, f))
     end
-    aff_terms, constant = ScalarAffineTerm{T}[], zero(T)
+    output = ScalarAffineFunction{T}(ScalarAffineTerm{T}[], zero(T))
     for arg in f.args
-        if arg isa Real
-            constant += convert(T, arg)
-        elseif arg isa ScalarNonlinearFunction && length(arg.args) == 2
-            push!(aff_terms, convert(ScalarAffineTerm{T}, arg))
-        else
+        output = _add_to_function(output, arg)
+        if output === nothing
             throw(InexactError(:convert, ScalarAffineFunction{T}, f))
         end
     end
-    return ScalarAffineFunction(aff_terms, constant)
+    return output
 end
 
 # ScalarQuadraticFunction
@@ -1013,6 +1035,27 @@ function Base.convert(
     return ScalarQuadraticTerm(coef, ret[2], ret[3])
 end
 
+function _add_to_function(
+    f::ScalarQuadraticFunction{T},
+    arg::Union{Real,VariableIndex,ScalarAffineFunction,ScalarQuadraticFunction},
+) where {T}
+    return Utilities.operate!(+, T, f, arg)
+end
+
+function _add_to_function(
+    f::ScalarQuadraticFunction{T},
+    arg::ScalarNonlinearFunction,
+) where {T}
+    if arg.head == :* && length(arg.args) == 2
+        push!(f.affine_terms, convert(ScalarAffineTerm{T}, arg))
+    elseif arg.head == :* && length(arg.args) == 3
+        push!(f.quadratic_terms, convert(ScalarQuadraticTerm{T}, arg))
+    else
+        _add_to_function(f, convert(ScalarQuadraticFunction{T}, arg))
+    end
+    return f
+end
+
 # This is a very rough-and-ready conversion function that only works for very
 # basic expressions, such as those created by
 # `convert(ScalarNonlinearFunction, f)`.
@@ -1020,25 +1063,35 @@ function Base.convert(
     ::Type{ScalarQuadraticFunction{T}},
     f::ScalarNonlinearFunction,
 ) where {T}
+    if f.head == :*
+        if length(f.args) == 2
+            quad_terms = ScalarQuadraticTerm{T}[]
+            affine_terms = [convert(ScalarAffineTerm{T}, f)]
+            return ScalarQuadraticFunction{T}(quad_terms, affine_terms, zero(T))
+        elseif length(f.args) == 3
+            quad_terms = [convert(ScalarQuadraticTerm{T}, f)]
+            affine_terms = ScalarAffineTerm{T}[]
+            return ScalarQuadraticFunction{T}(quad_terms, affine_terms, zero(T))
+        end
+    elseif f.head == :^ && length(f.args) == 2 && f.args[2] == 2
+        return convert(
+            ScalarQuadraticFunction{T},
+            ScalarNonlinearFunction(:*, Any[one(T), f.args[1], f.args[1]]),
+        )
+    end
     if f.head != :+
         throw(InexactError(:convert, ScalarQuadraticFunction{T}, f))
     end
-    quad_terms, aff_terms = ScalarQuadraticTerm{T}[], ScalarAffineTerm{T}[]
-    constant = zero(T)
+    output = ScalarQuadraticFunction(
+        ScalarQuadraticTerm{T}[],
+        ScalarAffineTerm{T}[],
+        zero(T),
+    )
     for arg in f.args
-        if arg isa Real
-            constant += convert(T, arg)
-        elseif arg isa ScalarNonlinearFunction && (2 <= length(arg.args) <= 3)
-            if length(arg.args) == 2
-                push!(aff_terms, convert(ScalarAffineTerm{T}, arg))
-            else
-                push!(quad_terms, convert(ScalarQuadraticTerm{T}, arg))
-            end
-        else
-            throw(InexactError(:convert, ScalarQuadraticFunction{T}, f))
-        end
+        # Unlike ScalarAffineFunction, _add_to_function cannot return ::Nothing
+        output = _add_to_function(output, arg)::ScalarQuadraticFunction{T}
     end
-    return ScalarQuadraticFunction(quad_terms, aff_terms, constant)
+    return output
 end
 
 # ScalarNonlinearFunction

--- a/test/Bridges/Constraint/functionize.jl
+++ b/test/Bridges/Constraint/functionize.jl
@@ -293,6 +293,21 @@ function test_runtests()
     return
 end
 
+function test_scalar_quadratic_to_nonlinear()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ScalarQuadraticToScalarNonlinearBridge,
+        """
+        variables: x, y
+        1.0 * x * x + 2.0 * x * y + 3.0 * y + 4.0 >= 1.0
+        """,
+        """
+        variables: x, y
+        ScalarNonlinearFunction(1.0 * x * x + 2.0 * x * y + 3.0 * y + 4.0) >= 1.0
+        """,
+    )
+    return
+end
+
 end  # module
 
 TestConstraintFunctionize.runtests()

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -304,6 +304,114 @@ function test_ScalarNonlinearFunction_isapprox()
     return
 end
 
+function test_convert_ScalarNonlinearFunction_ScalarAffineTerm()
+    x = MOI.VariableIndex(1)
+    f = MOI.ScalarAffineTerm(1.0, x)
+    g = MOI.ScalarNonlinearFunction(:*, Any[1.0, x])
+    h = MOI.ScalarNonlinearFunction(:*, Any[x, 1.0])
+    @test convert(MOI.ScalarNonlinearFunction, f) ≈ g
+    @test convert(MOI.ScalarAffineTerm{Float64}, g) == f
+    @test convert(MOI.ScalarAffineTerm{Float64}, h) == f
+    f = MOI.ScalarAffineTerm(1, x)
+    g = MOI.ScalarNonlinearFunction(:*, Any[1, x])
+    h = MOI.ScalarNonlinearFunction(:*, Any[x, 1])
+    @test convert(MOI.ScalarNonlinearFunction, f) ≈ g
+    @test convert(MOI.ScalarAffineTerm{Int}, h) == f
+    for f_error in (
+        MOI.ScalarNonlinearFunction(:*, Any[1.0, x, 2.0]),
+        MOI.ScalarNonlinearFunction(:+, Any[1.0, x]),
+        MOI.ScalarNonlinearFunction(:*, Any[x, x]),
+    )
+        @test_throws(
+            InexactError,
+            convert(MOI.ScalarAffineTerm{Float64}, f_error),
+        )
+    end
+    return
+end
+
+function test_convert_ScalarNonlinearFunction_ScalarAffineFunction()
+    x = MOI.VariableIndex(1)
+    y = MOI.VariableIndex(2)
+    for f in (
+        1.0 * x,
+        1.0 * x + 2.0,
+        1.0 * x + 1.0 * x + 2.0,
+        1.0 * x + 2.0 * y + 2.0,
+        2.0 * y + 2.0 + 2.0 * x,
+    )
+        g = convert(MOI.ScalarNonlinearFunction, f)
+        @test convert(MOI.ScalarAffineFunction{Float64}, g) ≈ f
+    end
+    for f_error in (
+        MOI.ScalarNonlinearFunction(:*, Any[1.0, x]),
+        MOI.ScalarNonlinearFunction(:+, Any[1.0, x]),
+    )
+        @test_throws(
+            InexactError,
+            convert(MOI.ScalarAffineFunction{Float64}, f_error),
+        )
+    end
+    return
+end
+
+function test_convert_ScalarNonlinearFunction_ScalarQuadraticTerm()
+    x = MOI.VariableIndex(1)
+    y = MOI.VariableIndex(2)
+    f = MOI.ScalarQuadraticTerm(1, x, y)
+    g = MOI.ScalarNonlinearFunction(:*, Any[1, x, y])
+    h = MOI.ScalarNonlinearFunction(:*, Any[x, 1, y])
+    i = MOI.ScalarNonlinearFunction(:*, Any[x, y, 1])
+    @test convert(MOI.ScalarNonlinearFunction, f) ≈ g
+    @test convert(MOI.ScalarQuadraticTerm{Int}, g) == f
+    @test convert(MOI.ScalarQuadraticTerm{Int}, h) == f
+    @test convert(MOI.ScalarQuadraticTerm{Int}, i) == f
+    f = MOI.ScalarQuadraticTerm(2.0, x, x)
+    g = MOI.ScalarNonlinearFunction(:*, Any[1.0, x, x])
+    h = MOI.ScalarNonlinearFunction(:*, Any[x, 1.0, x])
+    i = MOI.ScalarNonlinearFunction(:*, Any[x, x, 1.0])
+    @test convert(MOI.ScalarNonlinearFunction, f) ≈ g
+    @test convert(MOI.ScalarQuadraticTerm{Float64}, g) == f
+    @test convert(MOI.ScalarQuadraticTerm{Float64}, h) == f
+    @test convert(MOI.ScalarQuadraticTerm{Float64}, i) == f
+    for f_error in (
+        MOI.ScalarNonlinearFunction(:*, Any[1.0, x, 2.0]),
+        MOI.ScalarNonlinearFunction(:+, Any[1.0, x, x]),
+        MOI.ScalarNonlinearFunction(:*, Any[x, x]),
+    )
+        @test_throws(
+            InexactError,
+            convert(MOI.ScalarQuadraticTerm{Float64}, f_error),
+        )
+    end
+    return
+end
+
+function test_convert_ScalarNonlinearFunction_ScalarQuadraticFunction()
+    x = MOI.VariableIndex(1)
+    y = MOI.VariableIndex(2)
+    for f in (
+        1.0 * x * x,
+        1.0 * x * x + 2.0,
+        1.0 * x * x + 1.0 * x * y + 2.0,
+        1.0 * x + 2.0 * y * y + 2.0,
+        2.0 * y + 2.0 + 2.0 * x * x,
+    )
+        g = convert(MOI.ScalarNonlinearFunction, f)
+        @test convert(MOI.ScalarQuadraticFunction{Float64}, g) ≈ f
+    end
+    for f_error in (
+        MOI.ScalarNonlinearFunction(:*, Any[1.0, x]),
+        MOI.ScalarNonlinearFunction(:+, Any[1.0, x]),
+    )
+        @test_throws(
+            InexactError,
+            convert(MOI.ScalarQuadraticFunction{Float64}, f_error),
+        )
+    end
+    return
+end
+
 function runtests()
     for name in names(@__MODULE__; all = true)
         if startswith("$name", "test_")

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -343,9 +343,17 @@ function test_convert_ScalarNonlinearFunction_ScalarAffineFunction()
         g = convert(MOI.ScalarNonlinearFunction, f)
         @test convert(MOI.ScalarAffineFunction{Float64}, g) ≈ f
     end
+    f_add = MOI.ScalarNonlinearFunction(:+, Any[1.0, x])
+    for (f, g) in (
+        MOI.ScalarNonlinearFunction(:*, Any[1.0, x]) => 1.0 * x,
+        MOI.ScalarNonlinearFunction(:+, Any[1.0, x]) => 1.0 + x,
+        MOI.ScalarNonlinearFunction(:+, Any[f_add, f_add]) => 2.0 + 2.0 * x,
+    )
+        @test convert(MOI.ScalarAffineFunction{Float64}, f) ≈ g
+    end
     for f_error in (
-        MOI.ScalarNonlinearFunction(:*, Any[1.0, x]),
-        MOI.ScalarNonlinearFunction(:+, Any[1.0, x]),
+        MOI.ScalarNonlinearFunction(:/, Any[1.0, x]),
+        MOI.ScalarNonlinearFunction(:+, Any[1.0, 1.0*x*x]),
     )
         @test_throws(
             InexactError,
@@ -400,10 +408,18 @@ function test_convert_ScalarNonlinearFunction_ScalarQuadraticFunction()
         g = convert(MOI.ScalarNonlinearFunction, f)
         @test convert(MOI.ScalarQuadraticFunction{Float64}, g) ≈ f
     end
-    for f_error in (
-        MOI.ScalarNonlinearFunction(:*, Any[1.0, x]),
-        MOI.ScalarNonlinearFunction(:+, Any[1.0, x]),
+    f_add = MOI.ScalarNonlinearFunction(:+, Any[1.0, x])
+    for (f, g) in (
+        MOI.ScalarNonlinearFunction(:*, Any[1.0, x]) => 0.0 * x * x + 1.0 * x,
+        MOI.ScalarNonlinearFunction(:*, Any[x, 1.0, x]) => 1.0 * x * x,
+        MOI.ScalarNonlinearFunction(:+, Any[1.0, x]) => 0.0 * x * x + 1.0 + x,
+        MOI.ScalarNonlinearFunction(:+, Any[f_add, f_add]) =>
+            0.0 * x * x + 2.0 + 2.0 * x,
+        MOI.ScalarNonlinearFunction(:^, Any[x, 2]) => 1.0 * x * x,
     )
+        @test convert(MOI.ScalarQuadraticFunction{Float64}, f) ≈ g
+    end
+    for f_error in (MOI.ScalarNonlinearFunction(:/, Any[1.0, x]),)
         @test_throws(
             InexactError,
             convert(MOI.ScalarQuadraticFunction{Float64}, f_error),


### PR DESCRIPTION
cc @chriscoey 

Necessary precursor to https://github.com/jump-dev/Pavito.jl/issues/67

## Basic

 - [x] Create a new file in `src/Bridges/XXX/bridges`
 - [x] Define the bridge, following existing examples. The name of the bridge
       struct must end in `Bridge`
 - [x] Check if your bridge can be a subtype of [`MOI.Bridges.Constraint.SetMapBridge`](@ref)
 - [x] Define a new `const` that is a `SingleBridgeOptimizer` wrapping the
       new bridge. The name of the const must be the name of the bridge, less
       the `Bridge` suffix
 - [x] `include` the file in `src/Bridges/XXX/bridges/XXX.jl`
 - [x] If the bridge should be enabled by default, add the bridge to
       `add_all_bridges` at the bottom of `src/Bridges/XXX/XXX.jl`

## Tests

 - [x] Create a new file in the appropriate subdirectory of `tests/Bridges/XXX`
 - [x] Use `MOI.Bridges.runtests` to test various inputs and outputs of the
       bridge
 - [x] If, after opening the pull request to add the bridge, some lines are not
       covered by the tests, add additional bridge-specific tests to cover the
       untested lines.

## Documentation

 - [x] Add a docstring which uses the same template as existing bridges.
 - [x] Add the docstring to `docs/src/submodules/Bridges/list_of_bridges.md`

## Final touch

If the bridge depends on run-time values of other variables and constraints in
the model:

 - [x] <s>Implement `MOI.Utilities.needs_final_touch(::Bridge)`</s>
 - [x] <s>Implement `MOI.Utilities.final_touch(::Bridge, ::MOI.ModelLike)`</s>
 - [x] <s>Ensure that `final_touch` can be called multiple times in a row</s>