### PR TITLE
[FileFormats.MPS] revert change for backwards compatibility

### DIFF
--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -1837,4 +1837,5 @@ const SET_TYPES = (
     (MOI.EqualTo{Float64}, "E"),
     (MOI.Interval{Float64}, "L"),
 )
+
 end

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -1837,5 +1837,4 @@ const SET_TYPES = (
     (MOI.EqualTo{Float64}, "E"),
     (MOI.Interval{Float64}, "L"),
 )
-    
 end

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -1829,4 +1829,13 @@ PrecompileTools.@setup_workload begin
     end
 end
 
+# Originally removed by #2421, but this constant was used by extensions like
+# BilevelJuMP so I'm re-adding to maintain backwards compatibility.
+const SET_TYPES = (
+    (MOI.LessThan{Float64}, "L"),
+    (MOI.GreaterThan{Float64}, "G"),
+    (MOI.EqualTo{Float64}, "E"),
+    (MOI.Interval{Float64}, "L"),
+)
+    
 end


### PR DESCRIPTION
https://github.com/jump-dev/MathOptInterface.jl/pull/2421 broke BilevelJuMP.

See https://github.com/joaquimg/BilevelJuMP.jl/pull/214