### PR TITLE
adding ObjectiveLimit attribute

### DIFF
--- a/docs/src/manual/models.md
+++ b/docs/src/manual/models.md
@@ -100,3 +100,4 @@ The following attributes are available:
  * [`SolverVersion`](@ref)
  * [`SolveTimeSec`](@ref)
  * [`TimeLimitSec`](@ref)
+ * [`ObjectiveLimit`](@ref)

--- a/docs/src/reference/models.md
+++ b/docs/src/reference/models.md
@@ -77,6 +77,7 @@ SolverName
 SolverVersion
 Silent
 TimeLimitSec
+ObjectiveLimit
 RawOptimizerAttribute
 NumberOfThreads
 RawSolver

--- a/docs/src/tutorials/implementing.md
+++ b/docs/src/tutorials/implementing.md
@@ -333,6 +333,7 @@ method for each attribute.
 | [`Name`](@ref)         | Yes           | Yes           | Yes                |
 | [`Silent`](@ref)       | Yes           | Yes           | Yes                |
 | [`TimeLimitSec`](@ref) | Yes           | Yes           | Yes                |
+| [`ObjectiveLimit`](@ref) | Yes         | Yes           | Yes                |
 | [`RawOptimizerAttribute`](@ref) | Yes  | Yes           | Yes                |
 | [`NumberOfThreads`](@ref) | Yes        | Yes           | Yes                |
 | [`AbsoluteGapTolerance`](@ref) | Yes   | Yes           | Yes                |

--- a/src/Test/test_attribute.jl
+++ b/src/Test/test_attribute.jl
@@ -196,6 +196,8 @@ function test_attribute_ObjectiveLimit(model::MOI.AbstractOptimizer, ::Config)
     value = MOI.get(model, MOI.ObjectiveLimit())
     MOI.set(model, MOI.ObjectiveLimit(), 0.0)
     @test MOI.get(model, MOI.ObjectiveLimit()) == 0.0
+    MOI.set(model, MOI.ObjectiveLimit(), nothing)
+    @test MOI.get(model, MOI.ObjectiveLimit()) === nothing
     MOI.set(model, MOI.ObjectiveLimit(), 1.0)
     @test MOI.get(model, MOI.ObjectiveLimit()) == 1.0
     MOI.set(model, MOI.ObjectiveLimit(), value)

--- a/src/Test/test_attribute.jl
+++ b/src/Test/test_attribute.jl
@@ -190,6 +190,30 @@ function setup_test(
     return
 end
 
+function test_attribute_ObjectiveLimit(model::MOI.AbstractOptimizer, ::Config)
+    @requires MOI.supports(model, MOI.ObjectiveLimit())
+    # Get the current value to restore it at the end of the test
+    value = MOI.get(model, MOI.ObjectiveLimit())
+    MOI.set(model, MOI.ObjectiveLimit(), 0.0)
+    @test MOI.get(model, MOI.ObjectiveLimit()) == 0.0
+    MOI.set(model, MOI.ObjectiveLimit(), 1.0)
+    @test MOI.get(model, MOI.ObjectiveLimit()) == 1.0
+    MOI.set(model, MOI.ObjectiveLimit(), value)
+    @test value == MOI.get(model, MOI.ObjectiveLimit()) # Equality should hold
+    _test_attribute_value_type(model, MOI.ObjectiveLimit())
+    return
+end
+test_attribute_ObjectiveLimit(::MOI.ModelLike, ::Config) = nothing
+
+function setup_test(
+    ::typeof(test_attribute_ObjectiveLimit),
+    model::MOIU.MockOptimizer,
+    ::Config,
+)
+    MOI.set(model, MOI.ObjectiveLimit(), nothing)
+    return
+end
+
 """
     test_attribute_AbsoluteGapTolerance(model::MOI.AbstractOptimizer, config::Config)
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -851,6 +851,18 @@ struct TimeLimitSec <: AbstractOptimizerAttribute end
 attribute_value_type(::TimeLimitSec) = Union{Nothing,Float64}
 
 """
+    ObjectiveLimit()
+
+
+An optimizer attribute for setting a limit on the objective value.
+The solver may stop when the `ObjectiveValue` is better (lower for minimization, higher for maximization) than the `ObjectiveLimit`.
+When `set` to `nothing`, it removes the solver limit. The default value is `nothing`.
+"""
+struct ObjectiveLimit <: AbstractOptimizerAttribute end
+
+attribute_value_type(::ObjectiveLimit) = Union{Nothing,Float64}
+
+"""
     RawOptimizerAttribute(name::String)
 
 An optimizer attribute for the solver-specific parameter identified by `name`.

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -860,10 +860,10 @@ The provided limit must be a `Union{Float64,Nothing}`.
 When `set` to `nothing`, the limit reverts to the solver's default.
 
 The default value is `nothing`.
+
 The solver may stop when the [`ObjectiveValue`](@ref) is better (lower for
 minimization, higher for maximization) than the `ObjectiveLimit`. If stopped,
 the [`TerminationStatus`](@ref) should be `OBJECTIVE_LIMIT`.
-
 """
 struct ObjectiveLimit <: AbstractOptimizerAttribute end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -853,10 +853,17 @@ attribute_value_type(::TimeLimitSec) = Union{Nothing,Float64}
 """
     ObjectiveLimit()
 
-
 An optimizer attribute for setting a limit on the objective value.
-The solver may stop when the `ObjectiveValue` is better (lower for minimization, higher for maximization) than the `ObjectiveLimit`.
-When `set` to `nothing`, it removes the solver limit. The default value is `nothing`.
+
+The provided limit must be a `Union{Float64,Nothing}`.
+
+When `set` to `nothing`, the limit reverts to the solver's default.
+
+The default value is `nothing`.
+The solver may stop when the [`ObjectiveValue`](@ref) is better (lower for
+minimization, higher for maximization) than the `ObjectiveLimit`. If stopped,
+the [`TerminationStatus`](@ref) should be `OBJECTIVE_LIMIT`.
+
 """
 struct ObjectiveLimit <: AbstractOptimizerAttribute end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -867,7 +867,6 @@ the [`TerminationStatus`](@ref) should be `OBJECTIVE_LIMIT`.
 """
 struct ObjectiveLimit <: AbstractOptimizerAttribute end
 
-
 """
     RawOptimizerAttribute(name::String)
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -855,7 +855,7 @@ attribute_value_type(::TimeLimitSec) = Union{Nothing,Float64}
 
 An optimizer attribute for setting a limit on the objective value.
 
-The provided limit must be a `Union{Float64,Nothing}`.
+The provided limit must be a `Union{Real,Nothing}`.
 
 When `set` to `nothing`, the limit reverts to the solver's default.
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -867,7 +867,6 @@ the [`TerminationStatus`](@ref) should be `OBJECTIVE_LIMIT`.
 """
 struct ObjectiveLimit <: AbstractOptimizerAttribute end
 
-attribute_value_type(::ObjectiveLimit) = Union{Nothing,Float64}
 
 """
     RawOptimizerAttribute(name::String)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -79,6 +79,7 @@ function precompile_model(model, constraints)
         ObjectiveValue,
         Silent,
         TimeLimitSec,
+        ObjectiveBound,
         NumberOfVariables,
     )
         Base.precompile(get, (model, attr))

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -79,7 +79,6 @@ function precompile_model(model, constraints)
         ObjectiveValue,
         Silent,
         TimeLimitSec,
-        ObjectiveBound,
         NumberOfVariables,
     )
         Base.precompile(get, (model, attr))

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -190,6 +190,7 @@ function test_default_attributes()
         MOI.SolverName(),
         MOI.Silent(),
         MOI.TimeLimitSec(),
+        MOI.ObjectiveLimit(),
         MOI.NumberOfThreads(),
         MOI.ResultCount(),
     )
@@ -209,6 +210,7 @@ function test_copyable_solver_attributes()
     cached = MOIU.CachingOptimizer(cache, MOIU.MANUAL)
     MOI.set(cached, MOI.Silent(), true)
     MOI.set(cached, MOI.TimeLimitSec(), 0.0)
+    MOI.set(cached, MOI.ObjectiveLimit(), 42.0)
     MOI.set(cached, MOI.NumberOfThreads(), 1)
     mock = MOIU.MockOptimizer(MOIU.UniversalFallback(MOIU.Model{Float64}()))
     MOIU.reset_optimizer(cached, mock)
@@ -216,15 +218,20 @@ function test_copyable_solver_attributes()
     @test MOI.get(cached, MOI.Silent())
     @test MOI.get(mock, MOI.TimeLimitSec()) == 0.0
     @test MOI.get(cached, MOI.TimeLimitSec()) == 0.0
+    @test MOI.get(mock, MOI.ObjectiveLimit()) == 42.0
+    @test MOI.get(cached, MOI.ObjectiveLimit()) == 42.0
     @test MOI.get(mock, MOI.NumberOfThreads()) == 1
     @test MOI.get(cached, MOI.NumberOfThreads()) == 1
     MOI.set(cached, MOI.Silent(), false)
     MOI.set(cached, MOI.TimeLimitSec(), 1.0)
+    MOI.set(cached, MOI.ObjectiveLimit(), 1.0)
     MOI.set(cached, MOI.NumberOfThreads(), 2)
     @test !MOI.get(mock, MOI.Silent())
     @test !MOI.get(cached, MOI.Silent())
     @test MOI.get(mock, MOI.TimeLimitSec()) ≈ 1.0
+    @test MOI.get(mock, MOI.ObjectiveLimit()) ≈ 1.0
     @test MOI.get(cached, MOI.TimeLimitSec()) ≈ 1.0
+    @test MOI.get(cached, MOI.ObjectiveLimit()) ≈ 1.0
     @test MOI.get(mock, MOI.NumberOfThreads()) == 2
     @test MOI.get(cached, MOI.NumberOfThreads()) == 2
     mock = MOIU.MockOptimizer(MOIU.UniversalFallback(MOIU.Model{Float64}()))
@@ -233,6 +240,8 @@ function test_copyable_solver_attributes()
     @test !MOI.get(cached, MOI.Silent())
     @test MOI.get(mock, MOI.TimeLimitSec()) ≈ 1.0
     @test MOI.get(cached, MOI.TimeLimitSec()) ≈ 1.0
+    @test MOI.get(mock, MOI.ObjectiveLimit()) ≈ 1.0
+    @test MOI.get(cached, MOI.ObjectiveLimit()) ≈ 1.0
     @test MOI.get(mock, MOI.NumberOfThreads()) == 2
     @test MOI.get(cached, MOI.NumberOfThreads()) == 2
     MOI.set(cached, MOI.Silent(), true)

--- a/test/Utilities/universalfallback.jl
+++ b/test/Utilities/universalfallback.jl
@@ -382,6 +382,7 @@ function test_missing_attribute()
     model = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     @test MOI.get(model, MOI.Test.UnknownModelAttribute()) === nothing
     @test MOI.get(model, MOI.TimeLimitSec()) === nothing
+    @test MOI.get(model, MOI.ObjectiveLimit()) === nothing
     return
 end
 


### PR DESCRIPTION
This MR introduces an attribute to set an objective limit, after which the solver can stop.
This can be useful e.g. for separation routines, when one requires at least a certain objective value to be reached.

Setting this objective bound as a constraint in a feasibility formulation is often ill-advised and can lead to poor solver behaviour, most MIP solvers provide a dedicated parameter instead:
- Gurobi: https://www.gurobi.com/documentation/current/refman/bestobjstop.html#parameter:BestObjStop
- SCIP: `limits/objectivestop` is coming in the next major release
- HiGHS: objective_bound https://ergo-code.github.io/HiGHS/stable/options/definitions/#objective_bound

CPLEX seems to have [this](https://www.ibm.com/docs/en/icos/20.1.0?topic=parameters-lower-objective-value-limit) but it seems to be for LPs only?
Monotonically improving iterative solvers could also implement the attribute