### PR TITLE
Add new MipDualBound status

### DIFF
--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -1288,6 +1288,15 @@ A model attribute for the best known bound on the optimal objective value.
 """
 struct ObjectiveBound <: AbstractModelAttribute end
 
+
+"""
+    MipDualBound()
+
+A model attribute for the best known dual bound on the objective value.
+"""
+struct MipDualBound <: AbstractModelAttribute end
+
+
 """
     RelativeGap()
 
@@ -2192,6 +2201,7 @@ function is_set_by_optimize(
         ConstraintDual,
         ConstraintBasisStatus,
         VariableBasisStatus,
+        MipDualBound,
     },
 )
     return true


### PR DESCRIPTION
This is useful when the solver hits a time limit and contains no solution available from the "objective value" or "objective bound" field, but we still want to retrieve the latest dual bound computed in the last iteration.

This requires a version of HiGHS that implements this change: https://github.com/ERGO-Code/HiGHS/pull/1420 , hence the draft status for the time being