### PR TITLE
[Bridges] fix supports_constraint for IndicatorSOS1Bridge

### DIFF
--- a/src/Bridges/Constraint/bridges/indicator_sos.jl
+++ b/src/Bridges/Constraint/bridges/indicator_sos.jl
@@ -60,10 +60,10 @@ function bridge_constraint(
 end
 
 function MOI.supports_constraint(
-    ::Type{<:IndicatorSOS1Bridge},
-    ::Type{<:MOI.AbstractVectorFunction},
+    ::Type{<:IndicatorSOS1Bridge{T}},
+    ::Type{MOI.VectorAffineFunction{T}},
     ::Type{<:MOI.Indicator{MOI.ACTIVATE_ON_ONE,<:MOI.AbstractScalarSet}},
-)
+) where {T}
     return true
 end
 

--- a/src/Bridges/Constraint/bridges/indicator_sos.jl
+++ b/src/Bridges/Constraint/bridges/indicator_sos.jl
@@ -113,7 +113,7 @@ end
 
 function concrete_bridge_type(
     ::Type{<:IndicatorSOS1Bridge{T}},
-    ::Type{<:MOI.AbstractVectorFunction},
+    ::Type{MOI.VectorAffineFunction{T}},
     ::Type{MOI.Indicator{MOI.ACTIVATE_ON_ONE,S}},
 ) where {T,S}
     return IndicatorSOS1Bridge{T,S}

--- a/test/Bridges/Constraint/indicator_sos.jl
+++ b/test/Bridges/Constraint/indicator_sos.jl
@@ -332,6 +332,20 @@ function test_runtests()
         [y, z] in SOS1([0.4, 0.6])
         """,
     )
+    # Test that the bridge does nothing for VectorQuadraticFunctions
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.IndicatorSOS1Bridge,
+        """
+        variables: x, z
+        [z, 2.0 * x * x] in Indicator{ACTIVATE_ON_ONE}(LessThan(2.0))
+        z in ZeroOne()
+        """,
+        """
+        variables: x, z
+        [z, 2.0 * x * x] in Indicator{ACTIVATE_ON_ONE}(LessThan(2.0))
+        z in ZeroOne()
+        """,
+    )
     return
 end
 


### PR DESCRIPTION
Closes #2506

This now results in the expected:
```julia
julia> using JuMP, HiGHS

julia> model = Model(HiGHS.Optimizer)
A JuMP Model
Feasibility problem with:
Variables: 0
Model mode: AUTOMATIC
CachingOptimizer state: EMPTY_OPTIMIZER
Solver name: HiGHS

julia> @variable(model, x)
x

julia> @variable(model, z, Bin)
z

julia> @constraint(model, z --> {x * z == 0})
ERROR: Constraints of type MathOptInterface.VectorQuadraticFunction{Float64}-in-MathOptInterface.Indicator{MathOptInterface.ACTIVATE_ON_ONE, MathOptInterface.EqualTo{Float64}} are not supported by the solver.

If you expected the solver to support your problem, you may have an error in your formulation. Otherwise, consider using a different solver.

The list of available solvers, along with the problem types they support, is available at https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers.
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] _moi_add_constraint(model::MathOptInterface.Utilities.CachingOptimizer{…}, f::MathOptInterface.VectorQuadraticFunction{…}, s::MathOptInterface.Indicator{…})
   @ JuMP ~/.julia/packages/JuMP/Gwn88/src/constraints.jl:686
 [3] add_constraint(model::Model, con::VectorConstraint{QuadExpr, MathOptInterface.Indicator{…}, VectorShape}, name::String)
   @ JuMP ~/.julia/packages/JuMP/Gwn88/src/constraints.jl:713
 [4] macro expansion
   @ ~/.julia/packages/JuMP/Gwn88/src/macros/@constraint.jl:133 [inlined]
 [5] macro expansion
   @ ~/.julia/packages/JuMP/Gwn88/src/macros.jl:393 [inlined]
 [6] top-level scope
   @ REPL[6]:1
Some type information was truncated. Use `show(err)` to see complete types.
```