### PR TITLE
Prep for v1.25.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.25.0"
+version = "1.25.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,20 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.25.1 (January 11, 2024)
+
+### Fixed
+
+ - Fixed `map_indices` for `AbstractAutomaticDifferentiation` (#2394)
+ - Fixed deleting a variable in [`Bridges.Variable.VectorizeBridge`](@ref)
+   (#2393)
+ - Fixed super type of [`LowerBoundAlreadySet`](@ref) and [`UpperBoundAlreadySet`](@ref)
+   (#2397)
+
+### Other
+
+ - Removed a duplicated test (#2395)
+
 ## v1.25.0 (January 5, 2024)
 
 ### Added


### PR DESCRIPTION
## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/7480791502

The packages failing are:

 - [ ] MathOptSetDistances -- due to Hypatia
 - [x] Alpine -- due to Pavito. Needs https://github.com/jump-dev/Pavito.jl/pull/75
 - [ ] Hypatia -- upstream problem https://github.com/chriscoey/Hypatia.jl/pull/832
 - [x] Pavito -- caused by this release, but fixed in https://github.com/jump-dev/Pavito.jl/pull/74
 - [x] ProxSDP  upstream problem https://github.com/mariohsouto/ProxSDP.jl/pull/101
 - [ ] SDPA  upstream problem https://github.com/jump-dev/SDPA.jl/issues/56