### PR TITLE
[Bridges] add ConstraintPrimalStart for GeoMeanBridge

### DIFF
--- a/src/Bridges/Constraint/bridges/geomean.jl
+++ b/src/Bridges/Constraint/bridges/geomean.jl
@@ -332,7 +332,11 @@ function _get_attribute(model, attr, bridge::GeoMeanBridge{T}) where {T}
     return output
 end
 
-function MOI.supports(::MOI.ModelLike, ::MOI.ConstraintPrimalStart, ::GeoMeanBridge)
+function MOI.supports(
+    ::MOI.ModelLike,
+    ::MOI.ConstraintPrimalStart,
+    ::Type{<:GeoMeanBridge},
+)
     @show @__LINE__
     return true
 end
@@ -362,7 +366,12 @@ function MOI.set(
 )
     @show @__LINE__
     if d == 2
-        MOI.set(model, attr, bridge.t_upper_bound_constraint, value[1] - value[2])
+        MOI.set(
+            model,
+            attr,
+            bridge.t_upper_bound_constraint,
+            value[1] - value[2],
+        )
         MOI.set(model, attr, bridge.x_nonnegative_constraint, [value[2]])
         return
     end
@@ -372,7 +381,7 @@ function MOI.set(
     N = 1 << l
     sN = one(T) / sqrt(N)
     xij = zeros(N - 1)
-    xl1 = (prod(value[2:end]))^(1/n) / xN
+    xl1 = prod(value[2:end])^(1 / n) / xN
     xij[1] = xl1
     _getx(i) = i > n ? sN * xl1 : value[1+i]
 
@@ -398,8 +407,8 @@ function MOI.set(
         offset -= 1 << (i - 2)
     end
     @assert offset == 0
+    return
 end
-
 
 function MOI.get(
     model::MOI.ModelLike,

--- a/src/Bridges/Constraint/bridges/geomean.jl
+++ b/src/Bridges/Constraint/bridges/geomean.jl
@@ -342,7 +342,8 @@ function MOI.supports(
     ::Type{GeoMeanBridge{T,F,G,H}},
 ) where {T,F,G,H}
     FS, GS = MOI.LessThan{T}, MOI.RotatedSecondOrderCone
-    return MOI.supports(model, attr, MOI.ConstraintIndex{F,FS}) &&
+    return MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex) &&
+           MOI.supports(model, attr, MOI.ConstraintIndex{F,FS}) &&
            MOI.supports(model, attr, MOI.ConstraintIndex{G,GS}) &&
            MOI.supports(model, attr, MOI.ConstraintIndex{H,MOI.Nonnegatives})
 end


### PR DESCRIPTION
I though the tests would call this since `supports` is now `true` but it seems it does not.

See https://github.com/jump-dev/MathOptInterface.jl/issues/684