### PR TITLE
Run all tests against bridged SDPA model

### DIFF
--- a/src/Utilities/variables_container.jl
+++ b/src/Utilities/variables_container.jl
@@ -308,6 +308,8 @@ function MOI.is_valid(
     return !iszero(b.set_mask[ci.value] & _single_variable_flag(S))
 end
 
+MOI.is_valid(::VariablesContainer, ::MOI.ConstraintIndex) = false
+
 function MOI.get(
     model::VariablesContainer,
     ::MOI.ConstraintFunction,

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -319,25 +319,36 @@ function test_MOI_runtests_LPModel()
 end
 
 function test_MOI_runtests_StandardSDPAModel()
-    model = StandardSDPAModel{Float64}()
-    bridged = MOI.Bridges.full_bridge_optimizer(model, Float64)
+    model =
+        MOI.instantiate(StandardSDPAModel{Float64}; with_bridge_type = Float64)
     MOI.Test.runtests(
-        bridged,
+        model,
         MOI.Test.Config(
             exclude = Any[MOI.optimize!, MOI.SolverName, MOI.SolverVersion],
-        ),
+        );
+        exclude = String[
+            "test_model_ListOfVariablesWithAttributeSet",
+            "test_model_LowerBoundAlreadySet",
+            "test_model_UpperBoundAlreadySet",
+            "test_model_ScalarFunctionConstantNotZero",
+            "test_model_delete",
+        ],
     )
     return
 end
 
 function test_MOI_runtests_GeometricSDPAModel()
-    model = GeometricSDPAModel{Float64}()
-    bridged = MOI.Bridges.full_bridge_optimizer(model, Float64)
+    model =
+        MOI.instantiate(GeometricSDPAModel{Float64}; with_bridge_type = Float64)
     MOI.Test.runtests(
-        bridged,
+        model,
         MOI.Test.Config(
             exclude = Any[MOI.optimize!, MOI.SolverName, MOI.SolverVersion],
-        ),
+        );
+        exclude = String[
+            "test_model_LowerBoundAlreadySet",
+            "test_model_UpperBoundAlreadySet",
+        ],
     )
     return
 end

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -335,7 +335,6 @@ function test_MOI_runtests_StandardSDPAModel()
             # This seems okay. We can't get a list of variables if they are
             # bridged.
             "test_model_ListOfVariablesWithAttributeSet",
-
         ],
     )
     return

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -303,17 +303,8 @@ function test_MOI_runtests_LPModel()
     bridged = MOI.Bridges.full_bridge_optimizer(model, Float64)
     MOI.Test.runtests(
         bridged,
-        MOI.Test.Config(exclude = Any[MOI.optimize!]),
+        MOI.Test.Config(exclude = Any[MOI.optimize!]);
         include = ["test_model_", "test_constraint_"],
-        exclude = [
-            "test_constraint_ConstraintDualStart",
-            "test_constraint_ConstraintPrimalStart",
-            "test_model_default_DualStatus",
-            "test_model_default_PrimalStatus",
-            "test_model_default_TerminationStatus",
-            "test_model_LowerBoundAlreadySet",
-            "test_model_UpperBoundAlreadySet",
-        ],
     )
     return
 end
@@ -327,11 +318,24 @@ function test_MOI_runtests_StandardSDPAModel()
             exclude = Any[MOI.optimize!, MOI.SolverName, MOI.SolverVersion],
         );
         exclude = String[
-            "test_model_ListOfVariablesWithAttributeSet",
+            # TODO(odow): investigate. This seems like an actual bug.
+            "test_model_delete",
+            # Skip these tests because the bridge reformulates bound
+            # constraints, so there is no conflict. An error _is_ thrown if two
+            # sets of the same type are added.
             "test_model_LowerBoundAlreadySet",
             "test_model_UpperBoundAlreadySet",
+            # MOI.ScalarFunctionConstantNotZero is thrown, not of the original
+            # constraint, but of the bridged constraint. This seems okay. The
+            # fix would require that a bridge optimizer has a try-catch for this
+            # error.
             "test_model_ScalarFunctionConstantNotZero",
-            "test_model_delete",
+            # The error is:
+            # Cannot substitute `MOI.VariableIndex(1)` as it is bridged into `0.0 + 1.0 MOI.VariableIndex(-1)`.
+            # This seems okay. We can't get a list of variables if they are
+            # bridged.
+            "test_model_ListOfVariablesWithAttributeSet",
+
         ],
     )
     return
@@ -344,11 +348,7 @@ function test_MOI_runtests_GeometricSDPAModel()
         model,
         MOI.Test.Config(
             exclude = Any[MOI.optimize!, MOI.SolverName, MOI.SolverVersion],
-        );
-        exclude = String[
-            "test_model_LowerBoundAlreadySet",
-            "test_model_UpperBoundAlreadySet",
-        ],
+        ),
     )
     return
 end

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -104,7 +104,15 @@ end
 function MOI.supports(
     ::StandardLPModel{T},
     ::MOI.ObjectiveFunction{
-        <:Union{MOI.VariableIndex,MOI.ScalarQuadraticFunction{T}},
+        <:Union{
+            MOI.VariableIndex,
+            MOI.ScalarQuadraticFunction{T},
+            MOI.ScalarNonlinearFunction,
+            MOI.VectorOfVariables,
+            MOI.VectorAffineFunction{T},
+            MOI.VectorQuadraticFunction{T},
+            MOI.VectorNonlinearFunction,
+        },
     },
 ) where {T}
     return false
@@ -315,8 +323,9 @@ function test_MOI_runtests_StandardSDPAModel()
     bridged = MOI.Bridges.full_bridge_optimizer(model, Float64)
     MOI.Test.runtests(
         bridged,
-        MOI.Test.Config(exclude = Any[MOI.optimize!]),
-        include = ["ConstraintName", "VariableName"],
+        MOI.Test.Config(
+            exclude = Any[MOI.optimize!, MOI.SolverName, MOI.SolverVersion],
+        ),
     )
     return
 end
@@ -326,8 +335,9 @@ function test_MOI_runtests_GeometricSDPAModel()
     bridged = MOI.Bridges.full_bridge_optimizer(model, Float64)
     MOI.Test.runtests(
         bridged,
-        MOI.Test.Config(exclude = Any[MOI.optimize!]),
-        include = ["ConstraintName", "VariableName"],
+        MOI.Test.Config(
+            exclude = Any[MOI.optimize!, MOI.SolverName, MOI.SolverVersion],
+        ),
     )
     return
 end

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -318,8 +318,6 @@ function test_MOI_runtests_StandardSDPAModel()
             exclude = Any[MOI.optimize!, MOI.SolverName, MOI.SolverVersion],
         );
         exclude = String[
-            # TODO(odow): investigate. This seems like an actual bug.
-            "test_model_delete",
             # Skip these tests because the bridge reformulates bound
             # constraints, so there is no conflict. An error _is_ thrown if two
             # sets of the same type are added.

--- a/test/Bridges/sdpa_models.jl
+++ b/test/Bridges/sdpa_models.jl
@@ -62,7 +62,15 @@ end
 function MOI.supports(
     ::StandardSDPAModel{T},
     ::MOI.ObjectiveFunction{
-        <:Union{MOI.VariableIndex,MOI.ScalarQuadraticFunction{T}},
+        <:Union{
+            MOI.VariableIndex,
+            MOI.ScalarQuadraticFunction{T},
+            MOI.ScalarNonlinearFunction,
+            MOI.VectorOfVariables,
+            MOI.VectorAffineFunction{T},
+            MOI.VectorQuadraticFunction{T},
+            MOI.VectorNonlinearFunction,
+        },
     },
 ) where {T}
     return false


### PR DESCRIPTION
Closes #2375

When looking over the failing tests of https://github.com/blegat/SDPLR.jl/, I noticed some were due to MOI bugs. When looking at how to reproduce them, I found out that we could have detected them by running against all the tests. Looking back at the history, it seems I initially just called `nametest` because it wasn't so easy to run all the tests. When @odow migrated to the new test infrastructure, he used `include = ["ConstraintName", "VariableName"],` so that's its equivalent to `nametest`. This did not take the opportunity brought by this new test infrastructure to run it against all the tests. These tests are usually failing for all solvers so fixing them should help many solver wrappers at the same time.

This brings up a few bugs that I suggest we first fix in separate PRs with their own tests:

`GeometricSDPA` (so it should help SCS, ECOS, COSMO, SeDuMi, SDPT3, CDCS, Clarabel, ...)

- [x] `test_conic_SecondOrderCone_INFEASIBLE` https://github.com/jump-dev/MathOptInterface.jl/pull/2359 
- [x] `test_model_LowerBoundAlreadySet` https://github.com/jump-dev/MathOptInterface.jl/pull/2376
- [x] `test_model_UpperBoundAlreadySet` https://github.com/jump-dev/MathOptInterface.jl/pull/2376

`StandardSDPA` (so it should help CSDP, SDPA, SDPLR, DSDP, ...)

- [x] `test_basic_VectorOfVariables_Nonpositives` https://github.com/jump-dev/MathOptInterface.jl/pull/2362
- [x] `test_basic_VectorOfVariables_SecondOrderCone` https://github.com/jump-dev/MathOptInterface.jl/pull/2360
- [x] `test_conic_SecondOrderCone_INFEASIBLE` https://github.com/jump-dev/MathOptInterface.jl/pull/2359 
- [ ] `test_model_ListOfVariablesWithAttributeSet`
- [ ] `test_model_LowerBoundAlreadySet`
- [ ] `test_model_UpperBoundAlreadySet`
- [ ] `test_model_ScalarFunctionConstantNotZero`
- [x] `test_model_delete` https://github.com/jump-dev/MathOptInterface.jl/pull/2377
- [x] ~~`test_multiobjective_vector_nonlinear`, `test_multiobjective_vector_nonlinear_delete`, `test_multiobjective_vector_nonlinear_delete_vector`, `test_multiobjective_vector_nonlinear_modify`: missing `isapprox(::MOI.ScalarAffineFunction{Float64}, ::MOI.VariableIndex)`~~
- [x] ~~`test_multiobjective_vector_of_variables`, `test_multiobjective_vector_of_variables_delete_all`, `test_multiobjective_vector_of_variables_delete`, `test_multiobjective_vector_of_variables_delete_vector`: missing `substitute_variables(_, ::MOI.VectorOfVariables)`~~