### PR TITLE
[docs] fix links for the link checker

### DIFF
--- a/docs/src/background/naming_conventions.md
+++ b/docs/src/background/naming_conventions.md
@@ -29,6 +29,6 @@ following conventions:
   not `Integers`.
 * As much as possible, the names should follow established conventions in the
   domain where this set is used: for instance, convex sets should have names
-  close to those of [CVX](http://web.cvxr.com/cvx/doc/), and
+  close to those of [CVX](https://web.cvxr.com/cvx/doc/), and
   constraint-programming sets should follow
   [MiniZinc](https://www.minizinc.org/doc-latest/en/)'s constraints.

--- a/docs/src/submodules/FileFormats/overview.md
+++ b/docs/src/submodules/FileFormats/overview.md
@@ -58,9 +58,8 @@ julia> model = MOI.FileFormats.Model(format = MOI.FileFormats.FORMAT_REW)
 A Mathematical Programming System (MPS) model
 ```
 
-Note that the [REW format](https://www.gurobi.com/documentation/current/refman/rew_format.html)
-is identical to the MPS file format, except that all names are replaced with
-generic identifiers.
+Note that the REW format is identical to the MPS file format, except that all
+names are replaced with generic identifiers.
 
 **The SDPA file format**
 

--- a/docs/src/submodules/FileFormats/overview.md
+++ b/docs/src/submodules/FileFormats/overview.md
@@ -58,7 +58,7 @@ julia> model = MOI.FileFormats.Model(format = MOI.FileFormats.FORMAT_REW)
 A Mathematical Programming System (MPS) model
 ```
 
-Note that the [REW format](https://www.gurobi.com/documentation/9.5/refman/rew_format.html)
+Note that the [REW format](https://www.gurobi.com/documentation/current/refman/rew_format.html)
 is identical to the MPS file format, except that all names are replaced with
 generic identifiers.
 


### PR DESCRIPTION
Current builds of the documentation are failing because the link checker is timing out.