### PR TITLE
[Utilities] remove invalid and unused method

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -404,14 +404,6 @@ function MOI.add_constraint(
     return MOI.add_constraint(model.constraints, func, set)
 end
 
-function MOI.get(
-    model::AbstractModel,
-    attr::Union{MOI.AbstractFunction,MOI.AbstractSet},
-    ci::MOI.ConstraintIndex,
-)
-    return MOI.get(model.constraints, attr, ci)
-end
-
 function MOI.delete(model::AbstractModel, ci::MOI.ConstraintIndex)
     MOI.delete(constraints(model, ci), ci)
     model.name_to_con = nothing


### PR DESCRIPTION
I don't know what this is or why it was here. From what I can tell, it was added in https://github.com/jump-dev/MathOptInterface.jl/pull/1245, but it seems like a typo. It's not hit by codecov, and it isn't part of the documented API.