### PR TITLE
Prep for v1.28.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.27.1"
+version = "1.27.2"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.27.2"
+version = "1.28.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,23 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.27.2 (April 9, 2024)
+
+### Fixed
+
+ - Fixed a correctness bug getting the set of a constraint that used both
+   variable and constraint bridges (#2464)
+ - Fixed `MethodError` in some bridges when called with `Complex`-valued
+   functions (#2468)
+ - Fixed reading MPS files that use `*` as the start of a name and not as a
+   comment (#2470)
+
+### Other
+
+ - Updated `solver-tests.yml` (#2465)
+ - Removed two unused methods from `MOI.Bridges` (#2466)
+ - Improved docstring of [`Utilities.shift_constant`](@ref) (#2467)
+
 ## v1.27.1 (March 27, 2024)
 
 ### Fixed

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,12 +7,12 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.27.2 (April 9, 2024)
+## v1.27.2 (April 11, 2024)
 
 ### Fixed
 
  - Fixed a correctness bug getting the set of a constraint that used both
-   variable and constraint bridges (#2464)
+   variable and constraint bridges (#2464), (#2472)
  - Fixed `MethodError` in some bridges when called with `Complex`-valued
    functions (#2468)
  - Fixed reading MPS files that use `*` as the start of a name and not as a
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Updated `solver-tests.yml` (#2465)
  - Removed two unused methods from `MOI.Bridges` (#2466)
- - Improved docstring of [`Utilities.shift_constant`](@ref) (#2467)
+ - Documentation updates (#2467), (#2473), (#2474)
 
 ## v1.27.1 (March 27, 2024)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixed a correctness bug getting the set of a constraint that used both
    variable and constraint bridges (#2464) (#2472)
  - Fixed `MethodError` in some bridges when called with `Complex`-valued
-   functions (#2468)
+   functions (#2468) (#2475)
  - Fixed reading MPS files that use `*` as the start of a name and not as a
    comment (#2470)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,12 +7,16 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.27.2 (April 11, 2024)
+## v1.28.0 (April 11, 2024)
+
+### Added
+
+ - Added [`Bridges.Constraint.ComplexNormInfinityToSecondOrderConeBridge`](@ref) (#2451)
 
 ### Fixed
 
  - Fixed a correctness bug getting the set of a constraint that used both
-   variable and constraint bridges (#2464), (#2472)
+   variable and constraint bridges (#2464) (#2472)
  - Fixed `MethodError` in some bridges when called with `Complex`-valued
    functions (#2468)
  - Fixed reading MPS files that use `*` as the start of a name and not as a
@@ -23,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Updated `solver-tests.yml` (#2465)
  - Removed two unused methods from `MOI.Bridges` (#2466)
  - Documentation updates (#2467), (#2473), (#2474)
+ - Simplify reading CBF files (#2476)
 
 ## v1.27.1 (March 27, 2024)
 


### PR DESCRIPTION
## TODO

 - [x] #2451
 - [x] #2470
 - [x] #2472
 - [x] #2473
 - [x] #2474
 - [x] #2475
 - [x] #2476
 - [x] #2477

## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/8607293206