### PR TITLE
[Nonlinear] add support for univariate sign

### DIFF
--- a/src/FileFormats/NL/NLExpr.jl
+++ b/src/FileFormats/NL/NLExpr.jl
@@ -247,6 +247,7 @@ const _UNARY_SPECIAL_CASES = Dict{Symbol,Function}(
     :asech => (x) -> :(acosh(1 / $x)),
     :acsch => (x) -> :(asinh(1 / $x)),
     :acoth => (x) -> :(atanh(1 / $x)),
+    :sign => (x) -> :(ifelse($x >= 0, 1, -1)),
 )
 
 """

--- a/src/Nonlinear/operators.jl
+++ b/src/Nonlinear/operators.jl
@@ -81,17 +81,17 @@ The list of univariate operators that are supported by default.
 julia> import MathOptInterface as MOI
 
 julia> MOI.Nonlinear.DEFAULT_UNIVARIATE_OPERATORS
-72-element Vector{Symbol}:
+73-element Vector{Symbol}:
  :+
  :-
  :abs
+ :sign
  :sqrt
  :cbrt
  :abs2
  :inv
  :log
  :log10
- :log2
  ⋮
  :airybi
  :airyaiprime

--- a/src/Nonlinear/univariate_expressions.jl
+++ b/src/Nonlinear/univariate_expressions.jl
@@ -12,6 +12,7 @@ const SYMBOLIC_UNIVARIATE_EXPRESSIONS = Tuple{Symbol,Expr,Any}[
     (:+, :(one(x)), :(zero(x))),
     (:-, :(-one(x)), :(zero(x))),
     (:abs, :(ifelse(x >= 0, one(x), -one(x))), :(zero(x))),
+    (:sign, :(zero(x)), :(zero(x))),
     (:sqrt, :(0.5 / sqrt(x)), :((0.5 * -(0.5 / sqrt(x))) / sqrt(x) ^ 2)),
     (:cbrt, :(0.3333333333333333 / cbrt(x) ^ 2), :((0.3333333333333333 * -(2 * (0.3333333333333333 / cbrt(x) ^ 2) * cbrt(x))) / (cbrt(x) ^ 2) ^ 2)),
     (:abs2, :(2x), :((typeof(x))(2))),

--- a/src/Nonlinear/univariate_expressions_generator.jl
+++ b/src/Nonlinear/univariate_expressions_generator.jl
@@ -42,7 +42,8 @@ open("univariate_expressions.jl", "w") do io
 const SYMBOLIC_UNIVARIATE_EXPRESSIONS = Tuple{Symbol,Expr,Any}[
     (:+, :(one(x)), :(zero(x))),
     (:-, :(-one(x)), :(zero(x))),
-    (:abs, :(ifelse(x >= 0, one(x), -one(x))), :(zero(x))),""",
+    (:abs, :(ifelse(x >= 0, one(x), -one(x))), :(zero(x))),
+    (:sign, :(zero(x)), :(zero(x))),""",
     )
     for (op, deriv) in Calculus.symbolic_derivatives_1arg()
         f = Expr(:call, op, :x)

--- a/test/FileFormats/NL/NL.jl
+++ b/test/FileFormats/NL/NL.jl
@@ -151,6 +151,14 @@ function test_nlexpr_scalarnonlinearfunction_unary_special_case()
     return
 end
 
+function test_nlexpr_scalarnonlinearfunction_unary_special_case_sign()
+    x = MOI.VariableIndex(1)
+    f = MOI.ScalarNonlinearFunction(:sign, Any[x])
+    expr = NL._NLExpr(:(ifelse($x >= 0, 1, -1)))
+    _test_nlexpr(f, expr.nonlinear_terms, Dict(x => 0.0), 0.0)
+    return
+end
+
 function test_nlexpr_scalarnonlinearfunction_binary_special_case()
     x = MOI.VariableIndex(1)
     f = MOI.ScalarNonlinearFunction(:\, Any[x, 1])

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -1165,8 +1165,8 @@ end
 
 function test_univariate_sign()
     f(y, p) = sign(y) * abs(y)^p
-    ∇f(y, p) = p * abs(y)^(p-1)
-    ∇²f(y, p) = sign(y) * p * (p-1) * abs(y)^(p-2)
+    ∇f(y, p) = p * abs(y)^(p - 1)
+    ∇²f(y, p) = sign(y) * p * (p - 1) * abs(y)^(p - 2)
     for p in (-0.5, 0.5, 2.0)
         x = MOI.VariableIndex(1)
         model = MOI.Nonlinear.Model()


### PR DESCRIPTION
Closes https://github.com/jump-dev/MathOptInterface.jl/issues/2448

I don't know about this one. We might be better off documenting people to write a `signpower` function at the JuMP level because this still has the problem that `sign(x) * abs(x)^p` is not defined when `x=0` and `p < 1`.

Thoughts @ccoffrin?