### PR TITLE
[docs] add arxiv.org to linkcheck_ignore because it is flakey

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -154,6 +154,7 @@ write(joinpath(@__DIR__, "src", "MathOptInterface.pdf"), "")
         # Ignore issue and pull request links, because there are many of them,
         # and they sometimes time-out the linkcheck.
         r"https://github.com/jump-dev/MathOptInterface.jl/issues/([0-9]+)",
+        "https://arxiv.org/abs/2002.03447",
     ],
     modules = [MathOptInterface],
     checkdocs = :exports,

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -43,9 +43,6 @@ you know where to look for certain things.
 
 ## Citing MathOptInterface
 
-A [paper describing the design and features of MathOptInterface](https://arxiv.org/abs/2002.03447)
-is available on [arXiv](https://arxiv.org).
-
 If you find MathOptInterface useful in your work, we kindly request that you
 cite the following paper:
 ```bibtex
@@ -58,3 +55,5 @@ cite the following paper:
     publisher={INFORMS}
 }
 ```
+A preprint of this paper is [freely available](https://arxiv.org/abs/2002.03447).
+

--- a/docs/src/manual/standard_form.md
+++ b/docs/src/manual/standard_form.md
@@ -23,7 +23,7 @@ where:
   [`AbstractSet`](@ref) objects
 
 !!! tip
-    For more information on this standard form, read [our paper](https://arxiv.org/pdf/2002.03447.pdf).
+    For more information on this standard form, read [our paper](https://arxiv.org/abs/2002.03447).
 
 MOI defines some commonly used functions and sets, but the interface is
 extensible to other sets recognized by the solver.


### PR DESCRIPTION
arXiv is often the cause of the docs failing; https://github.com/jump-dev/MathOptInterface.jl/actions/runs/6333485810/job/17201676749?pr=2296