### PR TITLE
[Nonlinear] fix initialize for ExprGraphOnly

### DIFF
--- a/src/Nonlinear/evaluator.jl
+++ b/src/Nonlinear/evaluator.jl
@@ -74,9 +74,16 @@ function MOI.initialize(evaluator::Evaluator, features::Vector{Symbol})
     evaluator.eval_hessian_constraint_timer = 0.0
     evaluator.eval_hessian_lagrangian_timer = 0.0
     append!(evaluator.ordered_constraints, keys(evaluator.model.constraints))
+    # Every backend supports :ExprGraph, so don't forward it.
     filter!(f -> f != :ExprGraph, features)
     if evaluator.backend !== nothing
         MOI.initialize(evaluator.backend, features)
+    elseif !isempty(features)
+        @assert evaluator_backend === nothing  # ==> ExprGraphOnly used
+        error(
+            "Unable to initialize `Nonlinear.Evaluator` because the " *
+            "following features are not supported: $features",
+        )
     end
     return
 end

--- a/src/Nonlinear/evaluator.jl
+++ b/src/Nonlinear/evaluator.jl
@@ -79,7 +79,7 @@ function MOI.initialize(evaluator::Evaluator, features::Vector{Symbol})
     if evaluator.backend !== nothing
         MOI.initialize(evaluator.backend, features)
     elseif !isempty(features)
-        @assert evaluator_backend === nothing  # ==> ExprGraphOnly used
+        @assert evaluator.backend === nothing  # ==> ExprGraphOnly used
         error(
             "Unable to initialize `Nonlinear.Evaluator` because the " *
             "following features are not supported: $features",

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -1131,7 +1131,23 @@ function test_is_empty()
     return
 end
 
+function test_unsupported_features_expr_graph_only()
+    evaluator = Nonlinear.Evaluator(
+        Nonlinear.Model(),
+        Nonlinear.ExprGraphOnly(),
+        MOI.VariableIndex[],
+    )
+    @test_throws(
+        ErrorException(
+            "Unable to initialize `Nonlinear.Evaluator` because the " *
+            "following features are not supported: $([:Grad])",
+        ),
+        MOI.initialize(evaluator, [:ExprGraph, :Grad]),
+    )
+    return
 end
+
+end  # TestNonlinear
 
 TestNonlinear.runtests()
 


### PR DESCRIPTION
Found by https://github.com/jump-dev/Ipopt.jl/pull/397