### PR TITLE
[Bridges] error on set(_, ::ConstraintSet with variable and constraint bridges

### DIFF
--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1445,7 +1445,7 @@ function MOI.set(
     # into the set.
     if Variable.has_bridges(Variable.bridges(b))
         if is_bridged(b, ci)
-            # If ci is also ConstraintBridged, then we give up.
+            # If `ci` is also ConstraintBridged, then we give up as the current code path is known to contain unresolved issues, see https://github.com/jump-dev/MathOptInterface.jl/issues/2452
             throw(MOI.SetAttributeNotAllowed(attr))
         end
         func = MOI.get(b, MOI.ConstraintFunction(), ci)

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -1444,6 +1444,10 @@ function MOI.set(
     # mapped through the bridge substitution. This includes moving constants
     # into the set.
     if Variable.has_bridges(Variable.bridges(b))
+        if is_bridged(b, ci)
+            # If ci is also ConstraintBridged, then we give up.
+            throw(MOI.SetAttributeNotAllowed(attr))
+        end
         func = MOI.get(b, MOI.ConstraintFunction(), ci)
         # Updating the set will not modify the function, so we don't care about
         # the first argument. We only care about the new set.

--- a/test/Bridges/bridge_optimizer.jl
+++ b/test/Bridges/bridge_optimizer.jl
@@ -1257,10 +1257,10 @@ function test_2452()
     )
     @test MOI.get(dest.model, MOI.ConstraintSet(), ci) == MOI.Zeros(1)
     @test_throws(
-      MOI.SetAttributeNotAllowed,
-      MOI.set(dest, MOI.ConstraintSet(), index_map[c], set),
+        MOI.SetAttributeNotAllowed,
+        MOI.set(dest, MOI.ConstraintSet(), index_map[c], set),
     )
-  return
+    return
 end
 
 function test_issue_2452_with_constant()


### PR DESCRIPTION
Revisiting #2464 for another take at #2452. 

This time it definitely fixes the original MWE:
```Julia
(clarabel) pkg> st
Status `/private/tmp/clarabel/Project.toml`
  [61c947e1] Clarabel v0.7.1
  [4076af6c] JuMP v1.21.0
  [b8f27783] MathOptInterface v1.27.1 `~/.julia/dev/MathOptInterface`

julia> model = Model(Clarabel.Optimizer)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: Clarabel

julia> set_silent(model)

julia> @variable(model, x >= 1)
x

julia> @constraint(model, c, 2x == 3)
c : 2 x = 3

julia> optimize!(model)

julia> y = value(x)
1.4999999999999996

julia> b = normalized_rhs(c)
3.0

julia> set_normalized_rhs(c, b)

julia> optimize!(model)

julia> value(x)
1.4999999999999996
```

https://github.com/jump-dev/MathOptInterface.jl/blob/009004c527d4bdcddc9db8f552c3048bb2e5e8fd/src/Bridges/Constraint/bridges/vectorize.jl#L221-L225
calls
https://github.com/jump-dev/MathOptInterface.jl/blob/009004c527d4bdcddc9db8f552c3048bb2e5e8fd/src/Bridges/bridge_optimizer.jl#L2044-L2050
which calls 
https://github.com/jump-dev/MathOptInterface.jl/blob/009004c527d4bdcddc9db8f552c3048bb2e5e8fd/src/Bridges/bridge_optimizer.jl#L1992-L2003
but the issue is that we can't tell whether we're modifying from the user's perspective, or whether we're modifying the inner constraint.

I'm guessing we need some `call_in_context`, but I got confused, so I decided it's simpler just to punt for now and fix the correctness issue.