### PR TITLE
[Utilities] remove unecessary acronyms

### DIFF
--- a/src/Utilities/Utilities.jl
+++ b/src/Utilities/Utilities.jl
@@ -12,16 +12,6 @@ import MathOptInterface.Utilities as MOIU # used in macro
 import MutableArithmetics as MA
 import OrderedCollections: OrderedDict
 
-const SVF = MOI.VariableIndex
-const VVF = MOI.VectorOfVariables
-const SAF{T} = MOI.ScalarAffineFunction{T}
-const VAF{T} = MOI.VectorAffineFunction{T}
-const SQF{T} = MOI.ScalarQuadraticFunction{T}
-const VQF{T} = MOI.VectorQuadraticFunction{T}
-
-const VI = MOI.VariableIndex
-const CI{F,S} = MOI.ConstraintIndex{F,S}
-
 function print_with_acronym(io::IO, s::AbstractString)
     return print(io, replace_acronym(s))
 end

--- a/src/Utilities/cachingoptimizer.jl
+++ b/src/Utilities/cachingoptimizer.jl
@@ -553,7 +553,7 @@ end
 
 function MOI.modify(
     m::CachingOptimizer,
-    cindex::CI,
+    cindex::MOI.ConstraintIndex,
     change::MOI.AbstractFunctionModification,
 )
     if m.state == ATTACHED_OPTIMIZER
@@ -621,7 +621,7 @@ end
 function MOI.set(
     m::CachingOptimizer,
     ::MOI.ConstraintSet,
-    cindex::CI{F,S},
+    cindex::MOI.ConstraintIndex{F,S},
     set::S,
 ) where {F,S}
     _replace_constraint_function_or_set(m, MOI.ConstraintSet(), cindex, set)

--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -138,8 +138,14 @@ This is good at catching bugs in solvers which assume indices are ordered 1, 2,
 """
 const _INTERNAL_XOR_MASK = Int64(12345678)
 
-xor_index(vi::VI) = VI(xor(vi.value, _INTERNAL_XOR_MASK))
-xor_index(ci::CI{F,S}) where {F,S} = CI{F,S}(xor(ci.value, _INTERNAL_XOR_MASK))
+function xor_index(vi::MOI.VariableIndex)
+    return MOI.VariableIndex(xor(vi.value, _INTERNAL_XOR_MASK))
+end
+
+function xor_index(ci::MOI.ConstraintIndex{F,S}) where {F,S}
+    return MOI.ConstraintIndex{F,S}(xor(ci.value, _INTERNAL_XOR_MASK))
+end
+
 xor_indices(x) = map_indices(xor_index, x)
 
 function MOI.add_variable(mock::MockOptimizer)
@@ -854,7 +860,7 @@ end
 
 function MOI.modify(
     mock::MockOptimizer,
-    c::CI,
+    c::MOI.ConstraintIndex,
     change::MOI.AbstractFunctionModification,
 )
     if !mock.modify_allowed
@@ -867,7 +873,7 @@ end
 function MOI.set(
     mock::MockOptimizer,
     ::MOI.ConstraintSet,
-    c::CI{<:MOI.AbstractFunction,S},
+    c::MOI.ConstraintIndex{<:MOI.AbstractFunction,S},
     set::S,
 ) where {S<:MOI.AbstractSet}
     MOI.set(mock.inner_model, MOI.ConstraintSet(), xor_index(c), set)
@@ -877,7 +883,7 @@ end
 function MOI.set(
     mock::MockOptimizer,
     ::MOI.ConstraintFunction,
-    c::CI{F},
+    c::MOI.ConstraintIndex{F},
     func::F,
 ) where {F<:MOI.AbstractFunction}
     MOI.set(

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -43,8 +43,9 @@ function `f` are removed and the dimension of the set `s` is updated if
 needed (e.g. when `f` is a `VectorOfVariables` with `vi` being one of the
 variables).
 """
-remove_variable(f, s, vi::VI) = remove_variable(f, vi), s
-function remove_variable(f::MOI.VectorOfVariables, s, vi::VI)
+remove_variable(f, s, vi::MOI.VariableIndex) = remove_variable(f, vi), s
+
+function remove_variable(f::MOI.VectorOfVariables, s, vi::MOI.VariableIndex)
     g = remove_variable(f, vi)
     if length(g.variables) != length(f.variables)
         t = MOI.update_dimension(s, length(g.variables))
@@ -141,14 +142,30 @@ function MOI.set(model::AbstractModel, ::MOI.Name, name::String)
 end
 MOI.get(model::AbstractModel, ::MOI.Name) = model.name
 
-MOI.supports(::AbstractModel, ::MOI.VariableName, vi::Type{VI}) = true
-function MOI.set(model::AbstractModel, ::MOI.VariableName, vi::VI, name::String)
+function MOI.supports(
+    ::AbstractModel,
+    ::MOI.VariableName,
+    ::Type{MOI.VariableIndex},
+)
+    return true
+end
+
+function MOI.set(
+    model::AbstractModel,
+    ::MOI.VariableName,
+    vi::MOI.VariableIndex,
+    name::String,
+)
     model.var_to_name[vi] = name
     model.name_to_var = nothing # Invalidate the name map.
     return
 end
 
-function MOI.get(model::AbstractModel, ::MOI.VariableName, vi::VI)
+function MOI.get(
+    model::AbstractModel,
+    ::MOI.VariableName,
+    vi::MOI.VariableIndex,
+)
     return get(model.var_to_name, vi, EMPTYSTRING)
 end
 
@@ -159,13 +176,13 @@ Create and return a reverse map from name to variable index, given a map from
 variable index to name. The special value `MOI.VariableIndex(0)` is used to
 indicate that multiple variables have the same name.
 """
-function build_name_to_var_map(var_to_name::Dict{VI,String})
-    name_to_var = Dict{String,VI}()
+function build_name_to_var_map(var_to_name::Dict{MOI.VariableIndex,String})
+    name_to_var = Dict{String,MOI.VariableIndex}()
     for (var, var_name) in var_to_name
         if haskey(name_to_var, var_name)
             # 0 is a special value that means this string does not map to
             # a unique variable name.
-            name_to_var[var_name] = VI(0)
+            name_to_var[var_name] = MOI.VariableIndex(0)
         else
             name_to_var[var_name] = var
         end
@@ -186,7 +203,7 @@ function throw_if_multiple_with_name(index::MOI.Index, name::String)
     end
 end
 
-function MOI.get(model::AbstractModel, ::Type{VI}, name::String)
+function MOI.get(model::AbstractModel, ::Type{MOI.VariableIndex}, name::String)
     if model.name_to_var === nothing
         # Rebuild the map.
         model.name_to_var = build_name_to_var_map(model.var_to_name)
@@ -203,12 +220,18 @@ function MOI.get(
     return isempty(model.var_to_name) ? [] : [MOI.VariableName()]
 end
 
-MOI.supports(model::AbstractModel, ::MOI.ConstraintName, ::Type{<:CI}) = true
+function MOI.supports(
+    ::AbstractModel,
+    ::MOI.ConstraintName,
+    ::Type{<:MOI.ConstraintIndex},
+)
+    return true
+end
 
 function MOI.set(
     model::AbstractModel,
     ::MOI.ConstraintName,
-    ci::CI,
+    ci::MOI.ConstraintIndex,
     name::String,
 )
     model.con_to_name[ci] = name
@@ -233,7 +256,11 @@ function MOI.set(
     return throw(MOI.VariableIndexConstraintNameError())
 end
 
-function MOI.get(model::AbstractModel, ::MOI.ConstraintName, ci::CI)
+function MOI.get(
+    model::AbstractModel,
+    ::MOI.ConstraintName,
+    ci::MOI.ConstraintIndex,
+)
     return get(model.con_to_name, ci, EMPTYSTRING)
 end
 
@@ -245,11 +272,11 @@ constraint index to name. The special value
 `MOI.ConstraintIndex{Nothing, Nothing}(0)` is used to indicate that multiple
 constraints have the same name.
 """
-function build_name_to_con_map(con_to_name::Dict{CI,String})
-    name_to_con = Dict{String,CI}()
+function build_name_to_con_map(con_to_name::Dict{<:MOI.ConstraintIndex,String})
+    name_to_con = Dict{String,<:MOI.ConstraintIndex}()
     for (con, con_name) in con_to_name
         if haskey(name_to_con, con_name)
-            name_to_con[con_name] = CI{Nothing,Nothing}(0)
+            name_to_con[con_name] = MOI.ConstraintIndex{Nothing,Nothing}(0)
         else
             name_to_con[con_name] = con
         end
@@ -257,7 +284,11 @@ function build_name_to_con_map(con_to_name::Dict{CI,String})
     return name_to_con
 end
 
-function MOI.get(model::AbstractModel, ConType::Type{<:CI}, name::String)
+function MOI.get(
+    model::AbstractModel,
+    ::Type{ConType},
+    name::String,
+) where {ConType<:MOI.ConstraintIndex}
     if model.name_to_con === nothing
         # Rebuild the map.
         model.name_to_con = build_name_to_con_map(model.con_to_name)

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -29,7 +29,7 @@ mutable struct UniversalFallback{MT} <: MOI.ModelLike
     name_to_con::Union{Dict{String,MOI.ConstraintIndex},Nothing}
     optattr::Dict{MOI.AbstractOptimizerAttribute,Any}
     modattr::Dict{MOI.AbstractModelAttribute,Any}
-    varattr::Dict{MOI.AbstractVariableAttribute,Dict{VI,Any}}
+    varattr::Dict{MOI.AbstractVariableAttribute,Dict{MOI.VariableIndex,Any}}
     conattr::Dict{MOI.AbstractConstraintAttribute,Dict{MOI.ConstraintIndex,Any}}
     function UniversalFallback{MT}(model::MOI.ModelLike) where {MT}
         return new{typeof(model)}(
@@ -41,7 +41,7 @@ mutable struct UniversalFallback{MT} <: MOI.ModelLike
             nothing,
             Dict{MOI.AbstractOptimizerAttribute,Any}(),
             Dict{MOI.AbstractModelAttribute,Any}(),
-            Dict{MOI.AbstractVariableAttribute,Dict{VI,Any}}(),
+            Dict{MOI.AbstractVariableAttribute,Dict{MOI.VariableIndex,Any}}(),
             Dict{
                 MOI.AbstractConstraintAttribute,
                 Dict{MOI.ConstraintIndex,Any},
@@ -629,8 +629,8 @@ function MOI.get(
     return get(uf.con_to_name, ci, EMPTYSTRING)
 end
 
-function MOI.get(uf::UniversalFallback, ::Type{VI}, name::String)
-    return MOI.get(uf.model, VI, name)
+function MOI.get(uf::UniversalFallback, ::Type{MOI.VariableIndex}, name::String)
+    return MOI.get(uf.model, MOI.VariableIndex, name)
 end
 
 check_type_and_multiple_names(::Type, ::Nothing, ::Nothing, name) = nothing

--- a/src/Utilities/variables_container.jl
+++ b/src/Utilities/variables_container.jl
@@ -311,7 +311,7 @@ end
 function MOI.get(
     model::VariablesContainer,
     ::MOI.ConstraintFunction,
-    ci::CI{MOI.VariableIndex},
+    ci::MOI.ConstraintIndex{MOI.VariableIndex},
 )
     MOI.throw_if_not_valid(model, ci)
     return MOI.VariableIndex(ci.value)


### PR DESCRIPTION
We should check solver-tests, but `MOI.Utilities.VI` and `MOI.Utilities.SQF` should not be public symbols.