### PR TITLE
[Test] allow skipping ScalarFunctionConstantNotZero errors

### DIFF
--- a/src/Test/Test.jl
+++ b/src/Test/Test.jl
@@ -309,7 +309,12 @@ macro requires(x)
 end
 
 function _error_handler(
-    err::Union{MOI.NotAllowedError,MOI.UnsupportedError,RequirementUnmet},
+    err::Union{
+        MOI.NotAllowedError,
+        MOI.ScalarFunctionConstantNotZero,
+        MOI.UnsupportedError,
+        RequirementUnmet,
+    },
     name::String,
     warn_unsupported::Bool,
 )


### PR DESCRIPTION
This one is up for debate. We've said that solvers can optionally support this, so some tests fail, even though it's known and okay.

Here's one from Pavito because of https://github.com/jump-dev/MathOptInterface.jl/pull/2318#issuecomment-1780291375

![image](https://github.com/jump-dev/MathOptInterface.jl/assets/8177701/f2064895-6b99-4050-bc2f-390ffb4431b0)
