### PR TITLE
[docs] fix vale version

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,6 +33,8 @@ jobs:
           path: ${{ github.workspace }}/latex-debug-logs
       - uses: errata-ai/vale-action@reviewdog
         with:
+          # TODO(odow): at some point, update to vale@3
+          version: 2.17.0
           files: docs/src
           fail_on_error: true
           filter_mode: nofilter

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: errata-ai/vale-action@reviewdog
         with:
           # TODO(odow): at some point, update to vale@3
-          version: 2.17.0
+          version: 2.30.0
           files: docs/src
           fail_on_error: true
           filter_mode: nofilter


### PR DESCRIPTION
vale v3.0.0 was recently released with breaking changes. This fixes the version for now.