### PR TITLE
Prep for v1.33.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.32.0"
+version = "1.33.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added support for specifying the lower and upper bound suffixes for variable
    duals in [`FileFormats.NL.SolFileResults`](@ref) (#2567)
 
+### Fixed
+
+ - Fixed `MOI.objective_expr(::InvalidEvaluator)` (#2569)
+
 ## v1.32.0 (October 21, 2024)
 
 ### Added

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,13 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.33.0 (October 28, 2024)
+
+### Added
+
+ - Added support for specifing the lower and upper bound suffixes for variable
+   duals in [`FileFormats.NL.SolFileResults`](@ref) (#2567)
+
 ## v1.32.0 (October 21, 2024)
 
 ### Added

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
- - Added support for specifing the lower and upper bound suffixes for variable
+ - Added support for specifying the lower and upper bound suffixes for variable
    duals in [`FileFormats.NL.SolFileResults`](@ref) (#2567)
 
 ## v1.32.0 (October 21, 2024)


### PR DESCRIPTION
I'm going to make a release containing only #2567 because I need it for Uno.

## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/11544064060