### PR TITLE
[Utilities] Remove EMPTYSTRING

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1514,7 +1514,7 @@ function MOI.get(
     vi::MOI.VariableIndex,
 )
     if is_bridged(b, vi)
-        return get(b.var_to_name, vi, MOI.Utilities.EMPTYSTRING)
+        return get(b.var_to_name, vi, "")
     else
         return MOI.get(b.model, attr, vi)
     end
@@ -1541,7 +1541,7 @@ function MOI.get(
     constraint_index::MOI.ConstraintIndex,
 )
     if is_bridged(b, constraint_index)
-        return get(b.con_to_name, constraint_index, MOI.Utilities.EMPTYSTRING)
+        return get(b.con_to_name, constraint_index, "")
     else
         return MOI.get(b.model, attr, constraint_index)
     end

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -4,8 +4,6 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-const EMPTYSTRING = ""
-
 # Implementation of MOI for AbstractModel
 abstract type AbstractModelLike{T} <: MOI.ModelLike end
 abstract type AbstractOptimizer{T} <: MOI.AbstractOptimizer end
@@ -149,7 +147,7 @@ function MOI.set(model::AbstractModel, ::MOI.VariableName, vi::VI, name::String)
 end
 
 function MOI.get(model::AbstractModel, ::MOI.VariableName, vi::VI)
-    return get(model.var_to_name, vi, EMPTYSTRING)
+    return get(model.var_to_name, vi, "")
 end
 
 """
@@ -234,7 +232,7 @@ function MOI.set(
 end
 
 function MOI.get(model::AbstractModel, ::MOI.ConstraintName, ci::CI)
-    return get(model.con_to_name, ci, EMPTYSTRING)
+    return get(model.con_to_name, ci, "")
 end
 
 """
@@ -736,7 +734,7 @@ for (loop_name, loop_super_type) in [
             ext::Dict{Symbol,Any}
             function $name{T,O,V,C}() where {T,O,V,C}
                 return new{T,O,V,C}(
-                    EMPTYSTRING,
+                    "",
                     O(),
                     V(),
                     C(),

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -626,7 +626,7 @@ function MOI.get(
     if MOI.supports_constraint(uf.model, F, S)
         return MOI.get(uf.model, attr, ci)
     end
-    return get(uf.con_to_name, ci, EMPTYSTRING)
+    return get(uf.con_to_name, ci, "")
 end
 
 function MOI.get(uf::UniversalFallback, ::Type{VI}, name::String)


### PR DESCRIPTION
This seemed like such a random design choice.

So I traced it back to https://github.com/jump-dev/JuMP.jl/commit/cb8b47ffcc9710a7e22f24b6c47f48467a20b421.

At one point, JuMP used an explicit `UTF8String` type for names, and calling `""` did not make that type, so it was convenient to have an "empty UTF8String" sitting there in one place. Even once `String` came along, we kept it, and the variable even successfully made the transition to MathOptInterface!