### PR TITLE
Revert "[Bridges] use dual of equality in slack bridge (#2508)"

### DIFF
--- a/src/Bridges/Constraint/bridges/slack.jl
+++ b/src/Bridges/Constraint/bridges/slack.jl
@@ -127,15 +127,9 @@ function MOI.get(
     bridge::_AbstractSlackBridge,
 )
     # The dual constraint on slack (since it is free) is
-    # `-dual_slack_in_set + dual_equality = 0` so the two duals are
+    # -dual_slack_in_set + dual_equality = 0 so the two duals are
     # equal and we can return either one of them.
-    # We decide to use the dual of the equality constraints because
-    # the `slack_in_set` constraint might be bridge by a variable bridge that
-    # does not # support `ConstraintDual`. This is the case if the adjoint of
-    # the linear map on which the bridge is based is not invertible, as for
-    # instance with `Variable.ZerosBridge` or
-    # `SumOfSquares.Bridges.Variable.KernelBridge`.
-    return MOI.get(model, a, bridge.equality)
+    return MOI.get(model, a, bridge.slack_in_set)
 end
 
 function MOI.set(


### PR DESCRIPTION
This reverts commit 6d9378acf11653a1cb2ac6c969f388fa4be59f1e.

x-ref #2513 

- [x] https://github.com/jump-dev/MathOptInterface.jl/actions/workflows/solver-tests.yml