### PR TITLE
Prep for v1.27.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.27.0"
+version = "1.27.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,19 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.27.1 (March 27, 2024)
+
+### Fixed
+
+ - Fixed passing non-`IndexMap` in [`Utilities.pass_attributes`](@ref) (#2458)
+ - Fixed getting `MOI.ListOfConstraintAttributesSet` for `VectorOfConstraints`
+   (#2459)
+
+### Other
+
+ - Updated `solver-tests.yml` (#2453) (#2455)
+ - Fixed path in error message (#2461)
+
 ## v1.27.0 (February 27, 2024)
 
 ### Added

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
- - Fixed passing non-`IndexMap` in [`Utilities.pass_attributes`](@ref) (#2458)
+ - Fixed passing non-`IndexMap` in `Utilities.pass_attributes` (#2458)
  - Fixed getting `MOI.ListOfConstraintAttributesSet` for `VectorOfConstraints`
    (#2459)
 


### PR DESCRIPTION
This could arguably be 1.28.0, but it feels too small to be a minor release, and the "new" features are really bug fixes.

## TODO

 - [x] #2459

## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/8442608082