### PR TITLE
Fix order of model attributes during copy_to

### DIFF
--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -9,9 +9,10 @@
 
 include("copy/index_map.jl")
 
-_sort_priority(::Any) = 2
-_sort_priority(::MOI.UserDefinedFunction) = 0
-_sort_priority(::MOI.ObjectiveSense) = 1
+_sort_priority(::MOI.UserDefinedFunction) = 0.0
+_sort_priority(::MOI.ObjectiveSense) = 10.0
+_sort_priority(::MOI.ObjectiveFunction) = 20.0
+_sort_priority(::MOI.AbstractModelAttribute) = 30.0
 
 """
     pass_attributes(

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -935,6 +935,28 @@ function test_sorted_variable_sets_by_cost_2()
     return
 end
 
+function test_sorted_copy_to()
+    src = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    x = MOI.add_variable(src)
+    f = MOI.ScalarNonlinearFunction(:sqr, Any[x])
+    attr_1 = MOI.UserDefinedFunction(:sqr, 1)
+    attr_2 = MOI.ObjectiveSense()
+    attr_3 = MOI.ObjectiveFunction{typeof(f)}()
+    attr_4 = MOI.Name()
+    MOI.set(src, attr_4, "abc")
+    MOI.set(src, attr_1, (sqrt,))
+    MOI.set(src, attr_3, f)
+    MOI.set(src, attr_2, MOI.MAX_SENSE)
+    dest = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    index_map = MOI.copy_to(dest, src)
+    @test MOI.get(dest, attr_1) == (sqrt,)
+    @test MOI.get(dest, attr_2) == MOI.MAX_SENSE
+    g = MOI.ScalarNonlinearFunction(:sqr, Any[index_map[x]])
+    @test ≈(g, MOI.get(dest, attr_3))
+    @test MOI.get(dest, attr_4) == "abc"
+    return
+end
+
 end  # module
 
 TestCopy.runtests()


### PR DESCRIPTION
Closes #2366

Replacement for:

Closes #2369
Closes #2371

https://github.com/jump-dev/MathOptInterface.jl/actions/runs/7285412217