### PR TITLE
Allow get to return non-nothing

### DIFF
--- a/src/Test/test_attribute.jl
+++ b/src/Test/test_attribute.jl
@@ -184,7 +184,8 @@ function test_attribute_TimeLimitSec(model::MOI.AbstractOptimizer, ::Config)
     MOI.set(model, MOI.TimeLimitSec(), 1.0)
     @test MOI.get(model, MOI.TimeLimitSec()) == 1.0
     MOI.set(model, MOI.TimeLimitSec(), nothing)
-    @test _get_default(model) === nothing
+    reset_value = _get_default(model)
+    @test reset_value === nothing || reset_value == value
     MOI.set(model, MOI.TimeLimitSec(), value)
     return
 end


### PR DESCRIPTION
I looked at how to fix https://github.com/oxfordcontrol/COSMO.jl/pull/185 and it starts being too hacky.
The time limit can be tweaked with two attributes, `RawOptimizerAttribute("time_limit")` or `MOI.TimeLimitSec`. Both attribute actually modify the same thing so they are kept in sync. Asking for `get` to return `nothing` is maybe a bit too much:
```julia
MOI.set(model, RawOptimizerAttribute("time_limit"), 0.0)
MOI.get(model MOI.TimeLimitSec()) # what should this return ?
MOI.set(model, MOI.TimeLimitSec(), nothing)
MOI.get(model MOI.TimeLimitSec()) # returns `nothing`
MOI.set(model, RawOptimizerAttribute("time_limit"), 0.0)
MOI.get(model MOI.TimeLimitSec()) # what should this return ?
MOI.set(model, RawOptimizerAttribute("time_limit"), 1.0)
MOI.get(model MOI.TimeLimitSec()) # what should this return ?
```