### PR TITLE
Promote bound of Interval if they have different types

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -286,6 +286,10 @@ struct Interval{T<:Real} <: AbstractScalarSet
     upper::T
 end
 
+function Interval(lower, upper)
+    return Interval(promote(lower, upper)...)
+end
+
 function Base.:(==)(a::Interval{T}, b::Interval{T}) where {T}
     return a.lower == b.lower && a.upper == b.upper
 end

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -286,7 +286,7 @@ struct Interval{T<:Real} <: AbstractScalarSet
     upper::T
 end
 
-function Interval(lower, upper)
+function Interval(lower::Real, upper::Real)
     return Interval(promote(lower, upper)...)
 end
 

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -394,6 +394,10 @@ struct Semicontinuous{T<:Real} <: AbstractScalarSet
     upper::T
 end
 
+function Semicontinuous(lower::Real, upper::Real)
+    return Semicontinuous(promote(lower, upper)...)
+end
+
 function Base.:(==)(a::Semicontinuous{T}, b::Semicontinuous{T}) where {T}
     return a.lower == b.lower && a.upper == b.upper
 end
@@ -424,6 +428,10 @@ MathOptInterface.ConstraintIndex{MathOptInterface.VariableIndex, MathOptInterfac
 struct Semiinteger{T<:Real} <: AbstractScalarSet
     lower::T
     upper::T
+end
+
+function Semiinteger(lower::Real, upper::Real)
+    return Semiinteger(promote(lower, upper)...)
 end
 
 function Base.:(==)(a::Semiinteger{T}, b::Semiinteger{T}) where {T}

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -364,7 +364,7 @@ function runtests()
 end
 
 function test_interval_promote()
-    for S in [MOI.Interval, MOI.Semiinteger, MOI.Semicontinuous]
+    for S in (MOI.Interval, MOI.Semiinteger, MOI.Semicontinuous)
         set = S(1.0, π)
         @test set isa S{Float64}
         @test set.lower == 1.0
@@ -374,6 +374,7 @@ function test_interval_promote()
         @test set.lower == 1
         @test set.upper == 2
     end
+    return
 end
 
 end

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -363,6 +363,19 @@ function runtests()
     end
 end
 
+function test_interval_promote()
+    for S in [MOI.Interval, MOI.Semiinteger, MOI.Semicontinuous]
+        set = S(1.0, π)
+        @test set isa S{Float64}
+        @test set.lower == 1.0
+        @test set.upper == π
+        set = S(big(1), 2)
+        @test set isa S{BigInt}
+        @test set.lower == 1
+        @test set.upper == 2
+    end
+end
+
 end
 
 TestSets.runtests()

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -368,7 +368,7 @@ function test_interval_promote()
         set = S(1.0, π)
         @test set isa S{Float64}
         @test set.lower == 1.0
-        @test set.upper == π
+        @test set.upper ≈ π
         set = S(big(1), 2)
         @test set isa S{BigInt}
         @test set.lower == 1


### PR DESCRIPTION
- [x] Add tests
- [x] Do it for `Semiinteger` and `Semicontinuous` as well

Closes https://github.com/jump-dev/MathOptInterface.jl/issues/2576