### PR TITLE
[Bridge] implement special case for x != y in CountDistinctToMILPBridge

### DIFF
--- a/src/Bridges/Constraint/bridges/count_distinct.jl
+++ b/src/Bridges/Constraint/bridges/count_distinct.jl
@@ -55,7 +55,7 @@ which is equivalent to (for suitable `M`):
 \\begin{aligned}
 z \\in \\{0, 1\\} \\\\
 x - y - M * z <= -1 \\\\
-y - x - M * (z - 1) <= -1
+y - x - M * (1 - z) <= -1
 \\end{aligned}
 ```
 
@@ -310,7 +310,7 @@ function _final_touch_not_equal_case(
     # <-->
     #   {x - y <= -1} \/ {y - x <= -1}
     # <-->
-    # {x - y - M * z <= -1} /\ {y - x - M * (z - 1) <= -1}, z in {0, 1}
+    # {x - y - M * z <= -1} /\ {y - x - M * (1 - z) <= -1}, z in {0, 1}
     z, _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
     push!(bridge.variables, z)
     x, y = scalars[2], scalars[3]
@@ -327,15 +327,15 @@ function _final_touch_not_equal_case(
             allow_modify_function = true,
         ),
     )
-    # {y - x - M * (z - 1) <= -1}, M = u_x - l_y + 1
+    # {y - x - M * (1 - z) <= -1}, M = u_x - l_y + 1
     M = by[2] - bx[1] + 1
     g = MOI.Utilities.operate(-, T, y, x)
     push!(
         bridge.less_than,
         MOI.Utilities.normalize_and_add_constraint(
             model,
-            MOI.Utilities.operate!(-, T, g, M * z),
-            MOI.LessThan(T(-1 - M));
+            MOI.Utilities.operate!(+, T, g, M * z),
+            MOI.LessThan(T(-1 + M));
             allow_modify_function = true,
         ),
     )

--- a/src/Bridges/Constraint/bridges/count_distinct.jl
+++ b/src/Bridges/Constraint/bridges/count_distinct.jl
@@ -53,7 +53,7 @@ to `x != y`.
 which is equivalent to (for suitable `M`):
 ```math
 \\begin{aligned}
-z \\in \\{0, 1\\}
+z \\in \\{0, 1\\} \\\\
 x - y - M * z <= -1 \\\\
 y - x - M * (z - 1) <= -1
 \\end{aligned}

--- a/src/Bridges/Constraint/bridges/count_distinct.jl
+++ b/src/Bridges/Constraint/bridges/count_distinct.jl
@@ -315,7 +315,7 @@ function _final_touch_not_equal_case(
     push!(bridge.variables, z)
     x, y = scalars[2], scalars[3]
     bx, by = bridge.bounds[1], bridge.bounds[2]
-    # {x - y - M * z <= -1}, M = u_x - l_y
+    # {x - y - M * z <= -1}, M = u_x - l_y + 1
     M = bx[2] - by[1] + 1
     f = MOI.Utilities.operate(-, T, x, y)
     push!(
@@ -327,7 +327,7 @@ function _final_touch_not_equal_case(
             allow_modify_function = true,
         ),
     )
-    # {y - x - M * (z - 1) <= -1}, M = u_x - l_y
+    # {y - x - M * (z - 1) <= -1}, M = u_x - l_y + 1
     M = by[2] - bx[1] + 1
     g = MOI.Utilities.operate(-, T, y, x)
     push!(

--- a/src/Bridges/Constraint/bridges/count_distinct.jl
+++ b/src/Bridges/Constraint/bridges/count_distinct.jl
@@ -316,7 +316,7 @@ function _final_touch_not_equal_case(
     x, y = scalars[2], scalars[3]
     bx, by = bridge.bounds[1], bridge.bounds[2]
     # {x - y - M * z <= -1}, M = u_x - l_y
-    M = bx[2] - by[1]
+    M = bx[2] - by[1] + 1
     f = MOI.Utilities.operate(-, T, x, y)
     push!(
         bridge.less_than,
@@ -328,7 +328,7 @@ function _final_touch_not_equal_case(
         ),
     )
     # {y - x - M * (z - 1) <= -1}, M = u_x - l_y
-    M = by[2] - bx[1]
+    M = by[2] - bx[1] + 1
     g = MOI.Utilities.operate(-, T, y, x)
     push!(
         bridge.less_than,

--- a/test/Bridges/Constraint/count_distinct.jl
+++ b/test/Bridges/Constraint/count_distinct.jl
@@ -74,8 +74,8 @@ function test_runtests_VectorOfVariables_NotEqualTo()
         """,
         """
         variables: n, x, y, z
-        1.0 * x + -1.0 * y + -2.0 * z <= -1.0
-        1.0 * y + -1.0 * x + -4.0 * z <= -5.0
+        1.0 * x + -1.0 * y + -3.0 * z <= -1.0
+        1.0 * y + -1.0 * x + -5.0 * z <= -6.0
         x in Interval(1.0, 4.0)
         y >= 2.0
         y <= 5.0

--- a/test/Bridges/Constraint/count_distinct.jl
+++ b/test/Bridges/Constraint/count_distinct.jl
@@ -75,7 +75,7 @@ function test_runtests_VectorOfVariables_NotEqualTo()
         """
         variables: n, x, y, z
         1.0 * x + -1.0 * y + -3.0 * z <= -1.0
-        1.0 * y + -1.0 * x + -5.0 * z <= -6.0
+        1.0 * y + -1.0 * x + 5.0 * z <= 4.0
         x in Interval(1.0, 4.0)
         y >= 2.0
         y <= 5.0

--- a/test/Bridges/Constraint/count_distinct.jl
+++ b/test/Bridges/Constraint/count_distinct.jl
@@ -61,21 +61,46 @@ function test_runtests_VectorOfVariables()
     return
 end
 
+function test_runtests_VectorOfVariables_NotEqualTo()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.CountDistinctToMILPBridge,
+        """
+        variables: n, x, y
+        [n, x, y] in CountDistinct(3)
+        x in Interval(1.0, 4.0)
+        y >= 2.0
+        y <= 5.0
+        n == 2.0
+        """,
+        """
+        variables: n, x, y, z
+        1.0 * x + -1.0 * y + -2.0 * z <= -1.0
+        1.0 * y + -1.0 * x + -4.0 * z <= -5.0
+        x in Interval(1.0, 4.0)
+        y >= 2.0
+        y <= 5.0
+        n == 2.0
+        z in ZeroOne()
+        """,
+    )
+    return
+end
+
 function test_runtests_VectorAffineFunction()
     MOI.Bridges.runtests(
         MOI.Bridges.Constraint.CountDistinctToMILPBridge,
         """
-        variables: x, y
-        [2.0, 2.0 * x + -1.0, y] in CountDistinct(3)
+        variables: d, x, y
+        [d, 2.0 * x + -1.0, y] in CountDistinct(3)
         x in Interval(1.0, 2.0)
         y >= 2.0
         y <= 3.0
         """,
         """
-        variables: x, y, z_x1, z_x2, z_x3, z_y2, z_y3, a_1, a_2, a_3
+        variables: d, x, y, z_x1, z_x2, z_x3, z_y2, z_y3, a_1, a_2, a_3
         2.0 * x + -1.0 * z_x1 + -2.0 * z_x2 + -3.0 * z_x3 == 1.0
         1.0 * y + -2.0 * z_y2 + -3.0 * z_y3 == 0.0
-        a_1 + a_2 + a_3 == 2.0
+        a_1 + a_2 + a_3 + -1.0 * d == 0.0
         z_x1 + z_x2 + z_x3 == 1.0
         z_y2 + z_y3 == 1.0
         z_x1 + -1.0 * a_1 <= 0.0
@@ -143,6 +168,22 @@ function test_runtests_error_affine()
         ),
         MOI.Bridges.final_touch(model),
     )
+    return
+end
+
+function test_resolve_with_modified_not_equal_to()
+    inner = MOI.Utilities.Model{Int}()
+    model = MOI.Bridges.Constraint.CountDistinctToMILP{Int}(inner)
+    x = MOI.add_variables(model, 3)
+    c = MOI.add_constraint.(model, x[2:3], MOI.Interval(0, 2))
+    MOI.add_constraint(model, x[1], MOI.EqualTo(2))
+    MOI.add_constraint(model, MOI.VectorOfVariables(x), MOI.CountDistinct(3))
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 3
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 4
+    MOI.set(model, MOI.ConstraintSet(), c[2], MOI.Interval(0, 1))
+    MOI.Bridges.final_touch(model)
+    @test MOI.get(inner, MOI.NumberOfVariables()) == 4
     return
 end
 


### PR DESCRIPTION
Closes #2405

This PR implements a much stronger reformulation for the special case of `[2, x ,y] in CountDistinct` which is created by `[x, y] in AllDifferent(2)`, a.k.a. `x != y`.