### PR TITLE
Prep for v1.25.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.24.0"
+version = "1.25.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,18 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.25.0 (January 5, 2024)
+
+### Added
+
+ - Added the `AutomaticDifferentiationBackend` attribute (#2386)
+
+### Fixed
+
+ - Fixed [`initialize`](@ref) for [`Nonlinear.ExprGraphOnly`](@ref) (#2387)
+ - Fixed converting 0-valued [`ScalarAffineFunction`](@ref) and [`ScalarQuadraticFunction`](@ref)
+   to [`ScalarNonlinearFunction`](@ref) (#2388)
+
 ## v1.24.0 (January 2, 2024)
 
 ### Added

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixed [`initialize`](@ref) for [`Nonlinear.ExprGraphOnly`](@ref) (#2387)
  - Fixed converting 0-valued [`ScalarAffineFunction`](@ref) and [`ScalarQuadraticFunction`](@ref)
    to [`ScalarNonlinearFunction`](@ref) (#2388)
+ - Fixed reading `.nl` files with non-empty variable and constraint names (#2390)
 
 ## v1.24.0 (January 2, 2024)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixed converting 0-valued [`ScalarAffineFunction`](@ref) and [`ScalarQuadraticFunction`](@ref)
    to [`ScalarNonlinearFunction`](@ref) (#2388)
  - Fixed reading `.nl` files with non-empty variable and constraint names (#2390)
+ - Fixed reading `.nl` files with no objective (#2391)
+ - Fixed reading `.nl` files with free ranged constraints (#2392)
 
 ## v1.24.0 (January 2, 2024)
 


### PR DESCRIPTION
It's only been a couple of days since the last release, but I'd like to get these out ASAP.

## TODO

 - [x] https://github.com/jump-dev/MathOptInterface.jl/pull/2386
 - [x] #2390 
 - [x] #2391
 - [x] #2392

## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/7414126622
