### PR TITLE
[Bridges] mark ScalarQuadraticToScalarNonlinearBridge as experimental

### DIFF
--- a/docs/src/submodules/Bridges/list_of_bridges.md
+++ b/docs/src/submodules/Bridges/list_of_bridges.md
@@ -28,7 +28,6 @@ Bridges.Constraint.ScalarSlackBridge
 Bridges.Constraint.VectorSlackBridge
 Bridges.Constraint.ScalarFunctionizeBridge
 Bridges.Constraint.VectorFunctionizeBridge
-Bridges.Constraint.ScalarQuadraticToScalarNonlinearBridge
 Bridges.Constraint.SplitComplexEqualToBridge
 Bridges.Constraint.SplitComplexZerosBridge
 Bridges.Constraint.SplitHyperRectangleBridge

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -84,10 +84,11 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(bridged_model, VectorSlackBridge{T})
     MOI.Bridges.add_bridge(bridged_model, ScalarFunctionizeBridge{T})
     MOI.Bridges.add_bridge(bridged_model, VectorFunctionizeBridge{T})
-    MOI.Bridges.add_bridge(
-        bridged_model,
-        ScalarQuadraticToScalarNonlinearBridge{T},
-    )
+    # TODO(odow): this will likely be removed in a future commit.
+    # MOI.Bridges.add_bridge(
+    #     bridged_model,
+    #     ScalarQuadraticToScalarNonlinearBridge{T},
+    # )
     MOI.Bridges.add_bridge(bridged_model, SplitHyperRectangleBridge{T})
     MOI.Bridges.add_bridge(bridged_model, SplitIntervalBridge{T})
     MOI.Bridges.add_bridge(bridged_model, SplitComplexEqualToBridge{T})

--- a/src/Bridges/Constraint/bridges/functionize.jl
+++ b/src/Bridges/Constraint/bridges/functionize.jl
@@ -318,6 +318,10 @@ end
 """
     ScalarQuadraticToScalarNonlinearBridge{T,S} <: Bridges.Constraint.AbstractBridge
 
+!!! warning
+    This bridge is not enabled by default, and it may be removed in a future
+    release of MathOptInterface.
+
 `ScalarQuadraticToScalarNonlinearBridge` implements the following reformulations:
 
   * ``f(x) \\in S`` into ``g(x) \\in S``


### PR DESCRIPTION
#2232 has been sitting open for too long. It is blocked by #2235, which would remove this bridge. If we tagged 1.19 before #2235, then removing it would be breaking. So I've opted to leave the code in for now, but not add it by default. 

That should let us release v1.19 and take a longer look at #2235.