### PR TITLE
Fix Base.isless for sorting AbstractModelAttribute during MOI.copy_to

### DIFF
--- a/src/Bridges/Objective/bridges/slack.jl
+++ b/src/Bridges/Objective/bridges/slack.jl
@@ -199,6 +199,10 @@ end
 # Pretend that every model supports, and silently skip in set if unsupported
 MOI.supports_fallback(::MOI.ModelLike, ::SlackBridgePrimalDualStart) = true
 
+# Sort priority: SlackBridgePrimalDualStart after ObjectiveFunction
+Base.isless(::SlackBridgePrimalDualStart, ::MOI.ObjectiveFunction) = false
+Base.isless(::MOI.ObjectiveFunction, ::SlackBridgePrimalDualStart) = true
+
 function MOI.throw_set_error_fallback(
     ::MOI.ModelLike,
     ::SlackBridgePrimalDualStart,


### PR DESCRIPTION
Closes #2366

Thoughts on something like this?

An alternative would be to expand on the `_sort_priority(::Any) = 2` to have `copy_to_sort_priority(::ModelLike, ::AbstractModelAttribute)`, but then this gets a bit messy if we have to have extensions working together.