### PR TITLE
add_constrained_variable with 2 sets

### DIFF
--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -1226,3 +1226,20 @@ function test_model_show(model::MOI.ModelLike, ::Config{T}) where {T}
     @test sprint(show, model) isa String
     return
 end
+
+function test_model_add_constrained_variale_tuple(
+    model::MOI.ModelLike,
+    ::Config{T},
+) where {T}
+    F = MOI.VariableIndex
+    set = (MOI.GreaterThan(zero(T)), MOI.LessThan(one(T)))
+    @requires MOI.supports_add_constrained_variable(model, typeof(set))
+    x, (c_l, c_u) = MOI.add_constrained_variable(model, set)
+    @test c_l == MOI.ConstraintIndex{F,MOI.GreaterThan{T}}(x.value)
+    @test c_u == MOI.ConstraintIndex{F,MOI.LessThan{T}}(x.value)
+    @test MOI.get(model, MOI.ConstraintFunction(), c_l) == x
+    @test MOI.get(model, MOI.ConstraintSet(), c_l) == set[1]
+    @test MOI.get(model, MOI.ConstraintFunction(), c_u) == x
+    @test MOI.get(model, MOI.ConstraintSet(), c_u) == set[2]
+    return
+end

--- a/src/Test/test_model.jl
+++ b/src/Test/test_model.jl
@@ -1227,7 +1227,7 @@ function test_model_show(model::MOI.ModelLike, ::Config{T}) where {T}
     return
 end
 
-function test_model_add_constrained_variale_tuple(
+function test_model_add_constrained_variable_tuple(
     model::MOI.ModelLike,
     ::Config{T},
 ) where {T}

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -124,6 +124,12 @@ function add_constrained_variable(model::ModelLike, set::AbstractScalarSet)
     return variable, constraint
 end
 
+function add_constrained_variable(model::ModelLike, set1::AbstractScalarSet, set2::AbstractScalarSet)
+    variable, constraint1 = add_constrained_variable(model, set1)
+    constraint2 = add_constraint(model, variable, set2)
+    return variable, constraint1, constraint2
+end
+
 """
     supports_add_constrained_variables(
         model::ModelLike,

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -124,10 +124,63 @@ function add_constrained_variable(model::ModelLike, set::AbstractScalarSet)
     return variable, constraint
 end
 
-function add_constrained_variable(model::ModelLike, set1::AbstractScalarSet, set2::AbstractScalarSet)
-    variable, constraint1 = add_constrained_variable(model, set1)
-    constraint2 = add_constraint(model, variable, set2)
-    return variable, constraint1, constraint2
+"""
+    add_constrained_variable(
+        model::ModelLike,
+        set::Tuple{<:GreaterThan,<:LessThan},
+    )
+
+A special-case method to add a scalar variable with a lower and upper bound.
+
+This method should be implemented by optimizers which have native support for
+adding a variable with bounds and which cannot performantly modify the variable
+bounds after creation.
+
+## Example
+
+```jldoctest
+julia> import MathOptInterface as MOI
+
+julia> model = MOI.Utilities.Model{Float64}();
+
+julia> set = (MOI.GreaterThan(1.0), MOI.LessThan(2.0));
+
+julia> x, (c_l, c_u) = MOI.add_constrained_variable(model, set);
+
+julia> c_l
+MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.GreaterThan{Float64}}(1)
+
+julia> c_u
+MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterface.LessThan{Float64}}(1)
+
+julia> print(model)
+Feasibility
+
+Subject to:
+
+VariableIndex-in-GreaterThan{Float64}
+ v[1] >= 1.0
+
+VariableIndex-in-LessThan{Float64}
+ v[1] <= 2.0
+```
+"""
+function add_constrained_variable(
+    model::ModelLike,
+    set::Tuple{<:GreaterThan,<:LessThan},
+)
+    set_1, set_2 = set
+    x, c_1 = add_constrained_variable(model, set_1)
+    c_2 = add_constraint(model, x, set_2)
+    return x, (c_1, c_2)
+end
+
+function supports_add_constrained_variable(
+    model::ModelLike,
+    ::Type{Tuple{L,U}},
+) where {L<:GreaterThan,U<:LessThan}
+    return supports_add_constrained_variable(model, L) &&
+           supports_constraint(model, VariableIndex, U)
 end
 
 """


### PR DESCRIPTION
Alternative fix for https://github.com/jump-dev/MathOptInterface.jl/issues/2564
Actually, this also has the potential to solve another issue.
If you have a variable that belongs to 2 sets, you never know which one should be added at creation as it's solver specific.
When you have a caching optimizer and then a bridge layer it's fine because it will get reordered in `copy_to` but otherwise you have to manually check the bridging cost.
The implementation of this PR could be improved to handle this case as well by doing something like:
```julia
function _cost_of_bridging( # copy pasted from `Utilities/copy.jl`
    dest::MOI.ModelLike,
    ::Type{S},
) where {S<:MOI.AbstractScalarSet}
    x = MOI.get(dest, MOI.VariableBridgingCost{S}())
    y = MOI.get(dest, MOI.ConstraintBridgingCost{MOI.VariableIndex,S}())
    return x - y
end

# ...
cost1 = _cost_of_bridging(model, typeof(set1)
cost2 = _cost_of_bridging(model, typeof(set2)
if cost1 < cost2
    vi, ci1 = MOI.add_constrained_variable(model, set1)
    ci2 = MOI.add_constraint(model, vi, set2)
else
    vi, ci2 = MOI.add_constrained_variable(model, set2)
    ci1 = MOI.add_constraint(model, vi, set1)
end
return vi, ci1, ci2
#...
```

Closes https://github.com/jump-dev/MathOptInterface.jl/pull/2565