### PR TITLE
Use conversion cost for Objective bridge

### DIFF
--- a/src/Bridges/Objective/bridges/conversion.jl
+++ b/src/Bridges/Objective/bridges/conversion.jl
@@ -48,6 +48,12 @@ function supports_objective_function(
     return isfinite(MOI.Bridges.Constraint.conversion_cost(F, G))
 end
 
+function MOI.Bridges.bridging_cost(
+    ::Type{FunctionConversionBridge{T,F,G}},
+) where {T,F,G}
+    return MOI.Bridges.Constraint.conversion_cost(F, G)
+end
+
 function MOI.Bridges.added_constrained_variable_types(
     ::Type{<:FunctionConversionBridge},
 )

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -2140,7 +2140,7 @@ MOI.Utilities.@model(
     ModelQuadObj,
     (),
     (),
-    (MOI.Nonnegatives,MOI.Zeros),
+    (MOI.Nonnegatives, MOI.Zeros),
     (),
     (),
     (),
@@ -2148,7 +2148,10 @@ MOI.Utilities.@model(
     (MOI.VectorAffineFunction,),
 )
 
-function MOI.supports(::ModelQuadObj{T}, ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}) where {T}
+function MOI.supports(
+    ::ModelQuadObj{T},
+    ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}},
+) where {T}
     return false
 end
 

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -2162,6 +2162,7 @@ function test_objective_conversion_cost(T = Float64)
     MOI.set(bridged, MOI.ObjectiveSense(), MOI.MIN_SENSE)
     MOI.set(bridged, MOI.ObjectiveFunction{typeof(x)}(), one(T) * x)
     @test MOI.get(model, MOI.ObjectiveFunctionType()) == MOI.VariableIndex
+    return
 end
 
 end  # module

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -2136,6 +2136,31 @@ function test_ToScalarQuadraticBridge_variable_bounds()
     return
 end
 
+MOI.Utilities.@model(
+    ModelQuadObj,
+    (),
+    (),
+    (MOI.Nonnegatives,MOI.Zeros),
+    (),
+    (),
+    (),
+    (MOI.VectorOfVariables,),
+    (MOI.VectorAffineFunction,),
+)
+
+function MOI.supports(::ModelQuadObj{T}, ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}) where {T}
+    return false
+end
+
+function test_objective_conversion_cost(T = Float64)
+    model = ModelQuadObj{T}()
+    bridged = MOI.Bridges.full_bridge_optimizer(model, T)
+    x = MOI.add_variable(bridged)
+    MOI.set(bridged, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(bridged, MOI.ObjectiveFunction{typeof(x)}(), one(T) * x)
+    @test MOI.get(model, MOI.ObjectiveFunctionType()) == MOI.VariableIndex
+end
+
 end  # module
 
 TestBridgesLazyBridgeOptimizer.runtests()


### PR DESCRIPTION
Current, the added test fails which means that converting to a quadratic objective is preferred over using several bridges. The bridge cost fixes this issue the same way we fixed it for the constraint conversion bridge.