### PR TITLE
DNMY: [FileFormats.MOF] change parse_as_nlpblock to false by default

### DIFF
--- a/src/FileFormats/MOF/MOF.jl
+++ b/src/FileFormats/MOF/MOF.jl
@@ -123,7 +123,7 @@ function get_options(m::Model)
     return get(
         m.model.ext,
         :MOF_OPTIONS,
-        Options(false, false, MOI.Nonlinear.SparseReverseMode(), true),
+        Options(false, false, MOI.Nonlinear.SparseReverseMode(), false),
     )
 end
 
@@ -140,7 +140,7 @@ Keyword arguments are:
  - `differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation = MOI.Nonlinear.SparseReverseMode()`:
    automatic differentiation backend to use when reading models with nonlinear
    constraints and objectives.
- - `parse_as_nlpblock::Bool=true`: if `true` parse `"ScalarNonlinearFunction"`
+ - `parse_as_nlpblock::Bool=false`: if `true` parse `"ScalarNonlinearFunction"`
    into an `MOI.NLPBlock`. If `false`, `"ScalarNonlinearFunction"` are parsed as
    `MOI.ScalarNonlinearFunction` functions.
 """
@@ -148,7 +148,7 @@ function Model(;
     print_compact::Bool = false,
     warn::Bool = false,
     differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation = MOI.Nonlinear.SparseReverseMode(),
-    parse_as_nlpblock::Bool = true,
+    parse_as_nlpblock::Bool = false,
 )
     model = MOI.Utilities.UniversalFallback(InnerModel{Float64}())
     model.model.ext[:MOF_OPTIONS] =

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -119,7 +119,7 @@ function test_HS071()
 end
 
 function test_read_HS071()
-    model = MOF.Model()
+    model = MOF.Model(; parse_as_nlpblock = true)
     MOI.read_from_file(model, joinpath(@__DIR__, "nlp.mof.json"))
     @test MOI.get(model, MOI.ListOfConstraintTypesPresent()) ==
           Tuple{Type,Type}[(MOI.VariableIndex, MOI.Interval{Float64})]
@@ -283,7 +283,7 @@ function test_nonlinear_readingwriting()
     MOI.set(model, MOI.ConstraintName(), con, "con")
     MOI.write_to_file(model, TEST_MOF_FILE)
     # Read the model back in.
-    model2 = MOF.Model()
+    model2 = MOF.Model(; parse_as_nlpblock = true)
     MOI.read_from_file(model2, TEST_MOF_FILE)
     block = MOI.get(model2, MOI.NLPBlock())
     MOI.initialize(block.evaluator, [:ExprGraph])
@@ -748,8 +748,7 @@ variables: x
 minobjective: ScalarNonlinearFunction(exp(x))
 """,
         ["x"],
-        String[];
-        parse_as_nlpblock = false,
+        String[],
     )
 end
 
@@ -760,8 +759,7 @@ variables: x
 c1: ScalarNonlinearFunction(exp(x)^2) <= 1.0
 """,
         ["x"],
-        ["c1"];
-        parse_as_nlpblock = false,
+        ["c1"],
     )
 end
 
@@ -1423,7 +1421,7 @@ function test_parse_nonlinear_objective_only()
 }""",
     )
     seekstart(io)
-    model = MOF.Model()
+    model = MOF.Model(; parse_as_nlpblock = true)
     read!(io, model)
     block = MOI.get(model, MOI.NLPBlock())
     @test block isa MOI.NLPBlockData


### PR DESCRIPTION
I've opened this PR, not because I want to merge it, but because I think it needs some discussion.

Currently, if you have a `.mof.json` file that contains nonlinear functions, they are parsed into an `NLPBlock`.

#2293 added support for parsing them as regular `ScalarNonlinearFunction`s, but made it opt-in behind a `parse_as_nlpblock` keyword.

To read in JuMP, you'd need to write:
```julia
using JuMP
m = JuMP.read_from_file("test.mof.json"; parse_as_nlpblock = false)
```

This PR proposes swapping the default, which is a breaking change if people expect the `NLPBlock` to exist, or if they're passing to a solver that doesn't support the new syntax yet.

We could potentially reduce the breakage by changing `default_copy_to`, so that, if a `src` model has `ScalarNonlinearFunction` but the `dest` model doesn't support them, we could convert to a `NLPBlock`. This would then only impact people using `MOF.Model` directly, not not some reading from a file in JuMP.

Or we could say that the nonlinear support in `.mof.json` was always experimental. It seems likely that very few people are actually using `.mof.json` files to store models, particularly nonlinear ones.

Or we could keep the default as-is and add a warning telling people to use the keyword argument, and that it might change the default in a future release.

Thoughts?