### PR TITLE
[Coloring] avoid index conflict in variable name

### DIFF
--- a/src/Nonlinear/ReverseAD/Coloring/Coloring.jl
+++ b/src/Nonlinear/ReverseAD/Coloring/Coloring.jl
@@ -344,8 +344,8 @@ function recovery_preprocess(
         sorted_edges[idx] = Tuple{Int,Int}[]
         sizehint!(sorted_edges[idx], edge_count[idx])
     end
-    for i in eachindex(g.edges)
-        u, v = g.edges[i]
+    for k in eachindex(g.edges)
+        u, v = g.edges[k]
         i = min(color[u], color[v])
         j = max(color[u], color[v])
         idx = twocolorindex[i, j]


### PR DESCRIPTION
`i` is already used inside the loop so it's best to use `k` for the iteration just like in the previous `for` loop.