### PR TITLE
[Bridges] use dual of equality in slack bridge (take 2)

### DIFF
--- a/src/Bridges/Constraint/bridges/slack.jl
+++ b/src/Bridges/Constraint/bridges/slack.jl
@@ -124,8 +124,8 @@ end
 function MOI.get(
     model::MOI.ModelLike,
     a::Union{MOI.ConstraintDual,MOI.ConstraintDualStart},
-    bridge::_AbstractSlackBridge,
-)
+    bridge::_AbstractSlackBridge{T},
+) whhere {T}
     # The dual constraint on slack (since it is free) is
     # `-dual_slack_in_set + dual_equality = 0` so the two duals are
     # equal and we can return either one of them.

--- a/src/Bridges/Constraint/bridges/slack.jl
+++ b/src/Bridges/Constraint/bridges/slack.jl
@@ -125,7 +125,7 @@ function MOI.get(
     model::MOI.ModelLike,
     a::Union{MOI.ConstraintDual,MOI.ConstraintDualStart},
     bridge::_AbstractSlackBridge{T},
-) whhere {T}
+) where {T}
     # The dual constraint on slack (since it is free) is
     # `-dual_slack_in_set + dual_equality = 0` so the two duals are
     # equal and we can return either one of them.

--- a/src/Bridges/Constraint/bridges/slack.jl
+++ b/src/Bridges/Constraint/bridges/slack.jl
@@ -138,12 +138,11 @@ function MOI.get(
     dual = MOI.get(model, a, bridge.equality)
     if dual === nothing
         return nothing
+    elseif dual isa AbstractVector
+        scale = MOI.Utilities.SetDotScalingVector{T}(bridge.set)
+        return dual ./ scale.^2
     end
-    scale = MOI.Utilities.SetDotScalingVector{T}(bridge.set)
-    if dual isa AbstractVector
-        return MOI.Utilities.operate(*, T, LinearAlgebra.Diagonal(scale), dual)
-    end
-    return scale[1] * dual
+    return dual
 end
 
 function MOI.set(

--- a/src/Bridges/Constraint/bridges/slack.jl
+++ b/src/Bridges/Constraint/bridges/slack.jl
@@ -136,8 +136,8 @@ function MOI.get(
     # instance with `Variable.ZerosBridge` or
     # `SumOfSquares.Bridges.Variable.KernelBridge`.
     dual = MOI.get(model, a, bridge.equality)
+    scale = MOI.Utilities.SetDotScalingVector{T}(bridge.set)
     if dual isa AbstractVector
-        scale = MOI.Utilities.SetDotScalingVector{T}(bridge.set)
         return MOI.Utilities.operate(*, T, LinearAlgebra.Diagonal(scale), dual)
     end
     return scale[1] * dual

--- a/src/Bridges/Constraint/bridges/slack.jl
+++ b/src/Bridges/Constraint/bridges/slack.jl
@@ -127,9 +127,15 @@ function MOI.get(
     bridge::_AbstractSlackBridge,
 )
     # The dual constraint on slack (since it is free) is
-    # -dual_slack_in_set + dual_equality = 0 so the two duals are
+    # `-dual_slack_in_set + dual_equality = 0` so the two duals are
     # equal and we can return either one of them.
-    return MOI.get(model, a, bridge.slack_in_set)
+    # We decide to use the dual of the equality constraints because
+    # the `slack_in_set` constraint might be bridge by a variable bridge that
+    # does not # support `ConstraintDual`. This is the case if the adjoint of
+    # the linear map on which the bridge is based is not invertible, as for
+    # instance with `Variable.ZerosBridge` or
+    # `SumOfSquares.Bridges.Variable.KernelBridge`.
+    return MOI.get(model, a, bridge.equality)
 end
 
 function MOI.set(

--- a/src/Bridges/Constraint/bridges/slack.jl
+++ b/src/Bridges/Constraint/bridges/slack.jl
@@ -140,7 +140,7 @@ function MOI.get(
         return nothing
     elseif dual isa AbstractVector
         scale = MOI.Utilities.SetDotScalingVector{T}(bridge.set)
-        return dual ./ scale.^2
+        return dual ./ scale .^ 2
     end
     return dual
 end

--- a/src/Bridges/Constraint/bridges/slack.jl
+++ b/src/Bridges/Constraint/bridges/slack.jl
@@ -136,6 +136,9 @@ function MOI.get(
     # instance with `Variable.ZerosBridge` or
     # `SumOfSquares.Bridges.Variable.KernelBridge`.
     dual = MOI.get(model, a, bridge.equality)
+    if dual === nothing
+        return nothing
+    end
     scale = MOI.Utilities.SetDotScalingVector{T}(bridge.set)
     if dual isa AbstractVector
         return MOI.Utilities.operate(*, T, LinearAlgebra.Diagonal(scale), dual)

--- a/src/Bridges/Constraint/bridges/slack.jl
+++ b/src/Bridges/Constraint/bridges/slack.jl
@@ -136,8 +136,11 @@ function MOI.get(
     # instance with `Variable.ZerosBridge` or
     # `SumOfSquares.Bridges.Variable.KernelBridge`.
     dual = MOI.get(model, a, bridge.equality)
-    scale = MOI.Utilities.SetDotScalingVector{T}(bridge.set)
-    return MOI.Utilities.operate(*, T, LinearAlgebra.Diagonal(scale), dual)
+    if dual isa AbstractVector
+        scale = MOI.Utilities.SetDotScalingVector{T}(bridge.set)
+        return MOI.Utilities.operate(*, T, LinearAlgebra.Diagonal(scale), dual)
+    end
+    return scale[1] * dual
 end
 
 function MOI.set(

--- a/test/Bridges/Constraint/slack.jl
+++ b/test/Bridges/Constraint/slack.jl
@@ -384,6 +384,18 @@ function test_runtests()
         [y, z] in SecondOrderCone(2)
         """,
     )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.VectorSlackBridge,
+        """
+        variables: x11, x12, x22
+        [1.0 * x11, x12, 2.0 * x22] in PositiveSemidefiniteConeTriangle(2)
+        """,
+        """
+        variables: x11, x12, x22, y11, y12, y22
+        [1.0 * x11 + -1.0 * y11, x12 + -1.0 * y12, 2.0 * x22 + -1.0 * y22] in Zeros(3)
+        [y11, y12, y22] in PositiveSemidefiniteConeTriangle(2)
+        """,
+    )
     return
 end
 


### PR DESCRIPTION
We can take inspiration from https://github.com/jump-dev/MathOptInterface.jl/blob/08d34003cd3d7500379d9440e92445bc4d9a8fa8/src/Bridges/Constraint/bridges/set_dot_scaling.jl#L64-L75

Closes https://github.com/jump-dev/MathOptInterface.jl/issues/2513