### PR TITLE
[FileFormats.MOF] add support for Scaled set

### DIFF
--- a/docs/src/submodules/FileFormats/overview.md
+++ b/docs/src/submodules/FileFormats/overview.md
@@ -94,7 +94,7 @@ julia> print(read("file.mof.json", String))
   "name": "MathOptFormat Model",
   "version": {
     "major": 1,
-    "minor": 4
+    "minor": 5
   },
   "variables": [
     {
@@ -230,7 +230,7 @@ julia> good_model = JSON.parse("""
        {
          "version": {
            "major": 1,
-           "minor": 4
+           "minor": 5
          },
          "variables": [{"name": "x"}],
          "objective": {"sense": "feasibility"},
@@ -249,7 +249,7 @@ julia> bad_model = JSON.parse("""
        {
          "version": {
            "major": 1,
-           "minor": 4
+           "minor": 5
          },
          "variables": [{"NaMe": "x"}],
          "objective": {"sense": "feasibility"},

--- a/src/FileFormats/MOF/MOF.jl
+++ b/src/FileFormats/MOF/MOF.jl
@@ -11,10 +11,10 @@ import OrderedCollections
 import JSON
 import MathOptInterface as MOI
 
-const SCHEMA_PATH = joinpath(@__DIR__, "mof.1.4.schema.json")
-const VERSION = v"1.4"
+const SCHEMA_PATH = joinpath(@__DIR__, "mof.1.5.schema.json")
+const VERSION = v"1.5"
 const SUPPORTED_VERSIONS =
-    (v"1.4", v"1.3", v"1.2", v"1.1", v"1.0", v"0.6", v"0.5", v"0.4")
+    (v"1.5", v"1.4", v"1.3", v"1.2", v"1.1", v"1.0", v"0.6", v"0.5", v"0.4")
 
 const OrderedObject = OrderedCollections.OrderedDict{String,Any}
 const UnorderedObject = Dict{String,Any}
@@ -92,6 +92,7 @@ MOI.Utilities.@model(
 
 # Indicator is handled by UniversalFallback.
 # Reified is handled by UniversalFallback.
+# Scaled is handled bby UniversalFallback.
 
 const Model = MOI.Utilities.UniversalFallback{InnerModel{Float64}}
 

--- a/src/FileFormats/MOF/mof.1.5.schema.json
+++ b/src/FileFormats/MOF/mof.1.5.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/schema#",
-    "$id": "https://jump.dev/MathOptFormat/schemas/mof.1.4.schema.json",
+    "$id": "https://jump.dev/MathOptFormat/schemas/mof.1.5.schema.json",
     "title": "The schema for MathOptFormat",
     "type": "object",
     "required": ["version", "variables", "objective", "constraints"],
@@ -11,7 +11,7 @@
             "required": ["minor", "major"],
             "properties": {
                 "minor": {
-                    "enum": [0, 1, 2, 3, 4]
+                    "enum": [0, 1, 2, 3, 4, 5]
                 },
                 "major": {
                     "const": 1
@@ -765,8 +765,7 @@
                     }
                 }
             }, {
-                "description": "The (vectorized) cone of symmetric positive semidefinite matrices, with `side_dimension` rows and columns, such that the off-diagonal entries are scaled by √2. The entries of the upper-right triangular part of the matrix are given column by column (or equivalently, the entries of the lower-left triangular part are given row by row).",
-                "examples": ["{\"type\": \"ScaledPositiveSemidefiniteConeTriangle\", \"side_dimension\": 2}"],
+                "description": "DEPRECATED: use the Scaled set combinned with PositiveSemidefiniteConeTriangle instead.",
                 "required": ["side_dimension"],
                 "properties": {
                     "type": {
@@ -1149,6 +1148,18 @@
                     },
                     "p": {
                         "type": "number"
+                    }
+                }
+            }, {
+                "description": "The set in the `set` field, scaled such that the inner product of two elements in the set is the same as the dot product of the two vector functions. This is most useful for solvers which require PSD matrices in _scaled_ form.",
+                "examples": ["{\"type\": \"Scaled\", \"set\": {\"type\": \"PositiveSemidefiniteConeTriangle\", \"side_dimension\": 2}}"],
+                "required": ["set"],
+                "properties": {
+                    "type": {
+                        "const": "Scaled"
+                    },
+                    "set": {
+                        "$ref": "#/definitions/vector_sets"
                     }
                 }
             }]

--- a/src/FileFormats/MOF/read.jl
+++ b/src/FileFormats/MOF/read.jl
@@ -383,6 +383,7 @@ end
     LogDetConeSquare,
     PositiveSemidefiniteConeTriangle,
     ScaledPositiveSemidefiniteConeTriangle, # Required for v1.4
+    Scaled,                                 # Required for v1.5
     PositiveSemidefiniteConeSquare,
     HermitianPositiveSemidefiniteConeTriangle,
     ExponentialCone,
@@ -541,6 +542,10 @@ function set_to_moi(
 )
     d = object["side_dimension"]
     return MOI.Scaled(MOI.PositiveSemidefiniteConeTriangle(d))
+end
+
+function set_to_moi(::Val{:Scaled}, object::Object)
+    return MOI.Scaled(set_to_moi(object["set"]))
 end
 
 function set_to_moi(::Val{:PositiveSemidefiniteConeSquare}, object::Object)

--- a/src/FileFormats/MOF/write.jl
+++ b/src/FileFormats/MOF/write.jl
@@ -358,11 +358,11 @@ function moi_to_object(
 end
 
 function moi_to_object(
-    set::MOI.Scaled{MOI.PositiveSemidefiniteConeTriangle},
+    set::MOI.Scaled,
     name_map::Dict{MOI.VariableIndex,String},
 )
     return OrderedObject(
-        "type" => "ScaledPositiveSemidefiniteConeTriangle",
-        "side_dimension" => set.set.side_dimension,
+        "type" => "Scaled",
+        "set" => moi_to_object(set.set, name_map),
     )
 end

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -782,6 +782,18 @@ c1: [x1, x2, x3] in ScaledPositiveSemidefiniteConeTriangle(2)
     )
 end
 
+function test_Scaled_PositiveSemidefiniteConeTriangle()
+    return _test_model_equality(
+        """
+variables: x1, x2, x3
+minobjective: x1
+c1: [x1, x2, x3] in Scaled(PositiveSemidefiniteConeTriangle(2))
+""",
+        ["x1", "x2", "x3"],
+        ["c1"],
+    )
+end
+
 function test_PositiveSemidefiniteConeSquare()
     return _test_model_equality(
         """
@@ -1361,6 +1373,16 @@ function test_integer_coefficients()
         ],
         "constant" => 4,
     )
+    return
+end
+
+function test_ScaledPositiveSemidefiniteConeTriangle()
+    object = Dict(
+        "type" => "ScaledPositiveSemidefiniteConeTriangle",
+        "side_dimension" => 2,
+    )
+    @test MOF.set_to_moi(object) ==
+          MOI.Scaled(MOI.PositiveSemidefiniteConeTriangle(2))
     return
 end
 

--- a/test/FileFormats/MOF/nlp.mof.json
+++ b/test/FileFormats/MOF/nlp.mof.json
@@ -2,7 +2,7 @@
   "name": "MathOptFormat Model",
   "version": {
     "major": 1,
-    "minor": 4
+    "minor": 5
   },
   "variables": [
     {


### PR DESCRIPTION
Closes #2248 

## Basic

 - [x] The file at `src/FileFormats/MOF/mof.X.Y.schema.json` is updated
 - [x] The constants `SCHEMA_PATH`, `VERSION`, and `SUPPORTED_VERSIONS` are
       updated in `src/FileFormats/MOF/MOF.jl`

## New sets

 - [x] New sets are added to the `@model` in `src/FileFormats/MOF/MOF.jl`
 - [x] New sets are added to the `@enum` in `src/FileFormats/MOF/read.jl`
 - [x] `set_to_moi` is defined for each set in `src/FileFormats/MOF/read.jl`
 - [x] `head_name` is defined for each set in `src/FileFormats/MOF/write.jl`
 - [x] A new unit test calling `_test_model_equality` is aded to
       `test/FileFormats/MOF/MOF.jl`

## Tests

 - [x] The version field in `test/FileFormats/MOF/nlp.mof.json` is updated

## Documentation

 - [x] The version fields are updated in `docs/src/submodules/FileFormats/overview.md`