### PR TITLE
Fix Exception supertype of LowerBoundAlreadySet and UpperBoundAlreadySet

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -249,7 +249,7 @@ Error thrown when setting a `VariableIndex`-in-`S2` when a
 set a lower bound, i.e. they are [`EqualTo`](@ref), [`GreaterThan`](@ref),
 [`Interval`](@ref), [`Semicontinuous`](@ref) or [`Semiinteger`](@ref).
 """
-struct LowerBoundAlreadySet{S1,S2}
+struct LowerBoundAlreadySet{S1,S2} <: Exception
     vi::VariableIndex
 end
 
@@ -271,7 +271,7 @@ Error thrown when setting a `VariableIndex`-in-`S2` when a
 set an upper bound, i.e. they are [`EqualTo`](@ref), [`LessThan`](@ref),
 [`Interval`](@ref), [`Semicontinuous`](@ref) or [`Semiinteger`](@ref).
 """
-struct UpperBoundAlreadySet{S1,S2}
+struct UpperBoundAlreadySet{S1,S2} <: Exception
     vi::VariableIndex
 end
 

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -45,6 +45,7 @@ function test_LowerBoundAlreadySet_error()
     S1 = MOI.LessThan{Int}
     S2 = MOI.Interval{Int}
     err = MOI.LowerBoundAlreadySet{S1,S2}(x)
+    @test err isa Exception
     @test sprint(showerror, err) ==
           "$(typeof(err)): Cannot add `VariableIndex`-in-`$(S2)` constraint " *
           "for variable $(x) as a `VariableIndex`-in-`$(S1)` constraint was " *
@@ -57,6 +58,7 @@ function test_UpperBoundAlreadySet_error()
     S1 = MOI.GreaterThan{Int}
     S2 = MOI.Interval{Int}
     err = MOI.UpperBoundAlreadySet{S1,S2}(x)
+    @test err isa Exception
     @test sprint(showerror, err) ==
           "$(typeof(err)): Cannot add `VariableIndex`-in-`$(S2)` constraint " *
           "for variable $(x) as a `VariableIndex`-in-`$(S1)` constraint was " *


### PR DESCRIPTION
This is the cause of https://github.com/jump-dev/Pavito.jl/issues/73