### PR TITLE
[Utilities] ignore attributes in UniversalFallback if set to nothing

### DIFF
--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -486,8 +486,10 @@ function MOI.get(
     listattr::MOI.ListOfVariableAttributesSet,
 )
     list = MOI.get(uf.model, listattr)
-    for attr in keys(uf.varattr)
-        push!(list, attr)
+    for (attr, dict) in uf.varattr
+        if !isempty(dict)
+            push!(list, attr)
+        end
     end
     return list
 end

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -491,7 +491,7 @@ function MOI.get(
 )
     list = MOI.get(uf.model, listattr)
     for (attr, value) in uf.varattr
-        if value !== nothing
+        if any(!isnothing, values(value))
             push!(list, attr)
         end
     end

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -464,8 +464,10 @@ function MOI.get(
     listattr::MOI.ListOfOptimizerAttributesSet,
 )
     list = MOI.get(uf.model, listattr)
-    for attr in keys(uf.optattr)
-        push!(list, attr)
+    for (attr, value) in uf.optattr
+        if value !== nothing
+            push!(list, attr)
+        end
     end
     return list
 end
@@ -475,8 +477,10 @@ function MOI.get(uf::UniversalFallback, listattr::MOI.ListOfModelAttributesSet)
     if uf.objective !== nothing
         push!(list, MOI.ObjectiveFunction{typeof(uf.objective)}())
     end
-    for attr in keys(uf.modattr)
-        push!(list, attr)
+    for (attr, value) in uf.modattr
+        if value !== nothing
+            push!(list, attr)
+        end
     end
     return list
 end
@@ -486,8 +490,10 @@ function MOI.get(
     listattr::MOI.ListOfVariableAttributesSet,
 )
     list = MOI.get(uf.model, listattr)
-    for attr in keys(uf.varattr)
-        push!(list, attr)
+    for (attr, value) in uf.varattr
+        if value !== nothing
+            push!(list, attr)
+        end
     end
     return list
 end
@@ -498,8 +504,11 @@ function MOI.get(
 ) where {F,S}
     list = MOI.get(uf.model, listattr)
     for (attr, dict) in uf.conattr
-        if any(k -> k isa MOI.ConstraintIndex{F,S}, keys(dict))
-            push!(list, attr)
+        for (k, v) in dict
+            if v !== nothing && k isa MOI.ConstraintIndex{F,S}
+                push!(list, attr)
+                break
+            end
         end
     end
     # ConstraintName isn't stored in conattr, but in the .con_to_name dictionary

--- a/src/Utilities/universalfallback.jl
+++ b/src/Utilities/universalfallback.jl
@@ -505,7 +505,7 @@ function MOI.get(
     list = MOI.get(uf.model, listattr)
     for (attr, dict) in uf.conattr
         for (k, v) in dict
-            if v !== nothing && k isa MOI.ConstraintIndex{F,S}
+            if k isa MOI.ConstraintIndex{F,S} && !isnothing(v)
                 push!(list, attr)
                 break
             end

--- a/test/Utilities/universalfallback.jl
+++ b/test/Utilities/universalfallback.jl
@@ -68,26 +68,26 @@ end
 ### The tests
 ###
 
-# function test_MOI_Test()
-#     inner = ModelForUniversalFallback{Float64}()
-#     model = MOI.Utilities.UniversalFallback(inner)
-#     MOI.Test.runtests(
-#         model,
-#         MOI.Test.Config(exclude = Any[MOI.optimize!]),
-#         exclude = String[
-#             # UniversalFallback fails all these tests because it supports
-#             # everything
-#             "test_attribute_",
-#             "test_model_supports_constraint_",
-#             "test_model_copy_to_Unsupported",
-#             # Bugs in UniversalFallback
-#             "test_model_LowerBoundAlreadySet",
-#             "test_model_UpperBoundAlreadySet",
-#             "test_add_parameter",
-#         ],
-#     )
-#     return
-# end
+function test_MOI_Test()
+    inner = ModelForUniversalFallback{Float64}()
+    model = MOI.Utilities.UniversalFallback(inner)
+    MOI.Test.runtests(
+        model,
+        MOI.Test.Config(exclude = Any[MOI.optimize!]),
+        exclude = String[
+            # UniversalFallback fails all these tests because it supports
+            # everything
+            "test_attribute_",
+            "test_model_supports_constraint_",
+            "test_model_copy_to_Unsupported",
+            # Bugs in UniversalFallback
+            "test_model_LowerBoundAlreadySet",
+            "test_model_UpperBoundAlreadySet",
+            "test_add_parameter",
+        ],
+    )
+    return
+end
 
 function _test_Optimizer_Model_attributes(
     uf::MOI.Utilities.UniversalFallback,

--- a/test/Utilities/universalfallback.jl
+++ b/test/Utilities/universalfallback.jl
@@ -103,6 +103,7 @@ function _test_Optimizer_Model_attributes(
     @test MOI.get(uf, list) == [attr]
     MOI.set(uf, attr, nothing)
     @test isempty(MOI.get(uf, list))
+    MOI.set(uf, attr, 0)
     return
 end
 


### PR DESCRIPTION
x-ref https://github.com/jump-dev/Gurobi.jl/pull/584

We don't have a way to remove attributes once they've been set. We've mostly settled on `nothing` as the resetting to default.

For example
https://github.com/jump-dev/MathOptInterface.jl/blob/278fba5831af37d89bb0faed656e182f260343ff/src/attributes.jl#L329-L331

https://github.com/jump-dev/MathOptInterface.jl/blob/278fba5831af37d89bb0faed656e182f260343ff/src/attributes.jl#L848-L850

https://github.com/jump-dev/MathOptInterface.jl/blob/278fba5831af37d89bb0faed656e182f260343ff/src/attributes.jl#L861-L863