### PR TITLE
[Bridges] add support for start values in NumberConversionBridge

### DIFF
--- a/src/Bridges/Constraint/bridges/number_conversion.jl
+++ b/src/Bridges/Constraint/bridges/number_conversion.jl
@@ -139,7 +139,11 @@ function MOI.get(
     },
     bridge::NumberConversionBridge{T,F1,S1,F2,S2},
 ) where {T,F1,S1,F2,S2}
-    return MOI.get(model, attr, bridge.constraint)
+    ret = MOI.get(model, attr, bridge.constraint)
+    if ret === nothing
+        return nothing
+    end
+    return convert(MOI.Utilities.value_type(T,F1), ret)
 end
 
 function MOI.set(

--- a/src/Bridges/Constraint/bridges/number_conversion.jl
+++ b/src/Bridges/Constraint/bridges/number_conversion.jl
@@ -143,7 +143,7 @@ function MOI.get(
     if ret === nothing
         return nothing
     end
-    return convert(MOI.Utilities.value_type(T,F1), ret)
+    return convert(MOI.Utilities.value_type(T, F1), ret)
 end
 
 function MOI.set(

--- a/src/Bridges/Constraint/bridges/number_conversion.jl
+++ b/src/Bridges/Constraint/bridges/number_conversion.jl
@@ -124,9 +124,9 @@ end
 function MOI.supports(
     model::MOI.ModelLike,
     attr::Union{MOI.ConstraintPrimalStart,MOI.ConstraintDualStart},
-    ::Type{NumberConversionBridge{T,F1,S1,F2,S2}},
-) where {T,F1,S1,F2,S2}
-    return MOI.supports(model, attr, MOI.ConstraintIndex{F2,S2})
+    ::Type{<:NumberConversionBridge},
+)
+    return true
 end
 
 function MOI.get(

--- a/src/Bridges/Constraint/bridges/number_conversion.jl
+++ b/src/Bridges/Constraint/bridges/number_conversion.jl
@@ -124,9 +124,9 @@ end
 function MOI.supports(
     model::MOI.ModelLike,
     attr::Union{MOI.ConstraintPrimalStart,MOI.ConstraintDualStart},
-    ::Type{<:NumberConversionBridge},
-)
-    return true
+    ::Type{NumberConversionBridge{T,F1,S1,F2,S2}},
+) where {T,F1,S1,F2,S2}
+    return MOI.supports(model, attr, MOI.ConstraintIndex{F2,S2})
 end
 
 function MOI.get(

--- a/src/Bridges/Constraint/bridges/number_conversion.jl
+++ b/src/Bridges/Constraint/bridges/number_conversion.jl
@@ -120,3 +120,39 @@ function MOI.get(
     s = MOI.get(model, MOI.ConstraintSet(), bridge.constraint)
     return MOI.Utilities.convert_approx(S1, s)
 end
+
+function MOI.supports(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintPrimalStart,MOI.ConstraintDualStart},
+    ::Type{NumberConversionBridge{T,F1,S1,F2,S2}},
+) where {T,F1,S1,F2,S2}
+    return MOI.supports(model, attr, MOI.ConstraintIndex{F2,S2})
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::Union{
+        MOI.ConstraintPrimalStart,
+        MOI.ConstraintDualStart,
+        MOI.ConstraintPrimal,
+        MOI.ConstraintDual,
+    },
+    bridge::NumberConversionBridge{T,F1,S1,F2,S2},
+) where {T,F1,S1,F2,S2}
+    return MOI.get(model, attr, bridge.constraint)
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::Union{
+        MOI.ConstraintPrimalStart,
+        MOI.ConstraintDualStart,
+        MOI.ConstraintPrimal,
+        MOI.ConstraintDual,
+    },
+    bridge::NumberConversionBridge{T,F1,S1,F2,S2},
+    value,
+) where {T,F1,S1,F2,S2}
+    MOI.set(model, attr, bridge.constraint, value)
+    return
+end


### PR DESCRIPTION
Part of https://github.com/jump-dev/MathOptInterface.jl/issues/684

<s>This isn't very obvious what the return types should be, so I've opted to just leave them as-is and let the solvers deal with them.</s> I used `value_type`.