### PR TITLE
Prep for v1.24.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.23.0"
+version = "1.24.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,33 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.24.0 (December 30, 2023)
+
+### Added
+
+ - Added `get_fallback` for `ConstraintDual` of variable bounds (#2373)
+
+### Fixed
+
+ - Fixed `RSOCtoPSDBridge` for dimension 2 (#2359)
+ - Fixed getting `ConstraintFunction` in conversion bridge (#2360)
+ - Fixed `map_indices` (#2367)
+ - Fixed `SlackBridgePrimalDualStart` for non-slack bridges (#2365)
+ - Fixed `test_attribute_TimeLimitSec` (#2370)
+ - Fixed order of model attributes during `copy_to` (#2372)
+ - Fixed `ConstraintIndex` conflicts between variable and constraint bridges
+   (#2362)
+ - Fixed corner-case deletion in bridges (#2377)
+ - Fixed `ListOfVariablesWithAttributeSet` for variable bridges (#2380)
+
+### Other
+
+ - Minor documentation improvements (#2355), (#2374)
+ - Improved `side_dimension_for_vectorized_dimension` (#2356)
+ - Added DiffOpt and ParametricOptInterface to `solver-tests.yml` (#2368)
+ - Refactored `SDPAModel` into a separate test file and test more widely
+   (#2364), (#2357)
+
 ## v1.23.0 (November 29, 2023)
 
 ### Added

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.24.0 (December 30, 2023)
+## v1.24.0 (January 2, 2024)
 
 ### Added
 
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    (#2362)
  - Fixed corner-case deletion in bridges (#2377)
  - Fixed `ListOfVariablesWithAttributeSet` for variable bridges (#2380)
+ - Fixed `SlackBridge` if scalar constant is not zero (#2382)
+ - Fixed setting multiple bounds on a bridged variable (#2383)
 
 ### Other
 


### PR DESCRIPTION
## TODO

 - [x] https://github.com/jump-dev/MathOptInterface.jl/pull/2380
 - [x] https://github.com/jump-dev/MathOptInterface.jl/pull/2382
 - [x] https://github.com/jump-dev/MathOptInterface.jl/pull/2383

## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/7360060778
 - [ ] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/7382345901
