### PR TITLE
Fix link to CPLEX's CPXMIP_OPTIMAL_INFEAS

### DIFF
--- a/docs/src/manual/solutions.md
+++ b/docs/src/manual/solutions.md
@@ -110,7 +110,7 @@ Mixed-integer programming solvers fall into this category.
 | `CPXMIP_OPTIMAL_INFEAS`                          | `ALMOST_OPTIMAL`          | 1             | `INFEASIBLE_POINT` | `NO_SOLUTION` |
 
 !!! info
-    [`CPXMIP_OPTIMAL_INFEAS`](https://www.ibm.com/docs/en/SSSA5P_12.6.1/ilog.odms.cplex.help/refcallablelibrary/macros/CPXMIP_OPTIMAL_INFEAS.html)
+    [`CPXMIP_OPTIMAL_INFEAS`](https://www.ibm.com/docs/en/icos/22.1.1?topic=api-cpxmip-optimal-infeas)
     is a CPLEX status that indicates that a preprocessed problem was solved to
     optimality, but the solver was unable to recover a feasible solution to the
     original problem. Handling this status was one of the motivating drivers


### PR DESCRIPTION
It's making ci fail at the moment
```
[ Info: CheckDocument: running document checks.
┌ Error: linkcheck 'https://www.ibm.com/docs/en/SSSA5P_12.6.1/ilog.odms.cplex.help/refcallablelibrary/macros/CPXMIP_OPTIMAL_INFEAS.html' status: 404.
└ @ Documenter ~/.julia/packages/Documenter/C1XEF/src/utilities/utilities.jl:44
[ Info: Populate: populating indices.
ERROR: LoadError: `makedocs` encountered an error [:linkcheck] -- terminating build before rendering.
```