### PR TITLE
Prep for v1.25.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.25.2"
+version = "1.25.3"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
- - Improved performance of [`Bridges.Constraint.CounntDistinctToMILPBridge`](@ref)
+ - Improved performance of [`Bridges.Constraint.CountDistinctToMILPBridge`](@ref)
    (#2416)
  - Improved performance of `FileFormats.MPS` writer (#2421) (#2424) (#2426)
  - Updated `solver-tests.yml` (#2423)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
  - Fixed number type in `get_fallback` (#2414)
- - Fixed error type thrown when a variable bridge cannot unbridge. It used to
-   throw `ErrorException`. It now throws `MOI.GetAttributeNotAllowed{MOI.ConstraintFunction}`.
+ - Fixed error type thrown when a variable bridge cannot un-bridge the
+   function. It used to throw `ErrorException`. It now throws `MOI.GetAttributeNotAllowed{MOI.ConstraintFunction}`.
    This enables `Utilities.CachingOptimizer` to more uniformly implement
    fallbacks for common bridges like [`Bridges.Variable.ZerosBridge`](@ref).
    (#2415)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    This enables `Utilities.CachingOptimizer` to more uniformly implement
    fallbacks for common bridges like [`Bridges.Variable.ZerosBridge`](@ref).
    (#2415)
+ - Fixed tests on upcoming Julia v1.11 (#2428)
 
 ### Other
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    (#2416)
  - Improved performance of `FileFormats.MPS` writer (#2421) (#2424) (#2426)
  - Updated `solver-tests.yml` (#2423)
+ - Fixed typos in `src/attributes.jl` (#2429)
 
 ## v1.25.2 (January 29, 2024)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,24 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.25.3 (February 14, 2024)
+
+### Fixed
+
+ - Fixed number type in `get_fallback` (#2414)
+ - Fixed error type thrown when a variable bridge cannot unbridge. It used to
+   throw `ErrorException`. It now throws `MOI.GetAttributeNotAllowed{MOI.ConstraintFunction}`.
+   This enables `Utilities.CachingOptimizer` to more uniformly implement
+   fallbacks for common bridges like [`Bridges.Variable.ZerosBridge`](@ref).
+   (#2415)
+
+### Other
+
+ - Improved performance of [`Bridges.Constraint.CounntDistinctToMILPBridge`](@ref)
+   (#2416)
+ - Improved performance of `FileFormats.MPS` writer (#2421) (#2424) (#2426)
+ - Updated `solver-tests.yml` (#2423)
+
 ## v1.25.2 (January 29, 2024)
 
 ### Fixed


### PR DESCRIPTION
## TODO

 - [x] https://github.com/jump-dev/MathOptInterface.jl/pull/2426
 - [x] https://github.com/jump-dev/MutableArithmetics.jl/pull/262
 - [x] https://github.com/jump-dev/MathOptInterface.jl/pull/2428
 - [x] #2429

## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/7895476127
