### PR TITLE
[Utilities] remove MOIU acronym

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -8,7 +8,6 @@ module Utilities
 
 import LinearAlgebra
 import MathOptInterface as MOI
-import MathOptInterface.Utilities as MOIU # used in macro
 import MutableArithmetics as MA
 import OrderedCollections: OrderedDict
 

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -115,7 +115,7 @@ end
 
 function Base.show(io::IO, C::CachingOptimizer)
     indent = " "^get(io, :indent, 0)
-    MOIU.print_with_acronym(io, summary(C))
+    print_with_acronym(io, summary(C))
     print(io, "\n$(indent)in state $(C.state)")
     print(io, "\n$(indent)in mode $(C.mode)")
     print(io, "\n$(indent)with model cache ")
@@ -393,8 +393,8 @@ function MOI.add_constrained_variable(
     m::CachingOptimizer,
     set::S,
 ) where {S<:MOI.AbstractScalarSet}
-    if m.state == MOIU.ATTACHED_OPTIMIZER
-        if m.mode == MOIU.AUTOMATIC
+    if m.state == ATTACHED_OPTIMIZER
+        if m.mode == AUTOMATIC
             try
                 vindex_optimizer, cindex_optimizer =
                     MOI.add_constrained_variable(
@@ -422,7 +422,7 @@ function MOI.add_constrained_variable(
         end
     end
     vindex, cindex = MOI.add_constrained_variable(m.model_cache, set)
-    if m.state == MOIU.ATTACHED_OPTIMIZER
+    if m.state == ATTACHED_OPTIMIZER
         m.model_to_optimizer_map[vindex] = vindex_optimizer
         m.optimizer_to_model_map[vindex_optimizer] = vindex
         m.model_to_optimizer_map[cindex] = cindex_optimizer

--- a/src/Utilities/copy/index_map.jl
+++ b/src/Utilities/copy/index_map.jl
@@ -35,7 +35,7 @@ end
 
 function _identity_constraints_map(
     model,
-    map::MOIU.DoubleDicts.IndexDoubleDictInner{F,S},
+    map::DoubleDicts.IndexDoubleDictInner{F,S},
 ) where {F,S}
     for c in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         map[c] = c

--- a/src/Utilities/product_of_sets.jl
+++ b/src/Utilities/product_of_sets.jl
@@ -20,7 +20,7 @@ function _sets_code(esc_name, T, type_def, set_types...)
         push!(
             code.args,
             :(
-                function $MOIU.set_index(
+                function $MOI.Utilities.set_index(
                     ::$esc_name{$(T)},
                     ::Type{$(esc_type)},
                 ) where {$T}
@@ -31,7 +31,11 @@ function _sets_code(esc_name, T, type_def, set_types...)
     end
     push!(
         code.args,
-        :($MOIU.set_types(::$esc_name{$T}) where {$T} = [$(esc_types...)]),
+        :(
+            function $MOI.Utilities.set_types(::$esc_name{$T}) where {$T}
+                return [$(esc_types...)]
+            end
+        ),
     )
     return code
 end
@@ -66,14 +70,15 @@ Generate a new [`MixOfScalarSets`](@ref) subtype.
 macro mix_of_scalar_sets(name, set_types...)
     esc_name = esc(name)
     T = esc(:T)
-    type_def = :(struct $(esc_name){$(T)} <: $(MOIU).MixOfScalarSets{$(T)}
-        """
-        `set_ids[i]` maps the row `i` to the corresponding set type.
-        """
-        set_ids::Vector{Int}
+    type_def =
+        :(struct $(esc_name){$(T)} <: $MOI.Utilities.MixOfScalarSets{$(T)}
+            """
+            `set_ids[i]` maps the row `i` to the corresponding set type.
+            """
+            set_ids::Vector{Int}
 
-        $(esc_name){$(T)}() where {$(T)} = new(Int[])
-    end)
+            $(esc_name){$(T)}() where {$(T)} = new(Int[])
+        end)
     return _sets_code(esc_name, T, type_def, set_types...)
 end
 
@@ -164,7 +169,8 @@ macro product_of_sets(name, set_types...)
     esc_name = esc(name)
     T = esc(:T)
     type_def = :(
-        mutable struct $(esc_name){$(T)} <: $(MOIU).OrderedProductOfSets{$(T)}
+        mutable struct $(esc_name){$(T)} <:
+                       $MOI.Utilities.OrderedProductOfSets{$(T)}
             """
             During the copy, this counts the number of rows corresponding to
             each set. At the end of copy, `final_touch` is called, which

--- a/src/Utilities/product_of_sets.jl
+++ b/src/Utilities/product_of_sets.jl
@@ -31,11 +31,9 @@ function _sets_code(esc_name, T, type_def, set_types...)
     end
     push!(
         code.args,
-        :(
-            function $MOI.Utilities.set_types(::$esc_name{$T}) where {$T}
-                return [$(esc_types...)]
-            end
-        ),
+        :(function $MOI.Utilities.set_types(::$esc_name{$T}) where {$T}
+            return [$(esc_types...)]
+        end),
     )
     return code
 end

--- a/src/Utilities/struct_of_constraints.jl
+++ b/src/Utilities/struct_of_constraints.jl
@@ -291,16 +291,16 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
             num_variables::Int64
         end
 
-        function $MOIU.broadcastcall(f::Function, model::$struct_name)
+        function $MOI.Utilities.broadcastcall(f::Function, model::$struct_name)
             $(Expr(:block, _callfield.(Ref(:f), types)...))
             return
         end
 
-        function $MOIU.broadcastvcat(f::Function, model::$struct_name)
+        function $MOI.Utilities.broadcastvcat(f::Function, model::$struct_name)
             return vcat($(_callfield.(Ref(:f), types)...))
         end
 
-        function $MOIU.mapreduce_constraints(
+        function $MOI.Utilities.mapreduce_constraints(
             f::Function,
             op::Function,
             model::$struct_name,
@@ -316,7 +316,7 @@ function struct_of_constraint_code(struct_name, types, field_types = nothing)
         fun = t isa SymbolFun ? _typed(t) : :(MOI.AbstractFunction)
         set = t isa SymbolFun ? :(MOI.AbstractSet) : _typed(t)
         constraints_code = :(
-            function $MOIU.constraints(
+            function $MOI.Utilities.constraints(
                 model::$typed_struct,
                 ::Type{<:$fun},
                 ::Type{<:$set},

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -57,7 +57,7 @@ end
 function Base.show(io::IO, U::UniversalFallback)
     s(n) = n == 1 ? "" : "s"
     indent = " "^get(io, :indent, 0)
-    MOIU.print_with_acronym(io, summary(U))
+    print_with_acronym(io, summary(U))
     !(U.objective === nothing) && print(io, "\n$(indent)with objective")
     for (attr, name) in (
         (U.single_variable_constraints, "`VariableIndex` constraint"),


### PR DESCRIPTION
It's pretty weird for a module to import itself under a different name.