### PR TITLE
[Utilities] use foldl to avoid StackOverflow

### DIFF
--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -323,12 +323,7 @@ end
 ### 1c: operate(+, T, args...)
 
 function operate(::typeof(+), ::Type{T}, f, g, h, args...) where {T<:Number}
-    ret = operate(+, T, f, g)
-    ret = operate!(+, T, ret, h)
-    for a in args
-        ret = operate!(+, T, ret, a)
-    end
-    return ret
+    return operate!(+, T, operate(+, T, f, g), h, args...)
 end
 
 ### 2a: operate(::typeof(-), ::Type{T}, ::F)
@@ -1173,12 +1168,10 @@ end
 ### 1c: operate!(+, T, args...)
 
 function operate!(::typeof(+), ::Type{T}, f, g, h, args...) where {T<:Number}
-    ret = operate!(+, T, f, g)
-    ret = operate!(+, T, ret, h)
-    for a in args
-        ret = operate!(+, T, ret, a)
-    end
-    return ret
+    return Base.afoldl(
+        (f, g) -> operate!(+, T, f, g),
+        args...,
+    )
 end
 
 ### 2a: operate!(::typeof(-), ::Type{T}, ::F)

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -1169,20 +1169,10 @@ end
 
 function operate!(::typeof(+), ::Type{T}, f, g, h, args...) where {T<:Number}
     # In order to improve performance and avoid a `StackOverflow` if there are
-    # too many arguments, `afoldl` does not do recursion and fall back to a
+    # too many arguments, `foldl` does not do recursion and fall back to a
     # `for` loop if there are too many arguments.
-    let T = T
-        add!(f, g) = operate!(+, T, f, g)
-        return Base.afoldl(
-            (f, g) -> add!,
-            f,
-            g,
-            h,
-            args...,
-        )
-    end
+    return foldl((x, y) -> operate!(+, T, x, y), (f, g, h, args...))
 end
-
 
 ### 2a: operate!(::typeof(-), ::Type{T}, ::F)
 

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -1168,6 +1168,9 @@ end
 ### 1c: operate!(+, T, args...)
 
 function operate!(::typeof(+), ::Type{T}, f, g, h, args...) where {T<:Number}
+    # In order to improve performance and avoid a `StackOverflow` if there are
+    # too many arguments, `afoldl` does not do recursion and fall back to a
+    # `for` loop if there are too many arguments.
     return Base.afoldl(
         (f, g) -> operate!(+, T, f, g),
         args...,

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -1171,11 +1171,18 @@ function operate!(::typeof(+), ::Type{T}, f, g, h, args...) where {T<:Number}
     # In order to improve performance and avoid a `StackOverflow` if there are
     # too many arguments, `afoldl` does not do recursion and fall back to a
     # `for` loop if there are too many arguments.
-    return Base.afoldl(
-        (f, g) -> operate!(+, T, f, g),
-        args...,
-    )
+    let T = T
+        add!(f, g) = operate!(+, T, f, g)
+        return Base.afoldl(
+            (f, g) -> add!,
+            f,
+            g,
+            h,
+            args...,
+        )
+    end
 end
+
 
 ### 2a: operate!(::typeof(-), ::Type{T}, ::F)
 


### PR DESCRIPTION
Alternative fix to https://github.com/jump-dev/MathOptInterface.jl/pull/2285

The `for` loop is quite weird as you expect the list of arguments to be a `tuple` of mixed argument types.
I think there is a win of not doing the recursion and falling back to a `for` loop at some point but I think it's at least more readable to use the standard `afold` for this.

This shows a big win on @odow's benchmark in https://github.com/jump-dev/MathOptInterface.jl/issues/2284#issuecomment-1732136438
```julia
julia> import MathOptInterface as MOI

julia> using BenchmarkTools

julia> function my_operate(::typeof(+), ::Type{T}, f, g, h, args...) where {T<:Number}
           ret = MOI.Utilities.operate(+, T, f, g)
           ret = MOI.Utilities.operate!(+, T, ret, h)
           for a in args
               ret = MOI.Utilities.operate!(+, T, ret, a)
           end
           return ret
       end
my_operate (generic function with 1 method)

julia> f = (
           MOI.VariableIndex(1),
           1 * MOI.VariableIndex(1) + 2,
           3 * MOI.VariableIndex(1) * MOI.VariableIndex(1) + 4,
       )
(MOI.VariableIndex(1), (2) + (1) MOI.VariableIndex(1), (4) + 3.0 MOI.VariableIndex(1)²)

julia> x = f[[2, 1, 2, 1, 2, 3]]
((2) + (1) MOI.VariableIndex(1), MOI.VariableIndex(1), (2) + (1) MOI.VariableIndex(1), MOI.VariableIndex(1), (2) + (1) MOI.VariableIndex(1), (4) + 3.0 MOI.VariableIndex(1)²)

julia> foo(x) = MOI.Utilities.operate(+, Int, x...)
foo (generic function with 1 method)

julia> bar(x) = my_operate(+, Int, x...)
bar (generic function with 1 method)

julia> @benchmark foo($x)
BenchmarkTools.Trial: 10000 samples with 996 evaluations.
 Range (min … max):  25.117 ns …  1.026 μs  ┊ GC (min … max):  0.00% … 95.46%
 Time  (median):     28.674 ns              ┊ GC (median):     0.00%
 Time  (mean ± σ):   35.176 ns ± 56.915 ns  ┊ GC (mean ± σ):  10.90% ±  6.54%

  ▁ ▆█▇▅▅▅▃▂▂▁▁▁                                              ▂
  █▇█████████████████████▇▇▇▆▇▆▆▆▅▇▇▇█▅▄▆▇▇▅▅▅▄▄▅▄▄▄▃▃▄▄▆▇▆▇█ █
  25.1 ns      Histogram: log(frequency) by time      74.8 ns <

 Memory estimate: 224 bytes, allocs estimate: 2.

julia> @benchmark bar($x)
BenchmarkTools.Trial: 10000 samples with 206 evaluations.
 Range (min … max):  379.612 ns …  11.897 μs  ┊ GC (min … max): 0.00% … 95.58%
 Time  (median):     419.449 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   466.205 ns ± 502.626 ns  ┊ GC (mean ± σ):  5.41% ±  4.83%

     ▃▄▆▇▇█▆▅▄▄▃▂▂▂▁   ▁▁▁▁ ▁▁▁▁▂▁▁▁▁▁                          ▂
  ▇▇███████████████████████████████████▇█▇█▇▇▆▇▆▆▆▇▇▆▇████▇▇▆▅▆ █
  380 ns        Histogram: log(frequency) by time        673 ns <

 Memory estimate: 608 bytes, allocs estimate: 9.
```