### PR TITLE
Allow SetMapBridge to use bridge value

### DIFF
--- a/docs/src/submodules/Bridges/reference.md
+++ b/docs/src/submodules/Bridges/reference.md
@@ -90,6 +90,7 @@ Bridges.debug_supports
 ## [SetMap API](@id constraint_set_map)
 
 ```@docs
+Bridges.MapNotInvertible
 Bridges.map_set
 Bridges.inverse_map_set
 Bridges.map_function

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -102,7 +102,7 @@ function MOI.get(
     bridge::MultiSetMapBridge{T,S1,G},
 ) where {T,S1,G}
     mapped_func = MOI.get(model, attr, bridge.constraint)
-    func = MOI.Bridges.inverse_map_function(typeof(bridge), mapped_func)
+    func = MOI.Bridges.inverse_map_function(bridge, mapped_func)
     return MOI.Utilities.convert_approx(G, func)
 end
 
@@ -146,7 +146,7 @@ function MOI.get(
     if value === nothing
         return nothing
     end
-    return MOI.Bridges.inverse_map_function(typeof(bridge), value)
+    return MOI.Bridges.inverse_map_function(bridge, value)
 end
 
 function MOI.set(
@@ -173,7 +173,7 @@ function MOI.get(
     if value === nothing
         return nothing
     end
-    return MOI.Bridges.adjoint_map_function(typeof(bridge), value)
+    return MOI.Bridges.adjoint_map_function(bridge, value)
 end
 
 function MOI.set(
@@ -185,7 +185,7 @@ function MOI.set(
     if value === nothing
         MOI.set(model, attr, bridge.constraint, nothing)
     else
-        mapped_value = MOI.Bridges.inverse_adjoint_map_function(BT, value)
+        mapped_value = MOI.Bridges.inverse_adjoint_map_function(bridge, value)
         MOI.set(model, attr, bridge.constraint, mapped_value)
     end
     return

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -102,7 +102,15 @@ function MOI.get(
     bridge::MultiSetMapBridge{T,S1,G},
 ) where {T,S1,G}
     mapped_func = MOI.get(model, attr, bridge.constraint)
-    func = MOI.Bridges.inverse_map_function(bridge, mapped_func)
+    func = try
+        MOI.Bridges.inverse_map_function(bridge, mapped_func)
+    catch err
+        if err isa MOI.Bridges.MapNotInvertible
+            throw(MOI.GetAttributeNotAllowed(attr))
+        else
+            rethrow(err)
+        end
+    end
     return MOI.Utilities.convert_approx(G, func)
 end
 
@@ -146,7 +154,16 @@ function MOI.get(
     if value === nothing
         return nothing
     end
-    return MOI.Bridges.inverse_map_function(bridge, value)
+    return try
+        MOI.Bridges.inverse_map_function(bridge, value)
+    catch err
+        if err isa MOI.Bridges.MapNotInvertible
+            throw(MOI.GetAttributeNotAllowed(attr))
+        else
+            rethrow(err)
+        end
+    end
+
 end
 
 function MOI.set(

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -102,10 +102,10 @@ end
 # back to using the cache.
 function _not_invertible_error_message(attr, message)
     s = "Cannot get `$attr` as the constraint is reformulated through a linear transformation that is not invertible."
-    if !isempty(message)
-        s *= " " * message
+    if isempty(message)
+        return s
     end
-    return s
+    return s * " " * message
 end
 
 function MOI.get(
@@ -118,7 +118,8 @@ function MOI.get(
         MOI.Bridges.inverse_map_function(bridge, mapped_func)
     catch err
         if err isa MOI.Bridges.MapNotInvertible
-            throw(MOI.GetAttributeNotAllowed(attr, _not_invertible_error_message(attr, err.message)))
+            msg = _not_invertible_error_message(attr, err.message)
+            throw(MOI.GetAttributeNotAllowed(attr, msg))
         end
         rethrow(err)
     end
@@ -172,7 +173,8 @@ function MOI.get(
         # the function. The user doesn't need to know this, only that they
         # cannot get the attribute.
         if err isa MOI.Bridges.MapNotInvertible
-            throw(MOI.GetAttributeNotAllowed(attr, _not_invertible_error_message(attr, err.message)))
+            msg = _not_invertible_error_message(attr, err.message)
+            throw(MOI.GetAttributeNotAllowed(attr, msg))
         end
         rethrow(err)
     end
@@ -218,7 +220,8 @@ function MOI.set(
             MOI.Bridges.inverse_adjoint_map_function(bridge, value)
         catch err
             if err isa MOI.Bridges.MapNotInvertible
-                throw(MOI.SetAttributeNotAllowed(attr, _not_invertible_error_message(attr, err.message)))
+                msg = _not_invertible_error_message(attr, err.message)
+                throw(MOI.SetAttributeNotAllowed(attr, msg))
             end
             rethrow(err)
         end

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -96,17 +96,16 @@ end
 
 # Attributes, Bridge acting as a constraint
 
-# MapNotInvertible is thrown if the bridge does not support inverting
-# the function. The user doesn't need to know this, only that they
-# cannot get the attribute. Throwing `GetAttributeNotAllowed` allows
-# `CachingOptimizer` to fall back to using the cache
+# MapNotInvertible is thrown if the bridge does not support inverting the
+# function. The user doesn't need to know this, only that they cannot get the
+# attribute. Throwing `GetAttributeNotAllowed` allows `CachingOptimizer` to fall
+# back to using the cache.
 function _not_invertible_error(attr, message)
-    s = "Cannot get $attr as the constraint is reformulated through" *
-        " a linear transformation that is not invertible." * message
+    s = "Cannot get $attr as the constraint is reformulated through a linear transformation that is not invertible."
     if !isempty(message)
         s *= " " * message
     end
-    throw(MOI.GetAttributeNotAllowed(attr, s))
+    return MOI.GetAttributeNotAllowed(attr, s)
 end
 
 function MOI.get(
@@ -119,7 +118,7 @@ function MOI.get(
         MOI.Bridges.inverse_map_function(bridge, mapped_func)
     catch err
         if err isa MOI.Bridges.MapNotInvertible
-            _not_invertible_error(attr, err.message)
+            throw(_not_invertible_error(attr, err.message))
         end
         rethrow(err)
     end

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -163,7 +163,6 @@ function MOI.get(
             rethrow(err)
         end
     end
-
 end
 
 function MOI.set(

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -101,11 +101,7 @@ end
 # attribute. Throwing `GetAttributeNotAllowed` allows `CachingOptimizer` to fall
 # back to using the cache.
 function _not_invertible_error_message(attr, message)
-    s = "Cannot get `$attr` as the constraint is reformulated through a linear transformation that is not invertible."
-    if isempty(message)
-        return s
-    end
-    return s * " " * message
+    return "Cannot get `$attr` as the constraint is reformulated through a linear transformation that is not invertible. $message"
 end
 
 function MOI.get(

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -105,11 +105,13 @@ function MOI.get(
     func = try
         MOI.Bridges.inverse_map_function(bridge, mapped_func)
     catch err
+        # MapNotInvertible is thrown if the bridge does not support inverting
+        # the function. The user doesn't need to know this, only that they
+        # cannot get the attribute.
         if err isa MOI.Bridges.MapNotInvertible
             throw(MOI.GetAttributeNotAllowed(attr))
-        else
-            rethrow(err)
         end
+        rethrow(err)
     end
     return MOI.Utilities.convert_approx(G, func)
 end
@@ -154,14 +156,16 @@ function MOI.get(
     if value === nothing
         return nothing
     end
-    return try
-        MOI.Bridges.inverse_map_function(bridge, value)
+    try
+        return MOI.Bridges.inverse_map_function(bridge, value)
     catch err
+        # MapNotInvertible is thrown if the bridge does not support inverting
+        # the function. The user doesn't need to know this, only that they
+        # cannot get the attribute.
         if err isa MOI.Bridges.MapNotInvertible
             throw(MOI.GetAttributeNotAllowed(attr))
-        else
-            rethrow(err)
         end
+        rethrow(err)
     end
 end
 

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -5,14 +5,18 @@
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
 """
-    struct MapNotInvertible <: Exception end
+    struct MapNotInvertible <: Exception
+        message::String
+    end
 
 An error thrown by [`inverse_map_function`](@ref) or
 [`inverse_adjoint_map_function`](@ref) indicating that the linear map `A`
 defined in [`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref)
 is not invertible.
 """
-struct MapNotInvertible <: Exception end
+struct MapNotInvertible <: Exception
+    message::String
+end
 
 """
     map_set(::Type{BT}, set) where {BT}

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -29,13 +29,21 @@ the [`MOI.ConstraintSet`](@ref).
 function map_set end
 
 """
+    inverse_map_set(bridge::MOI.Bridges.AbstractBridge, set)
     inverse_map_set(::Type{BT}, set) where {BT}
 
 Return the preimage of `set` through the linear map `A` defined in
-[`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
-used for getting the [`MOI.ConstraintSet`](@ref).
+[`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref).
+
+This function is used for getting the [`MOI.ConstraintSet`](@ref).
+
+The method can alternatively be defined on the bridge type. This legacy
+interface is kept for backward compatibility.
 """
-function inverse_map_set end
+function inverse_map_set(bridge::AbstractBridge, set)
+    return map_function(typeof(bridge), set)
+end
+
 
 """
     map_function(bridge::MOI.Bridges.AbstractBridge, func)

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -4,6 +4,14 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
+"""
+    struct MapNotInvertible <: Exception end
+
+An error thrown by [`inverse_map_function`](@ref) or
+[`inverse_adjoint_map_function`](@ref) indicating that the linear map `A`
+defined in [`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref)
+is not invertible.
+"""
 struct MapNotInvertible <: Exception end
 
 """
@@ -55,7 +63,7 @@ function map_function(::Type{BT}, func, i::IndexInVector) where {BT}
 end
 
 """
-    inverse_map_function(::Type{BT}, func) where {BT}
+    inverse_map_function(bridge::MOI.Bridges.AbstractBridge, func)
 
 Return the image of `func` through the inverse of the linear map `A` defined in
 [`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
@@ -64,6 +72,13 @@ used by [`Variable.unbridged_map`](@ref) and for setting the
 and for getting the [`MOI.ConstraintFunction`](@ref),
 the [`MOI.ConstraintPrimal`](@ref) and the
 [`MOI.ConstraintPrimalStart`](@ref) of constraint bridges.
+If the linear map `A` is not invertible, the error [`MapNotInvertible`](@ref) is
+thrown.
+
+    inverse_map_function(::Type{BT}, func) where {BT}
+
+The method can alternatively be defined on the bridge type. This legacy
+interface is kept for backward compatibility.
 """
 function inverse_map_function end
 
@@ -72,12 +87,17 @@ function inverse_map_function(bridge::AbstractBridge, func)
 end
 
 """
-    adjoint_map_function(::Type{BT}, func) where {BT}
+    adjoint_map_function(bridge::MOI.Bridges.AbstractBridge, func)
 
 Return the image of `func` through the adjoint of the linear map `A` defined in
 [`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
 used for getting the [`MOI.ConstraintDual`](@ref) and
 [`MOI.ConstraintDualStart`](@ref) of constraint bridges.
+
+    adjoint_map_function(::Type{BT}, func) where {BT}
+
+The method can alternatively be defined on the bridge type. This legacy
+interface is kept for backward compatibility.
 """
 function adjoint_map_function end
 
@@ -86,13 +106,20 @@ function adjoint_map_function(bridge::AbstractBridge, func)
 end
 
 """
-    inverse_adjoint_map_function(::Type{BT}, func) where {BT}
+    inverse_adjoint_map_function(bridge::MOI.Bridges.AbstractBridge, func)
 
 Return the image of `func` through the inverse of the adjoint of the linear map
 `A` defined in [`Variable.SetMapBridge`](@ref) and
 [`Constraint.SetMapBridge`](@ref). This is used for getting the
 [`MOI.ConstraintDual`](@ref) of variable bridges and setting the
 [`MOI.ConstraintDualStart`](@ref) of constraint bridges.
+If the linear map `A` is not invertible, the error [`MapNotInvertible`](@ref) is
+thrown.
+
+    inverse_adjoint_map_function(::Type{BT}, func) where {BT}
+
+The method can alternatively be defined on the bridge type. This legacy
+interface is kept for backward compatibility.
 """
 function inverse_adjoint_map_function end
 

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -19,14 +19,19 @@ struct MapNotInvertible <: Exception
 end
 
 """
+    map_set(bridge::MOI.Bridges.AbstractBridge, set)
     map_set(::Type{BT}, set) where {BT}
 
 Return the image of `set` through the linear map `A` defined in
-[`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
-used for bridging the constraint and setting
-the [`MOI.ConstraintSet`](@ref).
+[`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref).
+
+This function is used for bridging the constraint and setting the
+[`MOI.ConstraintSet`](@ref).
+
+The method can alternatively be defined on the bridge type. This legacy
+interface is kept for backward compatibility.
 """
-function map_set end
+map_set(bridge::AbstractBridge, set) = map_set(typeof(bridge), set)
 
 """
     inverse_map_set(bridge::MOI.Bridges.AbstractBridge, set)

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -41,9 +41,8 @@ The method can alternatively be defined on the bridge type. This legacy
 interface is kept for backward compatibility.
 """
 function inverse_map_set(bridge::AbstractBridge, set)
-    return map_function(typeof(bridge), set)
+    return inverse_map_set(typeof(bridge), set)
 end
-
 
 """
     map_function(bridge::MOI.Bridges.AbstractBridge, func)

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -4,6 +4,8 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
+struct MapNotInvertible <: Exception end
+
 """
     map_set(::Type{BT}, set) where {BT}
 
@@ -43,6 +45,10 @@ the [`MOI.VariablePrimal`](@ref) and
 [`MOI.VariablePrimalStart`](@ref) of variable bridges.
 """
 function map_function end
+
+function map_function(bridge::AbstractBridge, func)
+    return map_function(typeof(bridge), func)
+end
 
 function map_function(::Type{BT}, func, i::IndexInVector) where {BT}
     return MOI.Utilities.eachscalar(map_function(BT, func))[i.value]

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -28,8 +28,10 @@ Return the image of `set` through the linear map `A` defined in
 This function is used for bridging the constraint and setting the
 [`MOI.ConstraintSet`](@ref).
 
-The method can alternatively be defined on the bridge type. This legacy
-interface is kept for backward compatibility.
+The default implementation of [`Variable.bridge_constraint`](@ref) uses
+[`map_set`](@ref) with the bridge type so if this function is defined
+on the bridge type, [`Variable.bridge_constraint`](@ref) does not need
+to be implemented.
 """
 map_set(bridge::AbstractBridge, set) = map_set(typeof(bridge), set)
 
@@ -61,8 +63,10 @@ bridges. For constraint bridges, this is used for bridging the constraint,
 setting the [`MOI.ConstraintFunction`](@ref) and [`MOI.ConstraintPrimalStart`](@ref)
 and modifying the function with [`MOI.modify`](@ref).
 
-The method can alternatively be defined on the bridge type. This legacy
-interface is kept for backward compatibility.
+The default implementation of [`Constraint.bridge_constraint`](@ref) uses
+[`map_function`](@ref) with the bridge type so if this function is defined
+on the bridge type, [`Constraint.bridge_constraint`](@ref) does not need
+to be implemented.
 """
 function map_function(bridge::AbstractBridge, func)
     return map_function(typeof(bridge), func)

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -61,6 +61,10 @@ the [`MOI.ConstraintPrimal`](@ref) and the
 """
 function inverse_map_function end
 
+function inverse_map_function(bridge::AbstractBridge, func)
+    return inverse_map_function(typeof(bridge), func)
+end
+
 """
     adjoint_map_function(::Type{BT}, func) where {BT}
 
@@ -70,6 +74,10 @@ used for getting the [`MOI.ConstraintDual`](@ref) and
 [`MOI.ConstraintDualStart`](@ref) of constraint bridges.
 """
 function adjoint_map_function end
+
+function adjoint_map_function(bridge::AbstractBridge, func)
+    return adjoint_map_function(typeof(bridge), func)
+end
 
 """
     inverse_adjoint_map_function(::Type{BT}, func) where {BT}
@@ -81,3 +89,7 @@ Return the image of `func` through the inverse of the adjoint of the linear map
 [`MOI.ConstraintDualStart`](@ref) of constraint bridges.
 """
 function inverse_adjoint_map_function end
+
+function inverse_adjoint_map_function(bridge::AbstractBridge, func)
+    return inverse_adjoint_map_function(typeof(bridge), func)
+end

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -27,11 +27,6 @@ Return the image of `set` through the linear map `A` defined in
 
 This function is used for bridging the constraint and setting the
 [`MOI.ConstraintSet`](@ref).
-
-The default implementation of [`Variable.bridge_constraint`](@ref) uses
-[`map_set`](@ref) with the bridge type so if this function is defined
-on the bridge type, [`Variable.bridge_constraint`](@ref) does not need
-to be implemented.
 """
 map_set(bridge::AbstractBridge, set) = map_set(typeof(bridge), set)
 

--- a/src/Bridges/set_map.jl
+++ b/src/Bridges/set_map.jl
@@ -34,16 +34,25 @@ used for getting the [`MOI.ConstraintSet`](@ref).
 function inverse_map_set end
 
 """
+    map_function(bridge::MOI.Bridges.AbstractBridge, func)
     map_function(::Type{BT}, func) where {BT}
 
 Return the image of `func` through the linear map `A` defined in
-[`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
-used for getting the [`MOI.ConstraintPrimal`](@ref) of variable
-bridges. For constraint bridges, this is used for bridging the constraint,
-setting the [`MOI.ConstraintFunction`](@ref) and
-[`MOI.ConstraintPrimalStart`](@ref) and
-modifying the function with [`MOI.modify`](@ref).
+[`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref).
 
+This function is used for getting the [`MOI.ConstraintPrimal`](@ref) of variable
+bridges. For constraint bridges, this is used for bridging the constraint,
+setting the [`MOI.ConstraintFunction`](@ref) and [`MOI.ConstraintPrimalStart`](@ref)
+and modifying the function with [`MOI.modify`](@ref).
+
+The method can alternatively be defined on the bridge type. This legacy
+interface is kept for backward compatibility.
+"""
+function map_function(bridge::AbstractBridge, func)
+    return map_function(typeof(bridge), func)
+end
+
+"""
     map_function(::Type{BT}, func, i::IndexInVector) where {BT}
 
 Return the scalar function at the `i`th index of the vector function that
@@ -52,77 +61,65 @@ would be returned by `map_function(BT, func)` except that it may compute the
 the [`MOI.VariablePrimal`](@ref) and
 [`MOI.VariablePrimalStart`](@ref) of variable bridges.
 """
-function map_function end
-
-function map_function(bridge::AbstractBridge, func)
-    return map_function(typeof(bridge), func)
-end
-
 function map_function(::Type{BT}, func, i::IndexInVector) where {BT}
     return MOI.Utilities.eachscalar(map_function(BT, func))[i.value]
 end
 
 """
     inverse_map_function(bridge::MOI.Bridges.AbstractBridge, func)
+    inverse_map_function(::Type{BT}, func) where {BT}
 
 Return the image of `func` through the inverse of the linear map `A` defined in
-[`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
-used by [`Variable.unbridged_map`](@ref) and for setting the
-[`MOI.VariablePrimalStart`](@ref) of variable bridges
-and for getting the [`MOI.ConstraintFunction`](@ref),
-the [`MOI.ConstraintPrimal`](@ref) and the
+[`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref).
+
+This function is used by [`Variable.unbridged_map`](@ref) and for setting the
+[`MOI.VariablePrimalStart`](@ref) of variable bridges and for getting the
+[`MOI.ConstraintFunction`](@ref), the [`MOI.ConstraintPrimal`](@ref) and the
 [`MOI.ConstraintPrimalStart`](@ref) of constraint bridges.
+
 If the linear map `A` is not invertible, the error [`MapNotInvertible`](@ref) is
 thrown.
-
-    inverse_map_function(::Type{BT}, func) where {BT}
 
 The method can alternatively be defined on the bridge type. This legacy
 interface is kept for backward compatibility.
 """
-function inverse_map_function end
-
 function inverse_map_function(bridge::AbstractBridge, func)
     return inverse_map_function(typeof(bridge), func)
 end
 
 """
     adjoint_map_function(bridge::MOI.Bridges.AbstractBridge, func)
+    adjoint_map_function(::Type{BT}, func) where {BT}
 
 Return the image of `func` through the adjoint of the linear map `A` defined in
-[`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref). This is
-used for getting the [`MOI.ConstraintDual`](@ref) and
-[`MOI.ConstraintDualStart`](@ref) of constraint bridges.
+[`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref).
 
-    adjoint_map_function(::Type{BT}, func) where {BT}
+This function is used for getting the [`MOI.ConstraintDual`](@ref) and
+[`MOI.ConstraintDualStart`](@ref) of constraint bridges.
 
 The method can alternatively be defined on the bridge type. This legacy
 interface is kept for backward compatibility.
 """
-function adjoint_map_function end
-
 function adjoint_map_function(bridge::AbstractBridge, func)
     return adjoint_map_function(typeof(bridge), func)
 end
 
 """
     inverse_adjoint_map_function(bridge::MOI.Bridges.AbstractBridge, func)
+    inverse_adjoint_map_function(::Type{BT}, func) where {BT}
 
 Return the image of `func` through the inverse of the adjoint of the linear map
-`A` defined in [`Variable.SetMapBridge`](@ref) and
-[`Constraint.SetMapBridge`](@ref). This is used for getting the
-[`MOI.ConstraintDual`](@ref) of variable bridges and setting the
-[`MOI.ConstraintDualStart`](@ref) of constraint bridges.
+`A` defined in [`Variable.SetMapBridge`](@ref) and [`Constraint.SetMapBridge`](@ref).
+
+This function is used for getting the [`MOI.ConstraintDual`](@ref) of variable
+bridges and setting the [`MOI.ConstraintDualStart`](@ref) of constraint bridges.
+
 If the linear map `A` is not invertible, the error [`MapNotInvertible`](@ref) is
 thrown.
-
-    inverse_adjoint_map_function(::Type{BT}, func) where {BT}
 
 The method can alternatively be defined on the bridge type. This legacy
 interface is kept for backward compatibility.
 """
-function inverse_adjoint_map_function end
-
 function inverse_adjoint_map_function(bridge::AbstractBridge, func)
     return inverse_adjoint_map_function(typeof(bridge), func)
 end

--- a/test/Bridges/set_map.jl
+++ b/test/Bridges/set_map.jl
@@ -12,10 +12,12 @@ using Test
 
 import MathOptInterface as MOI
 
+@enum(ErrType, NONE, NOT_INVERTIBLE, OTHER)
+
 # Constraints `[f[2], f[1]]` if `swap` and otherwise `f` to `Nonnegatives`
 struct SwapSet <: MOI.AbstractVectorSet
     swap::Bool
-    invertible::Bool
+    err::ErrType
 end
 
 MOI.dimension(::SwapSet) = 2
@@ -59,10 +61,13 @@ function MOI.Bridges.map_function(bridge::SwapBridge, func)
 end
 
 function MOI.Bridges.inverse_map_function(bridge::SwapBridge, func)
-    if !bridge.set.invertible
+    if bridge.set.err == NONE
+        return swap(func, bridge.set.swap)
+    elseif bridge.set.err == NOT_INVERTIBLE
         throw(MOI.Bridges.MapNotInvertible("no luck"))
+    else
+        error()
     end
-    return swap(func, bridge.set.swap)
 end
 
 function MOI.Bridges.adjoint_map_function(bridge::SwapBridge, func)
@@ -70,7 +75,13 @@ function MOI.Bridges.adjoint_map_function(bridge::SwapBridge, func)
 end
 
 function MOI.Bridges.inverse_adjoint_map_function(bridge::SwapBridge, func)
-    return swap(func, bridge.set.swap)
+    if bridge.set.err == NONE
+        return swap(func, bridge.set.swap)
+    elseif bridge.set.err == NOT_INVERTIBLE
+        throw(MOI.Bridges.MapNotInvertible("no luck"))
+    else
+        error()
+    end
 end
 
 swap(x, swap::Bool) = swap ? [x[2], x[1]] : x
@@ -90,23 +101,60 @@ function runtests()
     return
 end
 
-function test_set_set()
+function test_other_error()
     model = MOI.Bridges.Constraint.SingleBridgeOptimizer{SwapBridge{Float64}}(
-        MOI.Utilities.Model{Float64}(),
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
     )
     x = MOI.add_variables(model, 2)
     func = MOI.VectorOfVariables(x)
-    ci = MOI.add_constraint(model, func, SwapSet(true, false))
+    ci = MOI.add_constraint(model, func, SwapSet(true, OTHER))
+    @test_throws(
+        ErrorException(""),
+        MOI.get(model, MOI.ConstraintFunction(), ci),
+    )
+    MOI.set(model, MOI.ConstraintPrimalStart(), ci, ones(2))
+    @test_throws(
+        ErrorException(""),
+        MOI.get(model, MOI.ConstraintPrimalStart(), ci),
+    )
+    @test_throws(
+        ErrorException(""),
+        MOI.set(model, MOI.ConstraintDualStart(), ci, ones(2)),
+    )
+    return
+end
+function test_not_invertible()
+    model = MOI.Bridges.Constraint.SingleBridgeOptimizer{SwapBridge{Float64}}(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+    )
+    x = MOI.add_variables(model, 2)
+    func = MOI.VectorOfVariables(x)
+    ci = MOI.add_constraint(model, func, SwapSet(true, NOT_INVERTIBLE))
     @test_throws(
         ErrorException("Cannot change swap set"),
-        MOI.set(model, MOI.ConstraintSet(), ci, SwapSet(false, false)),
+        MOI.set(model, MOI.ConstraintSet(), ci, SwapSet(false, NOT_INVERTIBLE)),
     )
     @test_throws(
         MOI.GetAttributeNotAllowed(
             MOI.ConstraintFunction(),
-            "Cannot get MathOptInterface.ConstraintFunction() as the constraint is reformulated through a linear transformation that is not invertible. no luck",
+            "Cannot get `MathOptInterface.ConstraintFunction()` as the constraint is reformulated through a linear transformation that is not invertible. no luck",
         ),
         MOI.get(model, MOI.ConstraintFunction(), ci),
+    )
+    MOI.set(model, MOI.ConstraintPrimalStart(), ci, ones(2))
+    @test_throws(
+        MOI.GetAttributeNotAllowed(
+            MOI.ConstraintPrimalStart(),
+            "Cannot get `MathOptInterface.ConstraintPrimalStart()` as the constraint is reformulated through a linear transformation that is not invertible. no luck",
+        ),
+        MOI.get(model, MOI.ConstraintPrimalStart(), ci),
+    )
+    @test_throws(
+        MOI.SetAttributeNotAllowed(
+            MOI.ConstraintDualStart(),
+            "Cannot get `MathOptInterface.ConstraintDualStart()` as the constraint is reformulated through a linear transformation that is not invertible. no luck",
+        ),
+        MOI.set(model, MOI.ConstraintDualStart(), ci, ones(2)),
     )
     return
 end
@@ -118,7 +166,7 @@ function test_runtests()
             model -> begin
                 x = MOI.add_variables(model, 2)
                 func = MOI.VectorOfVariables(x)
-                set = SwapSet(do_swap, true)
+                set = SwapSet(do_swap, NONE)
                 MOI.add_constraint(model, func, set)
             end,
             model -> begin

--- a/test/Bridges/set_map.jl
+++ b/test/Bridges/set_map.jl
@@ -104,7 +104,7 @@ function test_set_set()
     @test_throws(
         MOI.GetAttributeNotAllowed(
             MOI.ConstraintFunction(),
-            "Cannot get MathOptInterface.ConstraintFunction() as the constraint is reformulated through a linear transformation that is not invertible.no luck no luck",
+            "Cannot get MathOptInterface.ConstraintFunction() as the constraint is reformulated through a linear transformation that is not invertible. no luck",
         ),
         MOI.get(model, MOI.ConstraintFunction(), ci),
     )

--- a/test/Bridges/set_map.jl
+++ b/test/Bridges/set_map.jl
@@ -1,0 +1,148 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+# Test with a bridge for which the map is defined on the bridge
+# value and not the bridge type
+module TestSetMapBridge
+
+import MathOptInterface as MOI
+
+
+# Constraints `[f[2], f[1]]` if `swap` and otherwise
+# `f` to `Nonnegatives`
+struct SwapSet <: MOI.AbstractVectorSet
+    swap::Bool
+    invertible::Bool
+end
+
+MOI.dimension(::SwapSet) = 2
+
+struct SwapBridge{T} <: MOI.Bridges.Constraint.SetMapBridge{
+    T,
+    MOI.Nonnegatives,
+    SwapSet,
+    MOI.VectorOfVariables,
+    MOI.VectorOfVariables,
+}
+    constraint::MOI.ConstraintIndex{
+        MOI.VectorOfVariables,
+        MOI.Nonnegatives,
+    }
+    set::SwapSet
+end
+
+function MOI.Bridges.Constraint.bridge_constraint(
+    ::Type{SwapBridge{T}},
+    model::MOI.ModelLike,
+    func::MOI.VectorOfVariables,
+    set::SwapSet,
+) where {T}
+    ci = MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables(swap(func.variables, set.swap)),
+        MOI.Nonnegatives(2),
+    )
+    return SwapBridge{T}(ci, set)
+end
+
+function MOI.Bridges.map_set(bridge::SwapBridge, set::SwapSet)
+    if set.swap != bridge.set.swap
+        error("Cannot change swap set")
+    else
+        return MOI.Nonnegatives(2)
+    end
+end
+
+function MOI.Bridges.inverse_map_set(bridge::SwapBridge, ::MOI.Nonnegatives)
+    return bridge.set
+end
+
+function MOI.Bridges.map_function(bridge::SwapBridge, func)
+    return swap(func, bridge.set.swap)
+end
+
+function MOI.Bridges.inverse_map_function(bridge::SwapBridge, func)
+    if !bridge.set.invertible
+        throw(MOI.Bridges.MapNotInvertible("no luck"))
+    end
+    return swap(func, bridge.set.swap)
+end
+
+function MOI.Bridges.adjoint_map_function(bridge::SwapBridge, func)
+    return swap(func, bridge.set.swap)
+end
+
+function MOI.Bridges.inverse_adjoint_map_function(bridge::SwapBridge, func)
+    return swap(func, bridge.set.swap)
+end
+
+using Test
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function swap(x, swap::Bool)
+    if swap
+        return [x[2], x[1]]
+    else
+        return x
+    end
+end
+
+function swap(f::MOI.VectorOfVariables, do_swap::Bool)
+    return MOI.VectorOfVariables(swap(f.variables, do_swap))
+end
+
+function test_set_set()
+    model = MOI.Bridges.Constraint.SingleBridgeOptimizer{SwapBridge{Float64}}(
+        MOI.Utilities.Model{Float64}()
+    )
+    x = MOI.add_variables(model, 2)
+    func = MOI.VectorOfVariables(x)
+    set = SwapSet(true, false)
+    ci = MOI.add_constraint(model, func, set)
+    err = ErrorException("Cannot change swap set")
+    @test_throws err MOI.set(model, MOI.ConstraintSet(), ci, SwapSet(false, false))
+    attr = MOI.ConstraintFunction()
+    err = MOI.GetAttributeNotAllowed(
+        attr,
+        "Cannot get MathOptInterface.ConstraintFunction() as the constraint is reformulated through a linear transformation that is not invertible.no luck no luck",
+    )
+    @test_throws err MOI.get(model, attr, ci)
+end
+
+function test_runtests()
+    for do_swap in [false, true]
+        MOI.Bridges.runtests(
+            SwapBridge,
+            model -> begin
+                x = MOI.add_variables(model, 2)
+                func = MOI.VectorOfVariables(x)
+                set = SwapSet(do_swap, true)
+                MOI.add_constraint(model, func, set)
+            end,
+            model -> begin
+                x = MOI.add_variables(model, 2)
+                func = MOI.VectorOfVariables(swap(x, do_swap))
+                set = MOI.Nonnegatives(2)
+                MOI.add_constraint(model, func, set)
+            end,
+        )
+    end
+    return
+end
+
+end  # module
+
+TestSetMapBridge.runtests()


### PR DESCRIPTION
When I decided that these functions would only depend on the type, it was for consistency for `map_function` because `map_function` clearly cannot depend on anything else given that it is used in `bridge_constraint`. However, you could also have a bridge that implements its own `bridge_constraint`, storing extra information then in the bridge to be able to implement `inverse_map_function`, etc... This is the case of the Sum-of-Squares bridge.

Needed for https://github.com/jump-dev/SumOfSquares.jl/pull/355