### PR TITLE
[FileFormats.MPS] improve performance of MPS writer

### DIFF
--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -155,7 +155,6 @@ struct Card
     f3::String
     f4::String
     f5::String
-    num_fields::Int
 
     function Card(;
         f1::String = "",
@@ -164,12 +163,7 @@ struct Card
         f4::String = "",
         f5::String = "",
     )
-        num_fields = isempty(f1) ? 0 : 1
-        num_fields = isempty(f2) ? num_fields : 2
-        num_fields = isempty(f3) ? num_fields : 3
-        num_fields = isempty(f4) ? num_fields : 4
-        num_fields = isempty(f5) ? num_fields : 5
-        return new(f1, f2, f3, f4, f5, num_fields)
+        return new(f1, f2, f3, f4, f5)
     end
 end
 
@@ -183,23 +177,17 @@ function print_offset(io, offset, field, min_start)
 end
 
 function Base.show(io::IO, card::Card)
-    offset = print_offset(io, 0, card.f1, 2)
-    if card.num_fields == 1
-        return
+     offset = print_offset(io, 0, card.f1, 2)
+     offset = print_offset(io, offset, card.f2, 5)
+    if !isempty(card.f3)
+        offset = print_offset(io, offset, card.f3, 15)
     end
-    offset = print_offset(io, offset, card.f2, 5)
-    if card.num_fields == 2
-        return
+    if !isempty(card.f4)
+        offset = print_offset(io, offset, card.f4, 25)
     end
-    offset = print_offset(io, offset, card.f3, 15)
-    if card.num_fields == 3
-        return
+    if !isempty(card.f5)
+        offset = print_offset(io, offset, card.f5, 40)
     end
-    offset = print_offset(io, offset, card.f4, 25)
-    if card.num_fields == 4
-        return
-    end
-    offset = print_offset(io, offset, card.f5, 40)
     return
 end
 

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -1792,4 +1792,33 @@ function parse_indicators_line(data, items)
     return
 end
 
+import PrecompileTools
+
+PrecompileTools.@setup_workload begin
+    PrecompileTools.@compile_workload begin
+        let
+            model = Model()
+            x = MOI.add_variables(model, 4)
+            for i in 1:4
+                MOI.set(model, MOI.VariableName(), x[i], "x[$i]")
+            end
+            MOI.add_constraint(model, x[1], MOI.LessThan(1.0))
+            MOI.add_constraint(model, x[2], MOI.GreaterThan(1.0))
+            MOI.add_constraint(model, x[3], MOI.EqualTo(1.2))
+            MOI.add_constraint(model, x[4], MOI.Interval(-1.0, 100.0))
+            MOI.add_constraint(model, x[1], MOI.ZeroOne())
+            MOI.add_constraint(model, x[2], MOI.Integer())
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+            f = 1.0 * x[1] + 2.0 * x[2] + 3.0
+            MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+            MOI.add_constraint(model, 1.5 * x[1], MOI.LessThan(1.0))
+            MOI.add_constraint(model, 1.5 * x[2], MOI.GreaterThan(1.0))
+            MOI.add_constraint(model, 1.5 * x[3], MOI.EqualTo(1.2))
+            MOI.add_constraint(model, 1.5 * x[4], MOI.Interval(-1.0, 100.0))
+            io = IOBuffer()
+            write(io, model)
+        end
+    end
+end
+
 end

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -155,7 +155,6 @@ struct Card
     f3::String
     f4::String
     f5::String
-    f6::String
     num_fields::Int
 
     function Card(;
@@ -170,7 +169,7 @@ struct Card
         num_fields = isempty(f3) ? num_fields : 3
         num_fields = isempty(f4) ? num_fields : 4
         num_fields = isempty(f5) ? num_fields : 5
-        return new(f1, f2, f3, f4, f5, "", num_fields)
+        return new(f1, f2, f3, f4, f5, num_fields)
     end
 end
 
@@ -291,7 +290,7 @@ const SET_TYPES = (
 const FUNC_TYPES =
     (MOI.ScalarAffineFunction{Float64}, MOI.ScalarQuadraticFunction{Float64})
 
-function _write_rows(io, model, F, S, sense_char)
+function _write_rows(io, model, ::Type{F}, ::Type{S}, sense_char) where {F,S}
     for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         row_name = MOI.get(model, MOI.ConstraintName(), index)
         if row_name == ""
@@ -302,7 +301,13 @@ function _write_rows(io, model, F, S, sense_char)
     return
 end
 
-function _write_rows(io, model, F, S::Type{MOI.Interval{Float64}}, ::Any)
+function _write_rows(
+    io,
+    model,
+    ::Type{F},
+    ::Type{S},
+    ::Any,
+) where {F,S<:MOI.Interval{Float64}}
     for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         row_name = MOI.get(model, MOI.ConstraintName(), index)
         set = MOI.get(model, MOI.ConstraintSet(), index)
@@ -391,11 +396,11 @@ end
 
 function _collect_coefficients(
     model,
-    F,
-    S,
+    ::Type{F},
+    ::Type{S},
     v_names::Dict{MOI.VariableIndex,String},
     coefficients::Dict{String,Vector{Tuple{String,Float64}}},
-)
+) where {F,S}
     for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         row_name = MOI.get(model, MOI.ConstraintName(), index)
         func = MOI.get(model, MOI.ConstraintFunction(), index)

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -496,7 +496,7 @@ _value(set::MOI.GreaterThan) = set.lower
 _value(set::MOI.EqualTo) = set.value
 _value(set::MOI.Indicator) = _value(set.set)
 
-function _write_rhs(io, model, F, S)
+function _write_rhs(io, model, ::Type{F}, ::Type{S}) where {F,S}
     for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         row_name = MOI.get(model, MOI.ConstraintName(), index)
         set = MOI.get(model, MOI.ConstraintSet(), index)
@@ -508,7 +508,12 @@ function _write_rhs(io, model, F, S)
     return
 end
 
-function _write_rhs(io, model, F, S::Type{MOI.Interval{Float64}})
+function _write_rhs(
+    io,
+    model,
+    ::Type{F},
+    ::Type{S},
+) where {F,S<:MOI.Interval{Float64}}
     for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         row_name = MOI.get(model, MOI.ConstraintName(), index)
         set = MOI.get(model, MOI.ConstraintSet(), index)

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -268,13 +268,6 @@ end
 #   ROWS
 # ==============================================================================
 
-const SET_TYPES = (
-    (MOI.LessThan{Float64}, "L"),
-    (MOI.GreaterThan{Float64}, "G"),
-    (MOI.EqualTo{Float64}, "E"),
-    (MOI.Interval{Float64}, "L"),  # See the note in the RANGES section.
-)
-
 function _write_rows(io, model, ::Type{F}, ::Type{S}, sense_char) where {F,S}
     for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
         row_name = MOI.get(model, MOI.ConstraintName(), index)
@@ -852,7 +845,12 @@ end
 function write_quadcons(io::IO, model::Model, ordered_names, var_to_column)
     options = get_options(model)
     F = MOI.ScalarQuadraticFunction{Float64}
-    for (S, _) in SET_TYPES
+    for S in (
+        MOI.LessThan{Float64},
+        MOI.GreaterThan{Float64},
+        MOI.EqualTo{Float64},
+        MOI.Interval{Float64},
+    )
         for ci in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
             name = MOI.get(model, MOI.ConstraintName(), ci)
             if options.quadratic_format == kQuadraticFormatMosek

--- a/src/FileFormats/utils.jl
+++ b/src/FileFormats/utils.jl
@@ -291,11 +291,11 @@ end
 struct AutomaticCompression <: AbstractCompressionScheme end
 
 function compressed_open(
-    f::Function,
+    f::F,
     filename::String,
     mode::String,
     ::AutomaticCompression,
-)
+) where {F<:Function}
     ext = Symbol(split(filename, ".")[end])
     return compressed_open(f, filename, mode, extension(Val{ext}()))
 end

--- a/src/FileFormats/utils.jl
+++ b/src/FileFormats/utils.jl
@@ -61,6 +61,92 @@ function _replace(s::String, replacements::Vector{Function})
     return s
 end
 
+function _create_unique_constraint_names_inner(
+    model,
+    warn,
+    replacements,
+    original_names,
+    added_names,
+    ::Type{MOI.VariableIndex},
+    ::Type{S},
+) where {S}
+    return  # VariableIndex constraints do not need a name.
+end
+
+function _create_unique_constraint_names_inner(
+    model,
+    warn,
+    replacements,
+    original_names,
+    added_names,
+    ::Type{F},
+    ::Type{S},
+) where {F,S}
+    for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+        original_name = MOI.get(model, MOI.ConstraintName(), index)
+        new_name = _replace(
+            original_name != "" ? original_name : "c$(index.value)",
+            replacements,
+        )
+        if new_name in added_names
+            # We found a duplicate name. We could just append a string like
+            # "_", but we're going to be clever and loop through the
+            # integers to name them appropriately. Thus, if we have three
+            # constraints named c, we'll end up with variables named c, c_1,
+            # and c_2.
+            i = 1
+            tmp_name = string(new_name, "_", i)
+            while tmp_name in added_names || tmp_name in original_names
+                i += 1
+                tmp_name = string(new_name, "_", i)
+            end
+            new_name = tmp_name
+        end
+        push!(added_names, new_name)
+        if new_name != original_name
+            if warn
+                if original_name == ""
+                    @warn(
+                        "Blank name detected for constraint $(index). " *
+                        "Renamed to $(new_name)."
+                    )
+                else
+                    @warn(
+                        "Duplicate name $(original_name) detected for " *
+                        "constraint $(index). Renamed to $(new_name)."
+                    )
+                end
+            end
+            MOI.set(model, MOI.ConstraintName(), index, new_name)
+        end
+    end
+    return
+end
+
+function _get_original_names_inner(
+    model,
+    replacements,
+    original_names,
+    ::Type{F},
+    ::Type{S},
+) where {F,S}
+    for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+        name = MOI.get(model, MOI.ConstraintName(), index)
+        push!(original_names, _replace(name, replacements))
+    end
+    return
+end
+
+function _get_original_names_inner(
+    model,
+    replacements,
+    original_names,
+    ::Type{MOI.VariableIndex},
+    ::Type{S},
+) where {S}
+    return  # VariableIndex constraints do not need a name.
+end
+
 function create_unique_constraint_names(
     model::MOI.ModelLike,
     warn::Bool,
@@ -68,58 +154,21 @@ function create_unique_constraint_names(
 )
     original_names = Set{String}()
     for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
-        if F == MOI.VariableIndex
-            continue  # VariableIndex constraints do not need a name.
-        end
-        for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-            name = MOI.get(model, MOI.ConstraintName(), index)
-            push!(original_names, _replace(name, replacements))
-        end
+        _get_original_names_inner(model, replacements, original_names, F, S)
     end
     added_names = Set{String}()
     for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
-        if F == MOI.VariableIndex
-            continue  # VariableIndex constraints do not need a name.
-        end
-        for index in MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-            original_name = MOI.get(model, MOI.ConstraintName(), index)
-            new_name = _replace(
-                original_name != "" ? original_name : "c$(index.value)",
-                replacements,
-            )
-            if new_name in added_names
-                # We found a duplicate name. We could just append a string like
-                # "_", but we're going to be clever and loop through the
-                # integers to name them appropriately. Thus, if we have three
-                # constraints named c, we'll end up with variables named c, c_1,
-                # and c_2.
-                i = 1
-                tmp_name = string(new_name, "_", i)
-                while tmp_name in added_names || tmp_name in original_names
-                    i += 1
-                    tmp_name = string(new_name, "_", i)
-                end
-                new_name = tmp_name
-            end
-            push!(added_names, new_name)
-            if new_name != original_name
-                if warn
-                    if original_name == ""
-                        @warn(
-                            "Blank name detected for constraint $(index). " *
-                            "Renamed to $(new_name)."
-                        )
-                    else
-                        @warn(
-                            "Duplicate name $(original_name) detected for " *
-                            "constraint $(index). Renamed to $(new_name)."
-                        )
-                    end
-                end
-                MOI.set(model, MOI.ConstraintName(), index, new_name)
-            end
-        end
+        _create_unique_constraint_names_inner(
+            model,
+            warn,
+            replacements,
+            original_names,
+            added_names,
+            F,
+            S,
+        )
     end
+    return
 end
 
 function create_unique_variable_names(

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -425,7 +425,7 @@ a_really_long_name <= 2.0
           "ROWS\n" *
           " N  OBJ\n" *
           "COLUMNS\n" *
-          "    a_really_long_name OBJ       1\n" *
+          "    a_really_long_name OBJ 1\n" *
           "RHS\n" *
           "RANGES\n" *
           "BOUNDS\n" *

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -79,10 +79,10 @@ end
 function test_sos()
     model = MPS.Model()
     x = MOI.add_variables(model, 3)
-    names = Dict{MOI.VariableIndex,String}()
+    names = Dict{MOI.VariableIndex,Int}()
     for i in 1:3
         MOI.set(model, MOI.VariableName(), x[i], "x$(i)")
-        names[x[i]] = "x$(i)"
+        names[x[i]] = i
     end
     MOI.add_constraint(
         model,
@@ -94,7 +94,7 @@ function test_sos()
         MOI.VectorOfVariables(x),
         MOI.SOS2([1.25, 2.25, 3.25]),
     )
-    @test sprint(MPS.write_sos, model, names) ==
+    @test sprint(MPS.write_sos, model, ["x1", "x2", "x3"], names) ==
           "SOS\n" *
           " S1 SOS1\n" *
           "    x1        1.5\n" *
@@ -104,6 +104,7 @@ function test_sos()
           "    x1        1.25\n" *
           "    x2        2.25\n" *
           "    x3        3.25\n"
+    return
 end
 
 function test_maximization()
@@ -112,7 +113,7 @@ function test_maximization()
     MOI.set(model, MOI.VariableName(), x, "x")
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{MOI.VariableIndex}(), x)
-    @test sprint(MPS.write_columns, model, true, ["x"], Dict(x => "x")) ==
+    @test sprint(MPS.write_columns, model, true, ["x"], Dict(x => 1)) ==
           "COLUMNS\n    x         OBJ       -1\n"
 end
 
@@ -123,7 +124,7 @@ function test_maximization_objsense_false()
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     MOI.set(model, MOI.ObjectiveFunction{MOI.VariableIndex}(), x)
     sprint(MPS.write, model)
-    @test sprint(MPS.write_columns, model, false, ["x"], Dict(x => "x")) ==
+    @test sprint(MPS.write_columns, model, false, ["x"], Dict(x => 1)) ==
           "COLUMNS\n    x         OBJ       1\n"
 end
 


### PR DESCRIPTION
Using the `Optimizer` from #2417 
```julia
using JuMP
function main(N)
    model = direct_model(Optimizer(MOI.FileFormats.MPS.Model()))
    @variable(model, 0 <= x[i in 1:N] <= 1; integer = isodd(i))
    @constraint(model, [i in 2:N], x[i] + x[i-1] <= 1)
    @objective(model, Max, sum(i * x[i] for i in 1:N))
    MOI.write_to_file(backend(model).inner, "file.mps")
    return
end
```

Before:

```julia
julia> GC.gc(); @time main(100_000);
  2.005077 seconds (18.45 M allocations: 812.105 MiB, 9.98% gc time, 24.17% compilation time: 44% of which was recompilation)

julia> GC.gc(); @time main(100_000);
  1.495755 seconds (17.55 M allocations: 751.348 MiB, 12.09% gc time)

julia> GC.gc(); @time main(100_000);
  1.529073 seconds (17.55 M allocations: 751.348 MiB, 12.28% gc time)
```

After:

```julia
julia> GC.gc(); @time main(100_000);
  1.873707 seconds (11.57 M allocations: 602.868 MiB, 8.18% gc time, 29.04% compilation time: 45% of which was recompilation)

julia> GC.gc(); @time main(100_000);
  1.341565 seconds (10.55 M allocations: 533.148 MiB, 10.52% gc time)

julia> GC.gc(); @time main(100_000);
  1.336950 seconds (10.55 M allocations: 533.148 MiB, 10.17% gc time)
```

Small improvement in time, but big improvement in the number of allocations.