### PR TITLE
[Utilities] Allow non-IndexMap for pass_attributes

### DIFF
--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -23,11 +23,7 @@ _sort_priority(::MOI.AbstractModelAttribute) = 30.0
 
 Pass the model attributes from the model `src` to the model `dest`.
 """
-function pass_attributes(
-    dest::MOI.ModelLike,
-    src::MOI.ModelLike,
-    index_map,
-)
+function pass_attributes(dest::MOI.ModelLike, src::MOI.ModelLike, index_map)
     attrs = MOI.get(src, MOI.ListOfModelAttributesSet())
     # We need to deal with the UserDefinedFunctions first, so that they are in
     # the model before we deal with the objective function or the constraints.

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -18,7 +18,7 @@ _sort_priority(::MOI.AbstractModelAttribute) = 30.0
     pass_attributes(
         dest::MOI.ModelLike,
         src::MOI.ModelLike,
-        index_map::IndexMap,
+        index_map,
     )
 
 Pass the model attributes from the model `src` to the model `dest`.
@@ -26,7 +26,7 @@ Pass the model attributes from the model `src` to the model `dest`.
 function pass_attributes(
     dest::MOI.ModelLike,
     src::MOI.ModelLike,
-    index_map::IndexMap,
+    index_map,
 )
     attrs = MOI.get(src, MOI.ListOfModelAttributesSet())
     # We need to deal with the UserDefinedFunctions first, so that they are in
@@ -47,7 +47,7 @@ end
 function _pass_attribute(
     dest::MOI.ModelLike,
     src::MOI.ModelLike,
-    index_map::IndexMap,
+    index_map,
     attr::MOI.AbstractModelAttribute,
 )
     value = MOI.get(src, attr)
@@ -61,7 +61,7 @@ end
     pass_attributes(
         dest::MOI.ModelLike,
         src::MOI.ModelLike,
-        index_map::IndexMap,
+        index_map,
         vis_src::Vector{MOI.VariableIndex},
     )
 
@@ -70,7 +70,7 @@ Pass the variable attributes from the model `src` to the model `dest`.
 function pass_attributes(
     dest::MOI.ModelLike,
     src::MOI.ModelLike,
-    index_map::IndexMap,
+    index_map,
     vis_src::Vector{MOI.VariableIndex},
 )
     for attr in MOI.get(src, MOI.ListOfVariableAttributesSet())
@@ -87,7 +87,7 @@ end
 function _pass_attribute(
     dest::MOI.ModelLike,
     src::MOI.ModelLike,
-    index_map::IndexMap,
+    index_map,
     vis_src::Vector{MOI.VariableIndex},
     attr::MOI.AbstractVariableAttribute,
 )
@@ -109,7 +109,7 @@ end
     pass_attributes(
         dest::MOI.ModelLike,
         src::MOI.ModelLike,
-        index_map::IndexMap,
+        index_map,
         cis_src::Vector{MOI.ConstraintIndex{F,S}},
     ) where {F,S}
 
@@ -119,7 +119,7 @@ the model `dest`.
 function pass_attributes(
     dest::MOI.ModelLike,
     src::MOI.ModelLike,
-    index_map::IndexMap,
+    index_map,
     cis_src::Vector{MOI.ConstraintIndex{F,S}},
 ) where {F,S}
     for attr in MOI.get(src, MOI.ListOfConstraintAttributesSet{F,S}())
@@ -140,7 +140,7 @@ end
 function _pass_attribute(
     dest::MOI.ModelLike,
     src::MOI.ModelLike,
-    index_map::IndexMap,
+    index_map,
     cis_src::Vector{MOI.ConstraintIndex{F,S}},
     attr::MOI.AbstractConstraintAttribute,
 ) where {F,S}
@@ -241,7 +241,8 @@ end
     _copy_constraints(
         dest::MOI.ModelLike,
         src::MOI.ModelLike,
-        index_map::IndexMap,
+        index_map,
+        index_map_FS,
         cis_src::Vector{<:MOI.ConstraintIndex},
     )
 


### PR DESCRIPTION
In https://github.com/jump-dev/PolyJuMP.jl/pull/119, the mapping is between constraint indices of different types so it cannot be an `IndexMap` but it would be useful to call `pass_attributes`.
This PR would help fix the broken test added in https://github.com/jump-dev/PolyJuMP.jl/pull/119