### PR TITLE
[FileFormats] revert change to extract_function_and_set

### DIFF
--- a/src/FileFormats/MOF/write.jl
+++ b/src/FileFormats/MOF/write.jl
@@ -54,7 +54,8 @@ end
 
 _lift_variable_indices(arg) = arg  # Recursion fallback.
 
-function _extract_function_and_set(expr::Expr)
+# TODO(odow): Used by PolyJuMP. Make private in future.
+function extract_function_and_set(expr::Expr)
     if expr.head == :call  # One-sided constraint or foo-in-set.
         @assert length(expr.args) == 3
         if expr.args[1] == :in
@@ -100,7 +101,7 @@ function write_nlpblock(
     end
     for (row, bounds) in enumerate(nlp_block.constraint_bounds)
         constraint = MOI.constraint_expr(nlp_block.evaluator, row)
-        (func, set) = _extract_function_and_set(constraint)
+        (func, set) = extract_function_and_set(constraint)
         func = _lift_variable_indices(func)
         push!(
             object["constraints"],

--- a/test/FileFormats/MOF/MOF.jl
+++ b/test/FileFormats/MOF/MOF.jl
@@ -190,15 +190,15 @@ function test_nonlinear_error_handling()
         [MOI.VariableIndex(1)],
     )
     # Function-in-Set
-    @test_throws Exception MOF._extract_function_and_set(:(foo in set))
+    @test_throws Exception MOF.extract_function_and_set(:(foo in set))
     # Not a constraint.
-    @test_throws Exception MOF._extract_function_and_set(:(x^2))
+    @test_throws Exception MOF.extract_function_and_set(:(x^2))
     # Two-sided constraints
-    @test MOF._extract_function_and_set(:(1 <= x <= 2)) ==
-          MOF._extract_function_and_set(:(2 >= x >= 1)) ==
+    @test MOF.extract_function_and_set(:(1 <= x <= 2)) ==
+          MOF.extract_function_and_set(:(2 >= x >= 1)) ==
           (:x, MOI.Interval(1, 2))
     # Less-than constraint.
-    @test MOF._extract_function_and_set(:(x <= 2)) == (:x, MOI.LessThan(2))
+    @test MOF.extract_function_and_set(:(x <= 2)) == (:x, MOI.LessThan(2))
 end
 
 function _convert_mof_to_expr(


### PR DESCRIPTION
This was changed in #2293 because I thought it was a private method (not documented or exported, and very niche inside `MOI.FileFormats.MOF`, but PolyJuMP started using it:

x-ref https://github.com/jump-dev/MathOptInterface.jl/pull/2319#issuecomment-1776658350