### PR TITLE
Fix converting 0-valued Scalar(Affine,Quadratic)Function to Nonlinear

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1215,7 +1215,7 @@ end
 
 function Base.convert(F::Type{ScalarNonlinearFunction}, f::ScalarAffineFunction)
     args = Any[convert(ScalarNonlinearFunction, term) for term in f.terms]
-    if !iszero(f.constant)
+    if isempty(args) || !iszero(f.constant)
         push!(args, f.constant)
     end
     return ScalarNonlinearFunction(:+, args)
@@ -1243,7 +1243,7 @@ function Base.convert(
     for term in f.affine_terms
         push!(args, convert(F, term))
     end
-    if !iszero(f.constant)
+    if isempty(args) || !iszero(f.constant)
         push!(args, f.constant)
     end
     return ScalarNonlinearFunction(:+, args)

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -363,6 +363,20 @@ function test_convert_ScalarNonlinearFunction_ScalarAffineFunction()
     return
 end
 
+function test_convert_ScalarNonlinearFunction_zero()
+    affine_terms = MOI.ScalarAffineTerm{Float64}[]
+    quad_terms = MOI.ScalarQuadraticTerm{Float64}[]
+    for f in (
+        MOI.ScalarAffineFunction(affine_terms, 0.0),
+        MOI.ScalarQuadraticFunction(quad_terms, affine_terms, 0.0),
+    )
+        g = convert(MOI.ScalarNonlinearFunction, f)
+        @test g.head == :+
+        @test g.args == Any[0.0]
+    end
+    return
+end
+
 function test_convert_ScalarNonlinearFunction_ScalarQuadraticTerm()
     x = MOI.VariableIndex(1)
     y = MOI.VariableIndex(2)


### PR DESCRIPTION
This was the cause of @ccoffrin's mysterious 
```
bad line 721 of /tmp/model.nl: C1
Cannot open .nl file
libc++abi: terminating due to uncaught exception of type Ipopt::TNLP::INVALID_TNLP
```