### PR TITLE
Fix RSOCtoPSD bridge for dimension 2

### DIFF
--- a/docs/src/submodules/Bridges/reference.md
+++ b/docs/src/submodules/Bridges/reference.md
@@ -36,6 +36,7 @@ Bridges.Constraint.SingleBridgeOptimizer
 Bridges.Constraint.add_all_bridges
 Bridges.Constraint.FlipSignBridge
 Bridges.Constraint.AbstractToIntervalBridge
+Bridges.Constraint.MultiSetMapBridge
 Bridges.Constraint.SetMapBridge
 Bridges.Constraint.conversion_cost
 ```

--- a/src/Bridges/Constraint/bridges/soc_to_psd.jl
+++ b/src/Bridges/Constraint/bridges/soc_to_psd.jl
@@ -177,7 +177,10 @@ struct RSOCtoPSDBridge{T,F,G} <: SetMapBridge{
     F,
     G,
 }
-    constraint::MOI.ConstraintIndex{F,MOI.PositiveSemidefiniteConeTriangle}
+    constraint::Union{
+        MOI.ConstraintIndex{F,MOI.PositiveSemidefiniteConeTriangle},
+        MOI.ConstraintIndex{G,MOI.Nonnegatives},
+    }
 end
 
 const RSOCtoPSD{T,OT<:MOI.ModelLike} =
@@ -194,11 +197,31 @@ function concrete_bridge_type(
     return RSOCtoPSDBridge{T,F,G}
 end
 
+function MOI.Bridges.added_constraint_types(
+    ::Type{<:RSOCtoPSDBridge{T,F,G}},
+) where {T,F,G}
+    return Tuple{Type,Type}[(F, MOI.PositiveSemidefiniteConeTriangle), (G, MOI.Nonnegatives)]
+end
+
+function MOI.supports(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintPrimalStart,MOI.ConstraintDualStart},
+    ::Type{<:RSOCtoPSDBridge{T,F,G}},
+) where {T,F,G}
+    return MOI.supports(model, attr, MOI.ConstraintIndex{F,MOI.PositiveSemidefiniteConeTriangle}) ||
+        MOI.supports(model, attr, MOI.ConstraintIndex{G,MOI.Nonnegatives})
+end
+
 function MOI.Bridges.map_set(
     ::Type{<:RSOCtoPSDBridge},
     set::MOI.RotatedSecondOrderCone,
 )
-    return MOI.PositiveSemidefiniteConeTriangle(MOI.dimension(set) - 1)
+    d = MOI.dimension(set)
+    if d == 2
+        return MOI.Nonnegatives(2)
+    else
+        return MOI.PositiveSemidefiniteConeTriangle(d - 1)
+    end
 end
 
 function MOI.Bridges.inverse_map_set(
@@ -208,13 +231,27 @@ function MOI.Bridges.inverse_map_set(
     return MOI.RotatedSecondOrderCone(MOI.side_dimension(set) + 1)
 end
 
+function MOI.Bridges.inverse_map_set(
+    ::Type{<:RSOCtoPSDBridge},
+    ::MOI.Nonnegatives,
+)
+    return MOI.RotatedSecondOrderCone(2)
+end
+
+function _rsoc_to_psd_too_small_message(n)
+    return "Unable to bridge RotatedSecondOrderCone to PSD because the " *
+        "dimension is too small: got $n, expected >= 2."
+end
+
 function MOI.Bridges.map_function(::Type{<:RSOCtoPSDBridge{T}}, func) where {T}
     scalars = MOI.Utilities.eachscalar(func)
-    if length(scalars) < 3
+    if length(scalars) < 2
         error(
             "Unable to bridge RotatedSecondOrderCone to PSD because the ",
-            "dimension is too small: got $(length(scalars)), expected >= 3.",
+            "dimension is too small: got $(length(scalars)), expected >= 2.",
         )
+    elseif length(scalars) == 2
+        return func
     end
     # Input is (t, u, x), and we need [t x'; x 2uI]
     h = MOI.Utilities.operate!(*, T, scalars[2], convert(T, 2))
@@ -226,6 +263,9 @@ function MOI.Bridges.inverse_map_function(
     func,
 ) where {T}
     scalars = MOI.Utilities.eachscalar(func)
+    if length(scalars) == 2
+        return func
+    end
     dim = MOI.Utilities.side_dimension_for_vectorized_dimension(length(scalars))
     t = scalars[1]
     # scalars[3] is 2u, so it needs to be divided by 2 to get u.
@@ -240,6 +280,9 @@ function MOI.Bridges.adjoint_map_function(
     func,
 ) where {T}
     scalars = MOI.Utilities.eachscalar(func)
+    if length(scalars) == 2
+        return func
+    end
     dim = MOI.Utilities.side_dimension_for_vectorized_dimension(length(scalars))
     return MOI.Utilities.operate(
         vcat,
@@ -271,6 +314,9 @@ function MOI.Bridges.inverse_adjoint_map_function(
     ::Type{<:RSOCtoPSDBridge{T}},
     func,
 ) where {T}
+    if length(func) == 2
+        return func
+    end
     t, u, x = func[1], func[2], func[3:end]
     Q = (u / (2 * (x' * x))) * (x * x')
     M = [t x'/2; x/2 Q]

--- a/src/Bridges/Constraint/bridges/soc_to_psd.jl
+++ b/src/Bridges/Constraint/bridges/soc_to_psd.jl
@@ -200,7 +200,10 @@ end
 function MOI.Bridges.added_constraint_types(
     ::Type{<:RSOCtoPSDBridge{T,F,G}},
 ) where {T,F,G}
-    return Tuple{Type,Type}[(F, MOI.PositiveSemidefiniteConeTriangle), (G, MOI.Nonnegatives)]
+    return Tuple{Type,Type}[
+        (F, MOI.PositiveSemidefiniteConeTriangle),
+        (G, MOI.Nonnegatives),
+    ]
 end
 
 function MOI.supports(
@@ -208,8 +211,11 @@ function MOI.supports(
     attr::Union{MOI.ConstraintPrimalStart,MOI.ConstraintDualStart},
     ::Type{<:RSOCtoPSDBridge{T,F,G}},
 ) where {T,F,G}
-    return MOI.supports(model, attr, MOI.ConstraintIndex{F,MOI.PositiveSemidefiniteConeTriangle}) ||
-        MOI.supports(model, attr, MOI.ConstraintIndex{G,MOI.Nonnegatives})
+    return MOI.supports(
+        model,
+        attr,
+        MOI.ConstraintIndex{F,MOI.PositiveSemidefiniteConeTriangle},
+    ) || MOI.supports(model, attr, MOI.ConstraintIndex{G,MOI.Nonnegatives})
 end
 
 function MOI.Bridges.map_set(
@@ -240,7 +246,7 @@ end
 
 function _rsoc_to_psd_too_small_message(n)
     return "Unable to bridge RotatedSecondOrderCone to PSD because the " *
-        "dimension is too small: got $n, expected >= 2."
+           "dimension is too small: got $n, expected >= 2."
 end
 
 function MOI.Bridges.map_function(::Type{<:RSOCtoPSDBridge{T}}, func) where {T}

--- a/src/Bridges/Constraint/bridges/soc_to_psd.jl
+++ b/src/Bridges/Constraint/bridges/soc_to_psd.jl
@@ -244,11 +244,6 @@ function MOI.Bridges.inverse_map_set(
     return MOI.RotatedSecondOrderCone(2)
 end
 
-function _rsoc_to_psd_too_small_message(n)
-    return "Unable to bridge RotatedSecondOrderCone to PSD because the " *
-           "dimension is too small: got $n, expected >= 2."
-end
-
 function MOI.Bridges.map_function(::Type{<:RSOCtoPSDBridge{T}}, func) where {T}
     scalars = MOI.Utilities.eachscalar(func)
     if length(scalars) < 2

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -5,7 +5,246 @@
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
 """
-    abstract type SetMapBridge{T,S2,S1,F,G} <: AbstractBridge end
+    abstract type MultiSetMapBridge{T,S1,G} <: AbstractBridge end
+
+Same as `SetMapBridge` but the output constraint type does not only depend on
+the input constraint type.  When subtyping `MultiSetMapBridge`,
+`added_constraint_types` and `supports` should additionally be implemented by
+the bridge.  For instance, if a bridge `BridgeType` may create either a
+constraint of type `F2`-in-`S2` or `F3`-in-`S3`, these methods may be
+implemented as follows:
+```julia
+function MOI.Bridges.added_constraint_types(
+    ::Type{<:BridgeType{T,F2,F3}},
+) where {T,F2,F3}
+    return Tuple{Type,Type}[(F2, S2), (F3, S3)]
+end
+
+function MOI.supports(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintPrimalStart,MOI.ConstraintDualStart},
+    ::Type{<:BridgeType{T,F2,F3}},
+) where {T,F2,F3}
+    return MOI.supports(model, attr, MOI.ConstraintIndex{F2,S2}) ||
+        MOI.supports(model, attr, MOI.ConstraintIndex{F3,S3})
+end
+```
+"""
+abstract type MultiSetMapBridge{T,S1,G} <: AbstractBridge end
+
+function bridge_constraint(
+    BT::Type{<:MultiSetMapBridge{T,S1,G}},
+    model::MOI.ModelLike,
+    func::G,
+    set::S1,
+) where {T,S1,G}
+    mapped_func = MOI.Bridges.map_function(BT, func)
+    mapped_set = MOI.Bridges.map_set(BT, set)
+    constraint = MOI.add_constraint(model, mapped_func, mapped_set)
+    return BT(constraint)
+end
+
+function MOI.supports_constraint(
+    ::Type{<:MultiSetMapBridge{T,S1}},
+    ::Type{<:MOI.AbstractScalarFunction},
+    ::Type{S1},
+) where {T,S1<:MOI.AbstractScalarSet}
+    return true
+end
+
+function MOI.supports_constraint(
+    ::Type{<:MultiSetMapBridge{T,S1}},
+    ::Type{<:MOI.AbstractVectorFunction},
+    ::Type{S1},
+) where {T,S1<:MOI.AbstractVectorSet}
+    return true
+end
+
+function MOI.Bridges.added_constrained_variable_types(::Type{<:MultiSetMapBridge})
+    return Tuple{Type}[]
+end
+
+# Attributes, Bridge acting as a model
+
+_get(::MOI.ConstraintIndex, ::MOI.NumberOfConstraints) = 0
+_get(::MOI.ConstraintIndex{F,S}, ::MOI.NumberOfConstraints{F,S}) where {F,S} = 1
+function _get(::MOI.ConstraintIndex, ::MOI.ListOfConstraintIndices{F,S}) where {F,S}
+    return MOI.ConstraintIndex{F,S}[]
+end
+function _get(ci::MOI.ConstraintIndex{F,S}, ::MOI.ListOfConstraintIndices{F,S}) where {F,S}
+    return [ci]
+end
+
+function MOI.get(
+    bridge::MultiSetMapBridge,
+    attr::MOI.NumberOfConstraints
+)::Int64
+    return _get(bridge.constraint, attr)
+end
+
+function MOI.get(
+    bridge::MultiSetMapBridge,
+    attr::MOI.ListOfConstraintIndices,
+)
+    return _get(bridge.constraint, attr)
+end
+
+
+# References
+
+function MOI.delete(model::MOI.ModelLike, bridge::MultiSetMapBridge)
+    MOI.delete(model, bridge.constraint)
+    return
+end
+
+# Attributes, Bridge acting as a constraint
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintFunction,
+    bridge::MultiSetMapBridge{T,S1,G},
+) where {T,S1,G}
+    mapped_func = MOI.get(model, attr, bridge.constraint)
+    func = MOI.Bridges.inverse_map_function(typeof(bridge), mapped_func)
+    return MOI.Utilities.convert_approx(G, func)
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintFunction,
+    bridge::MultiSetMapBridge{T,S1,G},
+    func::G,
+) where {T,S1,G}
+    new_f = MOI.Bridges.map_function(typeof(bridge), func)
+    MOI.set(model, attr, bridge.constraint, new_f)
+    return
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintSet,
+    bridge::MultiSetMapBridge,
+)
+    set = MOI.get(model, attr, bridge.constraint)
+    return MOI.Bridges.inverse_map_set(typeof(bridge), set)
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintSet,
+    bridge::MultiSetMapBridge{T,S1},
+    set::S1,
+) where {T,S1}
+    new_set = MOI.Bridges.map_set(typeof(bridge), set)
+    MOI.set(model, attr, bridge.constraint, new_set)
+    return
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintPrimal,MOI.ConstraintPrimalStart},
+    bridge::MultiSetMapBridge,
+)
+    value = MOI.get(model, attr, bridge.constraint)
+    if value === nothing
+        return nothing
+    end
+    return MOI.Bridges.inverse_map_function(typeof(bridge), value)
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintPrimalStart,
+    bridge::MultiSetMapBridge,
+    value,
+)
+    if value === nothing
+        MOI.set(model, attr, bridge.constraint, nothing)
+    else
+        mapped_value = MOI.Bridges.map_function(typeof(bridge), value)
+        MOI.set(model, attr, bridge.constraint, mapped_value)
+    end
+    return
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintDual,MOI.ConstraintDualStart},
+    bridge::MultiSetMapBridge,
+)
+    value = MOI.get(model, attr, bridge.constraint)
+    if value === nothing
+        return nothing
+    end
+    return MOI.Bridges.adjoint_map_function(typeof(bridge), value)
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintDualStart,
+    bridge::BT,
+    value,
+) where {BT<:MultiSetMapBridge}
+    if value === nothing
+        MOI.set(model, attr, bridge.constraint, nothing)
+    else
+        mapped_value = MOI.Bridges.inverse_adjoint_map_function(BT, value)
+        MOI.set(model, attr, bridge.constraint, mapped_value)
+    end
+    return
+end
+
+# By linearity of the map, we can just change the constant/coefficient
+
+function MOI.modify(
+    model::MOI.ModelLike,
+    bridge::BT,
+    change::MOI.ScalarConstantChange,
+) where {BT<:MultiSetMapBridge}
+    new_constant = MOI.Bridges.map_function(BT, change.new_constant)
+    MOI.modify(model, bridge.constraint, MOI.ScalarConstantChange(new_constant))
+    return
+end
+
+function MOI.modify(
+    model::MOI.ModelLike,
+    bridge::BT,
+    change::MOI.VectorConstantChange,
+) where {BT<:MultiSetMapBridge}
+    new_constant = MOI.Bridges.map_function(BT, change.new_constant)
+    MOI.modify(model, bridge.constraint, MOI.VectorConstantChange(new_constant))
+    return
+end
+
+function MOI.modify(
+    model::MOI.ModelLike,
+    bridge::BT,
+    change::MOI.ScalarCoefficientChange,
+) where {BT<:MultiSetMapBridge}
+    new_coefficient = MOI.Bridges.map_function(BT, change.new_coefficient)
+    new_change = MOI.ScalarCoefficientChange(change.variable, new_coefficient)
+    MOI.modify(model, bridge.constraint, new_change)
+    return
+end
+
+function MOI.modify(
+    model::MOI.ModelLike,
+    bridge::BT,
+    change::MOI.MultirowChange,
+) where {BT<:MultiSetMapBridge}
+    # It is important here that `change.new_coefficients` contains the complete
+    # new sparse column associated to the variable. Calling modify twice with
+    # part of the column won't work since  the linear map might reset all the
+    # column each time.
+    coefficients = MOI.Bridges.map_function(BT, change.new_coefficients)
+    new_change = MOI.MultirowChange(change.variable, coefficients)
+    MOI.modify(model, bridge.constraint, new_change)
+    return
+end
+
+
+"""
+    abstract type SetMapBridge{T,S2,S1,F,G} <: MultiSetMapBridge{T,S1,G} end
 
 Consider two type of sets, `S1` and `S2`, and a linear mapping `A` such that
 the image of a set of type `S1` under `A` is a set of type `S2`.
@@ -31,110 +270,12 @@ functions must be implemented:
 See the docstrings of each function to see which feature would be missing if it
 was not implemented for a given bridge.
 """
-abstract type SetMapBridge{T,S2,S1,F,G} <: AbstractBridge end
-
-function bridge_constraint(
-    BT::Type{<:SetMapBridge{T,S2,S1,F,G}},
-    model::MOI.ModelLike,
-    func::G,
-    set::S1,
-) where {T,S2,S1,F,G}
-    mapped_func = MOI.Bridges.map_function(BT, func)
-    mapped_set = MOI.Bridges.map_set(BT, set)
-    constraint = MOI.add_constraint(model, mapped_func, mapped_set)
-    return BT(constraint)
-end
-
-function MOI.supports_constraint(
-    ::Type{<:SetMapBridge{T,S2,S1}},
-    ::Type{<:MOI.AbstractScalarFunction},
-    ::Type{S1},
-) where {T,S2,S1<:MOI.AbstractScalarSet}
-    return true
-end
-
-function MOI.supports_constraint(
-    ::Type{<:SetMapBridge{T,S2,S1}},
-    ::Type{<:MOI.AbstractVectorFunction},
-    ::Type{S1},
-) where {T,S2,S1<:MOI.AbstractVectorSet}
-    return true
-end
-
-function MOI.Bridges.added_constrained_variable_types(::Type{<:SetMapBridge})
-    return Tuple{Type}[]
-end
+abstract type SetMapBridge{T,S2,S1,F,G} <: MultiSetMapBridge{T,S1,G} end
 
 function MOI.Bridges.added_constraint_types(
     ::Type{<:SetMapBridge{T,S2,S1,F}},
 ) where {T,S2,S1,F}
     return Tuple{Type,Type}[(F, S2)]
-end
-
-# Attributes, Bridge acting as a model
-
-function MOI.get(
-    ::SetMapBridge{T,S2,S1,F},
-    ::MOI.NumberOfConstraints{F,S2},
-)::Int64 where {T,S2,S1,F}
-    return 1
-end
-
-function MOI.get(
-    bridge::SetMapBridge{T,S2,S1,F},
-    ::MOI.ListOfConstraintIndices{F,S2},
-) where {T,S2,S1,F}
-    return [bridge.constraint]
-end
-
-# References
-
-function MOI.delete(model::MOI.ModelLike, bridge::SetMapBridge)
-    MOI.delete(model, bridge.constraint)
-    return
-end
-
-# Attributes, Bridge acting as a constraint
-
-function MOI.get(
-    model::MOI.ModelLike,
-    attr::MOI.ConstraintFunction,
-    bridge::SetMapBridge{T,S2,S1,F,G},
-) where {T,S2,S1,F,G}
-    mapped_func = MOI.get(model, attr, bridge.constraint)
-    func = MOI.Bridges.inverse_map_function(typeof(bridge), mapped_func)
-    return MOI.Utilities.convert_approx(G, func)
-end
-
-function MOI.set(
-    model::MOI.ModelLike,
-    attr::MOI.ConstraintFunction,
-    bridge::SetMapBridge{T,S2,S1,F,G},
-    func::G,
-) where {T,S2,S1,F,G}
-    new_f = MOI.Bridges.map_function(typeof(bridge), func)
-    MOI.set(model, attr, bridge.constraint, new_f)
-    return
-end
-
-function MOI.get(
-    model::MOI.ModelLike,
-    attr::MOI.ConstraintSet,
-    bridge::SetMapBridge,
-)
-    set = MOI.get(model, attr, bridge.constraint)
-    return MOI.Bridges.inverse_map_set(typeof(bridge), set)
-end
-
-function MOI.set(
-    model::MOI.ModelLike,
-    attr::MOI.ConstraintSet,
-    bridge::SetMapBridge{T,S2,S1},
-    set::S1,
-) where {T,S2,S1}
-    new_set = MOI.Bridges.map_set(typeof(bridge), set)
-    MOI.set(model, attr, bridge.constraint, new_set)
-    return
 end
 
 function MOI.supports(
@@ -143,106 +284,4 @@ function MOI.supports(
     ::Type{<:SetMapBridge{T,S2,S1,F}},
 ) where {T,S2,S1,F}
     return MOI.supports(model, attr, MOI.ConstraintIndex{F,S2})
-end
-
-function MOI.get(
-    model::MOI.ModelLike,
-    attr::Union{MOI.ConstraintPrimal,MOI.ConstraintPrimalStart},
-    bridge::SetMapBridge,
-)
-    value = MOI.get(model, attr, bridge.constraint)
-    if value === nothing
-        return nothing
-    end
-    return MOI.Bridges.inverse_map_function(typeof(bridge), value)
-end
-
-function MOI.set(
-    model::MOI.ModelLike,
-    attr::MOI.ConstraintPrimalStart,
-    bridge::SetMapBridge,
-    value,
-)
-    if value === nothing
-        MOI.set(model, attr, bridge.constraint, nothing)
-    else
-        mapped_value = MOI.Bridges.map_function(typeof(bridge), value)
-        MOI.set(model, attr, bridge.constraint, mapped_value)
-    end
-    return
-end
-
-function MOI.get(
-    model::MOI.ModelLike,
-    attr::Union{MOI.ConstraintDual,MOI.ConstraintDualStart},
-    bridge::SetMapBridge,
-)
-    value = MOI.get(model, attr, bridge.constraint)
-    if value === nothing
-        return nothing
-    end
-    return MOI.Bridges.adjoint_map_function(typeof(bridge), value)
-end
-
-function MOI.set(
-    model::MOI.ModelLike,
-    attr::MOI.ConstraintDualStart,
-    bridge::BT,
-    value,
-) where {BT<:SetMapBridge}
-    if value === nothing
-        MOI.set(model, attr, bridge.constraint, nothing)
-    else
-        mapped_value = MOI.Bridges.inverse_adjoint_map_function(BT, value)
-        MOI.set(model, attr, bridge.constraint, mapped_value)
-    end
-    return
-end
-
-# By linearity of the map, we can just change the constant/coefficient
-
-function MOI.modify(
-    model::MOI.ModelLike,
-    bridge::BT,
-    change::MOI.ScalarConstantChange,
-) where {BT<:SetMapBridge}
-    new_constant = MOI.Bridges.map_function(BT, change.new_constant)
-    MOI.modify(model, bridge.constraint, MOI.ScalarConstantChange(new_constant))
-    return
-end
-
-function MOI.modify(
-    model::MOI.ModelLike,
-    bridge::BT,
-    change::MOI.VectorConstantChange,
-) where {BT<:SetMapBridge}
-    new_constant = MOI.Bridges.map_function(BT, change.new_constant)
-    MOI.modify(model, bridge.constraint, MOI.VectorConstantChange(new_constant))
-    return
-end
-
-function MOI.modify(
-    model::MOI.ModelLike,
-    bridge::BT,
-    change::MOI.ScalarCoefficientChange,
-) where {BT<:SetMapBridge}
-    new_coefficient = MOI.Bridges.map_function(BT, change.new_coefficient)
-    new_change = MOI.ScalarCoefficientChange(change.variable, new_coefficient)
-    MOI.modify(model, bridge.constraint, new_change)
-    return
-end
-
-function MOI.modify(
-    model::MOI.ModelLike,
-    bridge::BT,
-    change::MOI.MultirowChange,
-) where {BT<:SetMapBridge}
-    # It is important here that `change.new_coefficients` contains the complete
-    # new sparse column associated to the variable. Calling modify twice with
-    # part of the column won't work since  the linear map might reset all the
-    # column each time.
-    coefficients = MOI.Bridges.map_function(BT, change.new_coefficients)
-    new_change = MOI.MultirowChange(change.variable, coefficients)
-    MOI.modify(model, bridge.constraint, new_change)
-    return
 end

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -60,7 +60,9 @@ function MOI.supports_constraint(
     return true
 end
 
-function MOI.Bridges.added_constrained_variable_types(::Type{<:MultiSetMapBridge})
+function MOI.Bridges.added_constrained_variable_types(
+    ::Type{<:MultiSetMapBridge},
+)
     return Tuple{Type}[]
 end
 
@@ -68,27 +70,29 @@ end
 
 _get(::MOI.ConstraintIndex, ::MOI.NumberOfConstraints) = 0
 _get(::MOI.ConstraintIndex{F,S}, ::MOI.NumberOfConstraints{F,S}) where {F,S} = 1
-function _get(::MOI.ConstraintIndex, ::MOI.ListOfConstraintIndices{F,S}) where {F,S}
+function _get(
+    ::MOI.ConstraintIndex,
+    ::MOI.ListOfConstraintIndices{F,S},
+) where {F,S}
     return MOI.ConstraintIndex{F,S}[]
 end
-function _get(ci::MOI.ConstraintIndex{F,S}, ::MOI.ListOfConstraintIndices{F,S}) where {F,S}
+function _get(
+    ci::MOI.ConstraintIndex{F,S},
+    ::MOI.ListOfConstraintIndices{F,S},
+) where {F,S}
     return [ci]
 end
 
 function MOI.get(
     bridge::MultiSetMapBridge,
-    attr::MOI.NumberOfConstraints
+    attr::MOI.NumberOfConstraints,
 )::Int64
     return _get(bridge.constraint, attr)
 end
 
-function MOI.get(
-    bridge::MultiSetMapBridge,
-    attr::MOI.ListOfConstraintIndices,
-)
+function MOI.get(bridge::MultiSetMapBridge, attr::MOI.ListOfConstraintIndices)
     return _get(bridge.constraint, attr)
 end
-
 
 # References
 
@@ -241,7 +245,6 @@ function MOI.modify(
     MOI.modify(model, bridge.constraint, new_change)
     return
 end
-
 
 """
     abstract type SetMapBridge{T,S2,S1,F,G} <: MultiSetMapBridge{T,S1,G} end

--- a/test/Bridges/Constraint/soc_to_psd.jl
+++ b/test/Bridges/Constraint/soc_to_psd.jl
@@ -146,15 +146,13 @@ function test_RSOCtoPSD()
         bridged_mock,
         ci,
         2,
-        ((
-            MOI.VectorAffineFunction{Float64},
-            MOI.PositiveSemidefiniteConeTriangle,
-            0,
-        ), (
-            MOI.VectorAffineFunction{Float64},
-            MOI.Nonnegatives,
-            0,
-        ),
+        (
+            (
+                MOI.VectorAffineFunction{Float64},
+                MOI.PositiveSemidefiniteConeTriangle,
+                0,
+            ),
+            (MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives, 0),
         ),
     )
     return
@@ -169,7 +167,10 @@ function test_rsoc_to_psd_dimension_2()
         MOI.VectorOfVariables(x),
         MOI.RotatedSecondOrderCone(2),
     )
-    @test MOI.get(inner, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
+    @test MOI.get(
+        inner,
+        MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}(),
+    ) == 1
     return
 end
 

--- a/test/Bridges/Constraint/soc_to_psd.jl
+++ b/test/Bridges/Constraint/soc_to_psd.jl
@@ -150,24 +150,26 @@ function test_RSOCtoPSD()
             MOI.VectorAffineFunction{Float64},
             MOI.PositiveSemidefiniteConeTriangle,
             0,
-        ),),
+        ), (
+            MOI.VectorAffineFunction{Float64},
+            MOI.Nonnegatives,
+            0,
+        ),
+        ),
     )
     return
 end
 
-# TODO(odow): we should fix this so it does not error.
 function test_rsoc_to_psd_dimension_2()
     inner = MOI.Utilities.Model{Float64}()
     model = MOI.Bridges.Constraint.RSOCtoPSD{Float64}(inner)
     x = MOI.add_variables(model, 2)
-    @test_throws(
-        ErrorException,
-        MOI.add_constraint(
-            model,
-            MOI.VectorOfVariables(x),
-            MOI.RotatedSecondOrderCone(2),
-        ),
+    MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables(x),
+        MOI.RotatedSecondOrderCone(2),
     )
+    @test MOI.get(inner, MOI.NumberOfConstraints{MOI.VectorOfVariables,MOI.Nonnegatives}()) == 1
     return
 end
 
@@ -192,6 +194,17 @@ function test_runtests()
         """
         variables: t, u, x
         [t, x, 2u] in PositiveSemidefiniteConeTriangle(2)
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.RSOCtoPSDBridge,
+        """
+        variables: t, u
+        [t, u] in RotatedSecondOrderCone(2)
+        """,
+        """
+        variables: t, u
+        [t, u] in Nonnegatives(2)
         """,
     )
     return


### PR DESCRIPTION
With this `MultiSetMapBridge`, it should be easy to fix other similar case, e.g., `SecondOrderCone(1)` -> `Nonnegatives(1)` while `SecondOrderCone(2)` -> `RotatedSecondOrderCone(2)` but we can wait for someone or for a test (like in this case) requesting to fix these corner cases before doing it.