### PR TITLE
[Bridges] fix deleting variable in Bridges.Variable.VectorizeBridge

### DIFF
--- a/src/Bridges/Variable/bridges/vectorize.jl
+++ b/src/Bridges/Variable/bridges/vectorize.jl
@@ -98,10 +98,14 @@ function MOI.get(
     return [bridge.vector_constraint]
 end
 
-# References
 function MOI.delete(model::MOI.ModelLike, bridge::VectorizeBridge)
-    MOI.delete(model, bridge.variable)
-    return
+    # It isn't safe to delete the variable because the constant may appear in
+    # other parts of the model (like the objective, or right-hand side sets).     Therefore, we don't implement
+    err = MOI.DeleteNotAllowed(
+        bridge.variable,
+        "Cannot delete variable because it is bridged by the `VectorizeBridge`.",
+    )
+    return throw(err)
 end
 
 # Attributes, Bridge acting as a constraint

--- a/src/Bridges/Variable/bridges/vectorize.jl
+++ b/src/Bridges/Variable/bridges/vectorize.jl
@@ -100,7 +100,7 @@ end
 
 function MOI.delete(model::MOI.ModelLike, bridge::VectorizeBridge)
     # It isn't safe to delete the variable because the constant may appear in
-    # other parts of the model (like the objective, or right-hand side sets).     Therefore, we don't implement
+    # other parts of the model (like the objective, or right-hand side sets).
     err = MOI.DeleteNotAllowed(
         bridge.variable,
         "Cannot delete variable because it is bridged by the `VectorizeBridge`.",

--- a/src/Bridges/Variable/bridges/vectorize.jl
+++ b/src/Bridges/Variable/bridges/vectorize.jl
@@ -140,19 +140,13 @@ function MOI.get(
     attr::MOI.ConstraintPrimal,
     bridge::VectorizeBridge,
 )
-    x = MOI.get(model, attr, bridge.vector_constraint)
-    @assert length(x) == 1
-    y = x[1]
-    status = MOI.get(model, MOI.PrimalStatus(attr.result_index))
-    if !MOI.Utilities.is_ray(status)
-        # If it is an infeasibility certificate, it is a ray and satisfies the
-        # homogenized problem, see https://github.com/jump-dev/MathOptInterface.jl/issues/433
-        # Otherwise, we need to add the set constant since the ConstraintPrimal
-        # is defined as the value of the function and the set_constant was
-        # removed from the original function
-        y += bridge.set_constant
-    end
-    return y
+    return throw(
+        MOI.GetAttributeNotAllowed(
+            attr,
+            "The variable `$(bridge.variable)` is bridged by the " *
+            "`VectorizeBridge`.",
+        ),
+    )
 end
 
 function MOI.get(

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -121,8 +121,7 @@ function test_exp3_with_add_constrained_variable_y()
     @test MOI.get(bridged_mock, MOI.VariablePrimal(), x) ≈ log(5)
     @test MOI.get(bridged_mock, MOI.VariablePrimal(), y) ≈ 5.0
     @test MOI.get(bridged_mock, MOI.ConstraintPrimal(), xc) ≈ 2log(5)
-    # TODO(odow): re-enable at some point
-    # @test MOI.get(bridged_mock, MOI.ConstraintPrimal(), yc) ≈ 5
+    @test MOI.get(bridged_mock, MOI.ConstraintPrimal(), yc) ≈ 5
     @test MOI.get(bridged_mock, MOI.ConstraintPrimal(), ec) ≈ [log(5), 1.0, 5.0]
     @test MOI.get(bridged_mock, MOI.ConstraintDual(), xc) ≈ 0.0
     @test MOI.get(bridged_mock, MOI.ConstraintDual(), yc) ≈ -1 / 5

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -236,6 +236,14 @@ function test_exp3_with_add_constrained_variable_y()
     return
 end
 
+function test_delete_variable()
+    inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    model = MOI.Bridges.Variable.Vectorize{Float64}(inner)
+    x, _ = MOI.add_constrained_variable(model, MOI.GreaterThan(1.0))
+    @test_throws MOI.DeleteNotAllowed{MOI.VariableIndex} MOI.delete(model, x)
+    return
+end
+
 function test_runtests()
     MOI.Bridges.runtests(
         MOI.Bridges.Variable.VectorizeBridge,

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -121,7 +121,8 @@ function test_exp3_with_add_constrained_variable_y()
     @test MOI.get(bridged_mock, MOI.VariablePrimal(), x) ≈ log(5)
     @test MOI.get(bridged_mock, MOI.VariablePrimal(), y) ≈ 5.0
     @test MOI.get(bridged_mock, MOI.ConstraintPrimal(), xc) ≈ 2log(5)
-    @test MOI.get(bridged_mock, MOI.ConstraintPrimal(), yc) ≈ 5
+    # TODO(odow): re-enable at some point
+    # @test MOI.get(bridged_mock, MOI.ConstraintPrimal(), yc) ≈ 5
     @test MOI.get(bridged_mock, MOI.ConstraintPrimal(), ec) ≈ [log(5), 1.0, 5.0]
     @test MOI.get(bridged_mock, MOI.ConstraintDual(), xc) ≈ 0.0
     @test MOI.get(bridged_mock, MOI.ConstraintDual(), yc) ≈ -1 / 5

--- a/test/Bridges/Variable/vectorize.jl
+++ b/test/Bridges/Variable/vectorize.jl
@@ -233,14 +233,6 @@ function test_exp3_with_add_constrained_variable_y()
     MOI.set(bridged_mock, MOI.VariablePrimalStart(), y, 1.0)
     @test MOI.get(mock, MOI.VariablePrimalStart(), z) == -4
     @test MOI.get(bridged_mock, MOI.VariablePrimalStart(), y) == 1
-
-    _test_delete_bridged_variable(
-        bridged_mock,
-        y,
-        MOI.LessThan{Float64},
-        2,
-        ((MOI.VectorOfVariables, MOI.Nonpositives, 0),),
-    )
     return
 end
 

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -519,17 +519,6 @@ function _test_SDPA_format(T)
     @test MOI.Bridges.bridge_type(bridged, MOI.RotatedSecondOrderCone) ==
           MOI.Bridges.Variable.RSOCtoPSDBridge{T}
     x, cx = MOI.add_constrained_variable(bridged, MOI.LessThan(one(T)))
-    _test_delete_bridged_variable(
-        bridged,
-        x,
-        MOI.LessThan{T},
-        1,
-        (
-            (MOI.VectorOfVariables, MOI.Nonnegatives, 0),
-            (MOI.VectorOfVariables, MOI.Nonpositives, 0),
-        ),
-        used_bridges = 2,
-    )
     @test !MOI.supports_constraint(
         bridged,
         MOI.VectorAffineFunction{T},


### PR DESCRIPTION
One issue from #2384.

It seems simpler to throw here than to carry around a bunch of extra state about which constants we need to modify.