### PR TITLE
[Test] Fix MOI.objective_expr(::InvalidEvaluator)

### DIFF
--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -1121,7 +1121,7 @@ function MOI.features_available(::InvalidEvaluator)
     return [:Grad, :ExprGraph]
 end
 
-MOI.objective_expr(::InvalidEvaluator) = :(NaN)
+MOI.objective_expr(::InvalidEvaluator) = :(+($NaN))
 
 MOI.eval_objective(::InvalidEvaluator, x) = NaN
 
@@ -1140,7 +1140,7 @@ written. External solvers can exclude this test without consequence.
 """
 function test_nonlinear_InvalidEvaluator_internal(::MOI.ModelLike, ::Config)
     d = InvalidEvaluator()
-    @test MOI.objective_expr(d) == :(NaN)
+    @test MOI.objective_expr(d) == :(+($NaN))
     MOI.initialize(d, [:Grad, :ExprGraph])
     x = [1.5]
     # f(x)


### PR DESCRIPTION
Even though `NaN` is a `Float64` literal, `:(NaN)` doesn't do what it looks like.

```julia
julia> dump(:(NaN))
Symbol NaN

julia> dump(:(1.0))
Float64 1.0

julia> dump(:($NaN))
Float64 NaN
```

https://github.com/jump-dev/MathOptInterface.jl/actions/runs/11544744456