### PR TITLE
[Utilities] throw correct error if get_fallback fails

### DIFF
--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -620,7 +620,8 @@ function MOI.get(
     end
     primal = get(mock.callback_variable_primal, xor_index(idx), nothing)
     if primal === nothing
-        error("No mock callback primal is set for variable `", idx, "`.")
+        msg = "No mock callback primal is set for variable `$idx`."
+        throw(MOI.GetAttributeNotAllowed(attr, msg))
     end
     return primal
 end
@@ -749,14 +750,13 @@ function _safe_get_result(
     index_name = index isa MOI.VariableIndex ? "variable" : "constraint"
     result_to_value = get(dict, xor_index(index), nothing)
     if result_to_value === nothing
-        error("No mock $name is set for ", index_name, " `", index, "`.")
+        msg = "No mock $name is set for $index_name `$index`."
+        throw(MOI.GetAttributeNotAllowed(attr, msg))
     end
     value = get(result_to_value, attr.result_index, nothing)
     if value === nothing
-        error(
-            "No mock $name is set for $(index_name) `$(index)` at result " *
-            "index `$(attr.result_index)`.",
-        )
+        msg = "No mock $name is set for $index_name `$index` at result index `$(attr.result_index)`."
+        throw(MOI.GetAttributeNotAllowed(attr, msg))
     end
     return value
 end

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -124,10 +124,9 @@ function test_CallbackVariablePrimal()
     y = MOI.get(mock, MOI.ListOfVariableIndices())[1]
     z = MOI.add_variable(bridged)
     attr = MOI.CallbackVariablePrimal(nothing)
-    @test_throws(
-        ErrorException("No mock callback primal is set for variable `$z`."),
-        MOI.get(bridged, attr, z),
-    )
+    msg = "No mock callback primal is set for variable `$z`."
+    err = MOI.GetAttributeNotAllowed(attr, msg)
+    @test_throws err MOI.get(bridged, attr, z)
     MOI.set(mock, attr, y, 1.0)
     MOI.set(mock, attr, z, 2.0)
     @test MOI.get(bridged, attr, z) == 2.0

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -357,8 +357,8 @@ function test_mapping_of_variables()
 
     @testset "CallbackVariablePrimal" begin
         attr = MOI.CallbackVariablePrimal(nothing)
-        err =
-            ErrorException("No mock callback primal is set for variable `$y`.")
+        msg = "No mock callback primal is set for variable `$y`."
+        err = MOI.GetCallbackNotAllowed(attr, msg)
         @test_throws err MOI.get(model, attr, x)
         MOI.set(mock, attr, y, 1.0)
         @test_throws MOI.InvalidIndex(x) MOI.get(mock, attr, x)

--- a/test/Utilities/cachingoptimizer.jl
+++ b/test/Utilities/cachingoptimizer.jl
@@ -358,7 +358,7 @@ function test_mapping_of_variables()
     @testset "CallbackVariablePrimal" begin
         attr = MOI.CallbackVariablePrimal(nothing)
         msg = "No mock callback primal is set for variable `$y`."
-        err = MOI.GetCallbackNotAllowed(attr, msg)
+        err = MOI.GetAttributeNotAllowed(attr, msg)
         @test_throws err MOI.get(model, attr, x)
         MOI.set(mock, attr, y, 1.0)
         @test_throws MOI.InvalidIndex(x) MOI.get(mock, attr, x)

--- a/test/Utilities/mockoptimizer.jl
+++ b/test/Utilities/mockoptimizer.jl
@@ -53,7 +53,7 @@ function test_optimizer_solve_with_result()
     MOI.set(optimizer, MOI.ObjectiveFunction{MOI.VariableIndex}(), v[1])
     MOI.set(optimizer, MOI.ResultCount(), 1)
     @test_throws(
-        ErrorException("No mock primal is set for variable `$(v[1])`."),
+        MOI.GetAttributeNotAllowed{MOI.VariablePrimal},
         MOI.get(optimizer, MOI.VariablePrimal(), v[1])
     )
     @test_throws(
@@ -87,15 +87,11 @@ function test_optimizer_solve_with_result()
     optimizer.eval_objective_value = true
     @test MOI.get(optimizer, MOI.ObjectiveValue()) == 3.0
     @test_throws(
-        ErrorException(
-            "No mock primal is set for variable `$(v[1])` at result index `2`.",
-        ),
+        MOI.GetAttributeNotAllowed(MOI.ObjectiveValue(2)),
         MOI.get(optimizer, MOI.ObjectiveValue(2))
     )
     @test_throws(
-        ErrorException(
-            "No mock dual is set for constraint `$c1` at result index `1`.",
-        ),
+        MOI.GetAttributeNotAllowed(MOI.DualObjectiveValue()),
         MOI.get(optimizer, MOI.DualObjectiveValue())
     )
     @test MOI.get(optimizer, MOI.DualObjectiveValue(2)) == 5.9
@@ -104,31 +100,23 @@ function test_optimizer_solve_with_result()
     @test MOI.get(optimizer, MOI.VariablePrimal(), v) == [3.0, 2.0]
     @test MOI.get(optimizer, MOI.VariablePrimal(), v[1]) == 3.0
     @test_throws(
-        ErrorException(
-            "No mock primal is set for variable `$(v[1])` at result index `2`.",
-        ),
+        MOI.GetAttributeNotAllowed{MOI.VariablePrimal},
         MOI.get(optimizer, MOI.VariablePrimal(2), v[1])
     )
     @test MOI.get(optimizer, MOI.ConstraintPrimal(), c1) == 3.0
     @test MOI.get(optimizer, MOI.ConstraintPrimal(), soc) == [3.0, 2.0]
     @test_throws(
-        ErrorException(
-            "No mock primal is set for variable `$(v[1])` at result index `2`.",
-        ),
+        MOI.GetAttributeNotAllowed(MOI.ConstraintPrimal(2)),
         @show MOI.get(optimizer, MOI.ConstraintPrimal(2), c1)
     )
     @test_throws(
-        ErrorException(
-            "No mock primal is set for variable `$(v[1])` at result index `2`.",
-        ),
+        MOI.GetAttributeNotAllowed(MOI.ConstraintPrimal(2)),
         MOI.get(optimizer, MOI.ConstraintPrimal(2), soc)
     )
     @test MOI.get(optimizer, MOI.ConstraintDual(2), c1) == 5.9
     @test MOI.get(optimizer, MOI.ConstraintDual(2), soc) == [1.0, 2.0]
     @test_throws(
-        ErrorException(
-            "No mock dual is set for constraint `$c1` at result index `1`.",
-        ),
+        MOI.GetAttributeNotAllowed{MOI.ConstraintDual},
         MOI.get(optimizer, MOI.ConstraintDual(1), c1)
     )
 end


### PR DESCRIPTION
This is a possible fix for https://github.com/jump-dev/MathOptInterface.jl/pull/2410#issuecomment-1907199988

https://github.com/jump-dev/MathOptInterface.jl/actions/runs/7635259102