### PR TITLE
[docs] add preprint to accept.txt

### DIFF
--- a/docs/styles/Vocab/JuMP-Vocab/accept.txt
+++ b/docs/styles/Vocab/JuMP-Vocab/accept.txt
@@ -34,3 +34,4 @@ Holy
 JSONSchema
 MOI
 PATHSolver
+preprint


### PR DESCRIPTION
Docs failed in https://github.com/jump-dev/MathOptInterface.jl/actions/runs/6428404927/job/17455533852?pr=2303 because of this, but I don't know why now and not before.