### PR TITLE
Fix Bridges.runtests when model has no variable

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -283,7 +283,10 @@ function runtests(
         Test.@test all(isnothing, MOI.get(model, attr, x))
         primal_start = fill(constraint_start, length(x))
         MOI.set(model, attr, x, primal_start)
-        Test.@test MOI.get(model, attr, x) ≈ primal_start
+        if !isempty(x)
+            # ≈ does not work if x is empty because the return of get is Any[]
+            Test.@test MOI.get(model, attr, x) ≈ primal_start
+        end
     end
     # Test ConstraintPrimalStart and ConstraintDualStart
     for (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
@@ -295,7 +298,11 @@ function runtests(
                     Test.@test MOI.get(model, attr, ci) === nothing
                     start = _fake_start(constraint_start, set)
                     MOI.set(model, attr, ci, start)
-                    Test.@test MOI.get(model, attr, ci) ≈ start
+                    if !isempty(ci)
+                        # ≈ does not work if ci is empty because the return of
+                        # get is Any[]
+                        Test.@test MOI.get(model, attr, ci) ≈ start
+                    end
                 end
             end
         end

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -277,8 +277,9 @@ function runtests(
     bridge_supported = all(values(Variable.bridges(model))) do bridge
         return MOI.supports(model, attr, typeof(bridge))
     end
-    if MOI.supports(model, attr, MOI.VariableIndex) && bridge_supported &&
-        MOI.get(model, MOI.NumberOfVariables()) > 0
+    if MOI.supports(model, attr, MOI.VariableIndex) &&
+       bridge_supported &&
+       MOI.get(model, MOI.NumberOfVariables()) > 0
         x = MOI.get(model, MOI.ListOfVariableIndices())
         MOI.set(model, attr, x, fill(nothing, length(x)))
         Test.@test all(isnothing, MOI.get(model, attr, x))

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -277,7 +277,8 @@ function runtests(
     bridge_supported = all(values(Variable.bridges(model))) do bridge
         return MOI.supports(model, attr, typeof(bridge))
     end
-    if MOI.supports(model, attr, MOI.VariableIndex) && bridge_supported
+    if MOI.supports(model, attr, MOI.VariableIndex) && bridge_supported &&
+        MOI.get(model, MOI.NumberOfVariables()) > 0
         x = MOI.get(model, MOI.ListOfVariableIndices())
         MOI.set(model, attr, x, fill(nothing, length(x)))
         Test.@test all(isnothing, MOI.get(model, attr, x))

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -277,9 +277,7 @@ function runtests(
     bridge_supported = all(values(Variable.bridges(model))) do bridge
         return MOI.supports(model, attr, typeof(bridge))
     end
-    if MOI.supports(model, attr, MOI.VariableIndex) &&
-       bridge_supported &&
-       MOI.get(model, MOI.NumberOfVariables()) > 0
+    if MOI.supports(model, attr, MOI.VariableIndex) && bridge_supported
         x = MOI.get(model, MOI.ListOfVariableIndices())
         MOI.set(model, attr, x, fill(nothing, length(x)))
         Test.@test all(isnothing, MOI.get(model, attr, x))

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -298,11 +298,7 @@ function runtests(
                     Test.@test MOI.get(model, attr, ci) === nothing
                     start = _fake_start(constraint_start, set)
                     MOI.set(model, attr, ci, start)
-                    if !isempty(ci)
-                        # ≈ does not work if ci is empty because the return of
-                        # get is Any[]
-                        Test.@test MOI.get(model, attr, ci) ≈ start
-                    end
+                    Test.@test MOI.get(model, attr, ci) ≈ start
                 end
             end
         end

--- a/test/Bridges/Constraint/flip_sign.jl
+++ b/test/Bridges/Constraint/flip_sign.jl
@@ -438,8 +438,16 @@ function test_runtests()
     )
     MOI.Bridges.runtests(
         MOI.Bridges.Constraint.GreaterToLessBridge,
-        model -> MOI.add_constraint(model, zero(MOI.ScalarAffineFunction{Float64}), MOI.GreaterThan(1.0)),
-        model -> MOI.add_constraint(model, zero(MOI.ScalarAffineFunction{Float64}), MOI.LessThan(-1.0)),
+        model -> MOI.add_constraint(
+            model,
+            zero(MOI.ScalarAffineFunction{Float64}),
+            MOI.GreaterThan(1.0),
+        ),
+        model -> MOI.add_constraint(
+            model,
+            zero(MOI.ScalarAffineFunction{Float64}),
+            MOI.LessThan(-1.0),
+        ),
     )
     return
 end

--- a/test/Bridges/Constraint/flip_sign.jl
+++ b/test/Bridges/Constraint/flip_sign.jl
@@ -436,6 +436,11 @@ function test_runtests()
         VectorNonlinearFunction([-(2.1 * x - 1.0)]) in Nonnegatives(1)
         """,
     )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.GreaterToLessBridge,
+        model -> MOI.add_constraint(model, zero(MOI.ScalarAffineFunction{Float64}), MOI.GreaterThan(1.0)),
+        model -> MOI.add_constraint(model, zero(MOI.ScalarAffineFunction{Float64}), MOI.LessThan(-1.0)),
+    )
     return
 end
 


### PR DESCRIPTION
Needed for https://github.com/jump-dev/SumOfSquares.jl/pull/296

- [x] Needs tests

Without the fix of this PR, the added tests throws
```julia
test_runtests: Error During Test at /home/blegat/.julia/dev/MathOptInterface/src/Bridges/Bridges.jl:286
  Test threw exception
  Expression: MOI.get(model, attr, x) ≈ primal_start
  MethodError: no method matching zero(::Type{Any})
  
  Closest candidates are:
    zero(::Type{Union{Missing, T}}) where T
     @ Base missing.jl:105
    zero(::Type{Union{}}, Any...)
     @ Base number.jl:310
    zero(::Type{Missing})
     @ Base missing.jl:104
    ...
  
  Stacktrace:
   [1] zero(::Type{Any})
     @ Base ./missing.jl:106
   [2] norm(itr::Vector{Any}, p::Int64)
     @ LinearAlgebra ~/.julia/juliaup/julia-1.10.3+0.x64.linux.gnu/share/julia/stdlib/v1.10/LinearAlgebra/src/generic.jl:596
   [3] isapprox(x::Vector{Any}, y::Vector{Float64}; atol::Int64, rtol::Float64, nans::Bool, norm::typeof(LinearAlgebra.norm))
     @ LinearAlgebra ~/.julia/juliaup/julia-1.10.3+0.x64.linux.gnu/share/julia/stdlib/v1.10/LinearAlgebra/src/generic.jl:1789
   [4] isapprox(x::Vector{Any}, y::Vector{Float64})
     @ LinearAlgebra ~/.julia/juliaup/julia-1.10.3+0.x64.linux.gnu/share/julia/stdlib/v1.10/LinearAlgebra/src/generic.jl:1785
   [5] eval_test(evaluated::Expr, quoted::Expr, source::LineNumberNode, negate::Bool)
     @ Test ~/.julia/juliaup/julia-1.10.3+0.x64.linux.gnu/share/julia/stdlib/v1.10/Test/src/Test.jl:355
   [6] macro expansion
     @ ~/.julia/juliaup/julia-1.10.3+0.x64.linux.gnu/share/julia/stdlib/v1.10/Test/src/Test.jl:669 [inlined]
   [7] runtests(Bridge::Type{MathOptInterface.Bridges.Constraint.GreaterToLessBridge}, input_fn::Main.TestConstraintFlipSign.var"#59#61", output_fn::Main.TestConstraintFlipSign.var"#60#62"; variable_start::Float64, constraint_start::Float64, eltype::Type, print_inner_model::Bool)
     @ MathOptInterface.Bridges ~/.julia/dev/MathOptInterface/src/Bridges/Bridges.jl:286
```