### PR TITLE
[Bridges] fix adjoint functions in SetDotInverseScalingBridge

### DIFF
--- a/src/Bridges/Constraint/bridges/set_dot_scaling.jl
+++ b/src/Bridges/Constraint/bridges/set_dot_scaling.jl
@@ -179,14 +179,14 @@ function MOI.Bridges.adjoint_map_function(
     ::Type{<:SetDotInverseScalingBridge{T,S}},
     func,
 ) where {T,S}
-    return _inverse_scale(T, S, func)
+    return _scale(T, S, func)
 end
 
 function MOI.Bridges.inverse_adjoint_map_function(
     ::Type{<:SetDotInverseScalingBridge{T,S}},
     func,
 ) where {T,S}
-    return _scale(T, S, func)
+    return _inverse_scale(T, S, func)
 end
 
 # Since the set type is not defined, the default `MOI.supports_constraint`

--- a/test/Bridges/Constraint/set_dot_scaling.jl
+++ b/test/Bridges/Constraint/set_dot_scaling.jl
@@ -111,6 +111,42 @@ function test_inverse_scaling_quadratic()
     return
 end
 
+function test_set_dot_scaling_constraint_dual_start()
+    inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    model = MOI.Bridges.Constraint.SetDotScaling{Float64}(inner)
+    x = MOI.add_variables(model, 3)
+    c = MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables(x),
+        MOI.PositiveSemidefiniteConeTriangle(2),
+    )
+    MOI.set(model, MOI.ConstraintDualStart(), c, [1.0, 1.0, 1.0])
+    @test MOI.get(model, MOI.ConstraintDualStart(), c) ≈ [1.0, 1.0, 1.0]
+    F = MOI.VectorAffineFunction{Float64}
+    S = MOI.Scaled{MOI.PositiveSemidefiniteConeTriangle}
+    d = MOI.get(inner, MOI.ListOfConstraintIndices{F,S}())[1]
+    @test MOI.get(inner, MOI.ConstraintDualStart(), d) ≈ [1.0, √2, 1.0]
+    return
+end
+
+function test_set_dot_inverse_scaling_constraint_dual_start()
+    inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    model = MOI.Bridges.Constraint.SetDotInverseScaling{Float64}(inner)
+    x = MOI.add_variables(model, 3)
+    c = MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables(x),
+        MOI.ScaledPositiveSemidefiniteConeTriangle(2),
+    )
+    MOI.set(model, MOI.ConstraintDualStart(), c, [1.0, 1.0, 1.0])
+    @test MOI.get(model, MOI.ConstraintDualStart(), c) ≈ [1.0, 1.0, 1.0]
+    F = MOI.VectorAffineFunction{Float64}
+    S = MOI.PositiveSemidefiniteConeTriangle
+    d = MOI.get(inner, MOI.ListOfConstraintIndices{F,S}())[1]
+    @test MOI.get(inner, MOI.ConstraintDualStart(), d) ≈ [1.0, 1 / √2, 1.0]
+    return
+end
+
 end  # module
 
 TestConstraintSetDotScaling.runtests()


### PR DESCRIPTION
Potential fix for https://github.com/jump-dev/MathOptInterface.jl/pull/2262#issuecomment-1709227184.

I don't really understand what's going here, but it makes sense that the adjoint should be the opposite of the forward map? That's what it is for `SetDotScalingBridge`, so I think this is just a typo.

Seemed to fix SDPA, so I'll re-run solver-tests on this branch: https://github.com/jump-dev/MathOptInterface.jl/actions/runs/6103555292