### PR TITLE
[Utilities] fix checking supports_constraint in default_copy_to

### DIFF
--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -393,7 +393,7 @@ function default_copy_to(dest::MOI.ModelLike, src::MOI.ModelLike)
                 throw(MOI.AddConstraintNotAllowed{F,S}())
             end
         else
-            if !MOI.supports_add_constraint(dest, F, S)
+            if !MOI.supports_constraint(dest, F, S)
                 throw(MOI.AddConstraintNotAllowed{F,S}())
             end
         end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -393,7 +393,7 @@ function default_copy_to(dest::MOI.ModelLike, src::MOI.ModelLike)
                 throw(MOI.AddConstraintNotAllowed{F,S}())
             end
         else
-            if !MOI.supports_add_constrainet(dest, F, S)
+            if !MOI.supports_add_constraint(dest, F, S)
                 throw(MOI.AddConstraintNotAllowed{F,S}())
             end
         end

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -513,8 +513,8 @@ function _add_variable_with_domain(
     src,
     index_map,
     f,
-    ci::MOI.ConstraintIndex{MOI.VariableIndex,S},
-) where {S<:MOI.AbstractScalarSet}
+    ci::MOI.ConstraintIndex{MOI.VariableIndex,<:MOI.AbstractScalarSet},
+)
     set = MOI.get(src, MOI.ConstraintSet(), ci)
     dest_x, dest_ci = MOI.add_constrained_variable(dest, set)
     index_map[only(f)] = dest_x
@@ -527,8 +527,8 @@ function _add_variable_with_domain(
     src,
     index_map,
     f,
-    ci::MOI.ConstraintIndex{MOI.VectorOfVariables,S},
-) where {S<:MOI.AbstractVectorSet}
+    ci::MOI.ConstraintIndex{MOI.VectorOfVariables,<:MOI.AbstractVectorSet},
+)
     set = MOI.get(src, MOI.ConstraintSet(), ci)
     dest_x, dest_ci = MOI.add_constrained_variables(dest, set)
     for (fi, xi) in zip(f, dest_x)

--- a/src/Utilities/copy.jl
+++ b/src/Utilities/copy.jl
@@ -386,16 +386,14 @@ function default_copy_to(dest::MOI.ModelLike, src::MOI.ModelLike)
     for (F, S) in MOI.get(src, MOI.ListOfConstraintTypesPresent())
         if F == MOI.VariableIndex
             if !MOI.supports_add_constrained_variable(dest, S)
-                throw(MOI.AddConstraintNotAllowed{F,S}())
+                throw(MOI.UnsupportedConstraint{F,S}())
             end
         elseif F == MOI.VectorOfVariables
             if !MOI.supports_add_constrained_variables(dest, S)
-                throw(MOI.AddConstraintNotAllowed{F,S}())
+                throw(MOI.UnsupportedConstraint{F,S}())
             end
-        else
-            if !MOI.supports_constraint(dest, F, S)
-                throw(MOI.AddConstraintNotAllowed{F,S}())
-            end
+        elseif !MOI.supports_constraint(dest, F, S)
+            throw(MOI.UnsupportedConstraint{F,S}())
         end
     end
     index_map, vis_src, constraints_not_added =

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -1003,6 +1003,35 @@ function test_copy_to_sorted_sets()
     return
 end
 
+function test_add_constraint_not_allowed_scalar_variable()
+    F, S = MOI.VariableIndex, MOI.GreaterThan{Float64}
+    model = MOI.Utilities.Model{Float64}()
+    x, _ = MOI.add_constrained_variable(model, MOI.GreaterThan(1.0))
+    dest = MOI.FileFormats.CBF.Model()
+    @test_throws(MOI.AddConstraintNotAllowed{F,S}, MOI.copy_to(dest, model))
+    return
+end
+
+function test_add_constraint_not_allowed_vector_variables()
+    F, S = MOI.VectorOfVariables, MOI.AllDifferent
+    model = MOI.Utilities.Model{Float64}()
+    x, _ = MOI.add_constrained_variables(model, MOI.AllDifferent(3))
+    dest = MOI.FileFormats.CBF.Model()
+    @test_throws(MOI.AddConstraintNotAllowed{F,S}, MOI.copy_to(dest, model))
+    return
+end
+
+function test_add_constraint_not_allowed_scalar_function()
+    F, S = MOI.ScalarNonlinearFunction, MOI.EqualTo{Float64}
+    model = MOI.Utilities.Model{Float64}()
+    x = MOI.add_variable(model)
+    f = MOI.ScalarNonlinearFunction(:log, Any[x])
+    MOI.add_constraint(model, f, MOI.EqualTo(0.0))
+    dest = MOI.FileFormats.CBF.Model()
+    @test_throws(MOI.AddConstraintNotAllowed{F,S}, MOI.copy_to(dest, model))
+    return
+end
+
 end  # module
 
 TestCopy.runtests()

--- a/test/Utilities/copy.jl
+++ b/test/Utilities/copy.jl
@@ -753,7 +753,7 @@ end
 function MOI.supports_constraint(
     ::BoundModel,
     ::Type{MOI.VariableIndex},
-    ::MOI.LessThan{Float64},
+    ::Type{MOI.LessThan{Float64}},
 )
     return true
 end


### PR DESCRIPTION
Closes #2570

I'm surprised this one lasted as long as it did. I think because we mainly use bridges, and because it's rare for the underlying method to exist but `supports` return `false`. 