### PR TITLE
[FileFormats.MPS] fix reading default bounds of INTORG variables

### DIFF
--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -1472,6 +1472,8 @@ end
 function _set_intorg(data, column, column_name)
     if data.intorg_flag
         data.vtype[column] = VTYPE_INTEGER
+        # The default upper bound for variables in INTORG is `1`, not `Inf`...
+        data.col_upper[column] = 1.0
     elseif data.vtype[column] != VTYPE_CONTINUOUS
         error(
             "Variable $(column_name) appeared in COLUMNS outside an " *

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -191,6 +191,15 @@ function test_stacked_data()
     return
 end
 
+function test_integer_default_bounds()
+    model = MPS.Model()
+    MOI.read_from_file(model, joinpath(@__DIR__, "integer_default_bounds.mps"))
+    x = only(MOI.get(model, MOI.ListOfVariableIndices()))
+    ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.Interval{Float64}}(x.value)
+    @test MOI.get(model, MOI.ConstraintSet(), ci) == MOI.Interval(0.0, 1.0)
+    return
+end
+
 function test_free_integer()
     model = MPS.Model()
     MOI.read_from_file(model, joinpath(@__DIR__, "free_integer.mps"))

--- a/test/FileFormats/MPS/integer_default_bounds.mps
+++ b/test/FileFormats/MPS/integer_default_bounds.mps
@@ -1,0 +1,11 @@
+NAME
+OBJSENSE MIN
+ROWS
+ N  obj
+COLUMNS
+    MARKER    'MARKER'                 'INTORG'
+    x         obj       1
+    MARKER    'MARKER'                 'INTEND'
+RHS
+BOUNDS
+ENDATA


### PR DESCRIPTION
Closes #2479 