### PR TITLE
Add Variable bridges to use runtests without unbridged_variable

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -247,7 +247,7 @@ Run a series of tests that check the correctness of `Bridge`.
 and `output_fn(model)` load the corresponding model into `model`.
 
 Set `cannot_unbridge` to `true` if the bridge is a variable bridge
-that does not supports [`Variable.unbridged_function`](@ref) so that
+for which [`Variable.unbridged_map`](@ref) returns `nothing` so that
 the tests allow errors that can be raised due to this.
 
 ## Example

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -144,7 +144,11 @@ MOI.get_fallback(model::MOI.ModelLike, ::ListOfNonstandardBridges) = Type[]
 
 include("precompile.jl")
 
-function _test_structural_identical(a::MOI.ModelLike, b::MOI.ModelLike; allow_constraint_function_error::Bool = false)
+function _test_structural_identical(
+    a::MOI.ModelLike,
+    b::MOI.ModelLike;
+    allow_constraint_function_error::Bool = false,
+)
     # Test that the variables are the same. We make the strong assumption that
     # the variables are added in the same order to both models.
     a_x = MOI.get(a, MOI.ListOfVariableIndices())
@@ -193,7 +197,8 @@ function _test_structural_identical(a::MOI.ModelLike, b::MOI.ModelLike; allow_co
             try
                 f_b = MOI.get(b, MOI.ConstraintFunction(), ci)
             catch err
-                if allow_constraint_function_error && err isa MOI.GetAttributeNotAllowed{MOI.ConstraintFunction}
+                if allow_constraint_function_error &&
+                   err isa MOI.GetAttributeNotAllowed{MOI.ConstraintFunction}
                     continue
                 else
                     rethrow(err)
@@ -276,7 +281,11 @@ function runtests(
     # Load a non-bridged input model, and check that getters are the same.
     test = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{eltype}())
     input_fn(test)
-    _test_structural_identical(test, model; allow_constraint_function_error = allow_outer_constraint_function_error)
+    _test_structural_identical(
+        test,
+        model;
+        allow_constraint_function_error = allow_outer_constraint_function_error,
+    )
     # Load a bridged target model, and check that getters are the same.
     target = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{eltype}())
     output_fn(target)

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -247,7 +247,7 @@ Run a series of tests that check the correctness of `Bridge`.
 and `output_fn(model)` load the corresponding model into `model`.
 
 Set `cannot_unbridge` to `true` if the bridge is a variable bridge
-that does not supports [`Variables.unbridged_func`](@ref) so that
+that does not supports [`Variable.unbridged_func`](@ref) so that
 the tests allow errors that can be raised due to this.
 
 ## Example
@@ -286,11 +286,7 @@ function runtests(
     # Load a non-bridged input model, and check that getters are the same.
     test = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{eltype}())
     input_fn(test)
-    _test_structural_identical(
-        test,
-        model;
-        cannot_unbridge = cannot_unbridge,
-    )
+    _test_structural_identical(test, model; cannot_unbridge = cannot_unbridge)
     # Load a bridged target model, and check that getters are the same.
     target = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{eltype}())
     output_fn(target)

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -247,7 +247,7 @@ Run a series of tests that check the correctness of `Bridge`.
 and `output_fn(model)` load the corresponding model into `model`.
 
 Set `cannot_unbridge` to `true` if the bridge is a variable bridge
-that does not supports [`Variable.unbridged_func`](@ref) so that
+that does not supports [`Variable.unbridged_function`](@ref) so that
 the tests allow errors that can be raised due to this.
 
 ## Example

--- a/test/Bridges/Variable/zeros.jl
+++ b/test/Bridges/Variable/zeros.jl
@@ -28,10 +28,18 @@ function test_runtests()
         MOI.Bridges.Variable.ZerosBridge,
         model -> begin
             x, _ = MOI.add_constrained_variables(model, MOI.Zeros(2))
-            MOI.add_constraint(model, 1.0 * x[1] + 2.0 * x[2], MOI.EqualTo(3.0))
+            MOI.add_constraint(
+                model,
+                1.0 * x[1] + 2.0 * x[2],
+                MOI.EqualTo(3.0),
+            )
         end,
         model -> begin
-            MOI.add_constraint(model, zero(MOI.ScalarAffineFunction{Float64}), MOI.EqualTo(3.0))
+            MOI.add_constraint(
+                model,
+                zero(MOI.ScalarAffineFunction{Float64}),
+                MOI.EqualTo(3.0),
+            )
         end;
         cannot_unbridge = true,
     )

--- a/test/Bridges/Variable/zeros.jl
+++ b/test/Bridges/Variable/zeros.jl
@@ -23,6 +23,21 @@ end
 
 include("../utilities.jl")
 
+function test_runtests()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Variable.ZerosBridge,
+        model -> begin
+            x, _ = MOI.add_constrained_variables(model, MOI.Zeros(2))
+            MOI.add_constraint(model, 1.0 * x[1] + 2.0 * x[2], MOI.EqualTo(3.0))
+        end,
+        model -> begin
+            MOI.add_constraint(model, zero(MOI.ScalarAffineFunction{Float64}), MOI.EqualTo(3.0))
+        end;
+        cannot_unbridge = true,
+    )
+    return
+end
+
 function test_zeros()
     mock = MOI.Utilities.MockOptimizer(MOI.Utilities.Model{Float64}())
     bridged_mock = MOI.Bridges.Variable.Zeros{Float64}(mock)


### PR DESCRIPTION
Some variable bridges don't support `unbridged_variable` and that makes `runtests` fail when getting `ConstraintFunction` or when getting `ConstraintSet` for scalar constraints. For example, `ZerosBridge` does not support it so it cannot use `runtests`.
Another example is the SOS cone: https://github.com/jump-dev/SumOfSquares.jl/pull/353 I could support it in the nonweighted version but if it's weighted by arbitrary polynomials, it seems difficult to unbridge. It might be possible but it's not high priority. By using only vector cones in the tests, it turns out that only this small change is enough to pass the tests. This is still testing the inner model completely.

- [x] Explain in docstring why this is used for
- [x] Use it for `ZerosBridge` by adding a tests without scalar sets