### PR TITLE
[Bridges] add ComplementsToScalarNonlinearFunctionBridge

### DIFF
--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -113,6 +113,10 @@ function add_all_bridges(bridged_model, ::Type{T}) where {T}
         bridged_model,
         ExponentialConeToScalarNonlinearFunctionBridge{T},
     )
+    MOI.Bridges.add_bridge(
+        bridged_model,
+        ComplementsToScalarNonlinearFunctionBridge{T},
+    )
     return
 end
 

--- a/src/Bridges/Constraint/bridges/ComplementsToScalarNonlinearFunctionBridge.jl
+++ b/src/Bridges/Constraint/bridges/ComplementsToScalarNonlinearFunctionBridge.jl
@@ -1,0 +1,242 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+"""
+    ComplementsToScalarNonlinearFunctionBridge{T,F} <:
+        Bridges.Constraint.AbstractBridge
+
+`ComplementsToScalarNonlinearFunctionBridge` implements the following
+reformulation:
+
+  * ``(F, x) \\in \\textsf{Complements}()`` to
+    ```julia
+    if isfinite(l)
+        (x - l) * F <= 0.0
+    else
+        1.0 * F <= 0.0
+    end
+    if isfinite(u)
+        (x - u) * F <= 0.0
+    else
+        -1.0 * F <= 0.0
+    end
+    ```
+
+## Source node
+
+`ComplementsToScalarNonlinearFunctionBridge` supports:
+
+  * `F` in [`MOI.Complements`](@ref)
+
+## Target nodes
+
+`ComplementsToScalarNonlinearFunctionBridge` creates:
+
+  * [`MOI.ScalarNonlinearFunction`](@ref) in [`MOI.LessThan{T}`](@ref)
+"""
+mutable struct ComplementsToScalarNonlinearFunctionBridge{
+    T,
+    F<:Union{
+        MOI.VectorOfVariables,
+        MOI.VectorAffineFunction{T},
+        MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
+    },
+} <: AbstractBridge
+    f::F
+    ci::Vector{MOI.ConstraintIndex{MOI.ScalarNonlinearFunction,MOI.LessThan{T}}}
+    bounds::Vector{NTuple{2,T}}
+    function ComplementsToScalarNonlinearFunctionBridge{T}(
+        f,
+        ::MOI.Complements,
+    ) where {T}
+        ci = MOI.ConstraintIndex{MOI.ScalarNonlinearFunction,MOI.LessThan{T}}[]
+        return new{T,typeof(f)}(f, ci, NTuple{2,T}[])
+    end
+end
+
+const ComplementsToScalarNonlinearFunction{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{ComplementsToScalarNonlinearFunctionBridge{T},OT}
+
+function bridge_constraint(
+    ::Type{ComplementsToScalarNonlinearFunctionBridge{T,F}},
+    model::MOI.ModelLike,
+    f::F,
+    s::MOI.Complements,
+) where {
+    T,
+    F<:Union{
+        MOI.VectorOfVariables,
+        MOI.VectorAffineFunction{T},
+        MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
+    },
+}
+    # !!! info
+    #     Postpone creation until final_touch.
+    return ComplementsToScalarNonlinearFunctionBridge{T}(f, s)
+end
+
+function MOI.supports_constraint(
+    ::Type{<:ComplementsToScalarNonlinearFunctionBridge{T}},
+    ::Type{F},
+    ::Type{MOI.Complements},
+) where {
+    T,
+    F<:Union{
+        MOI.VectorOfVariables,
+        MOI.VectorAffineFunction{T},
+        MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
+    },
+}
+    return true
+end
+
+function MOI.Bridges.added_constrained_variable_types(
+    ::Type{<:ComplementsToScalarNonlinearFunctionBridge},
+)
+    return Tuple{Type}[]
+end
+
+function MOI.Bridges.added_constraint_types(
+    ::Type{<:ComplementsToScalarNonlinearFunctionBridge{T}},
+) where {T}
+    return Tuple{Type,Type}[(MOI.ScalarNonlinearFunction, MOI.LessThan{T})]
+end
+
+function concrete_bridge_type(
+    ::Type{<:ComplementsToScalarNonlinearFunctionBridge{T}},
+    ::Type{F},
+    ::Type{MOI.Complements},
+) where {
+    T,
+    F<:Union{
+        MOI.VectorOfVariables,
+        MOI.VectorAffineFunction{T},
+        MOI.VectorQuadraticFunction{T},
+        MOI.VectorNonlinearFunction,
+    },
+}
+    return ComplementsToScalarNonlinearFunctionBridge{T,F}
+end
+
+function MOI.get(
+    ::MOI.ModelLike,
+    ::MOI.ConstraintFunction,
+    bridge::ComplementsToScalarNonlinearFunctionBridge,
+)
+    return copy(bridge.f)
+end
+
+function MOI.get(
+    ::MOI.ModelLike,
+    ::MOI.ConstraintSet,
+    bridge::ComplementsToScalarNonlinearFunctionBridge,
+)
+    n = MOI.output_dimension(bridge.f)
+    return MOI.Complements(n)
+end
+
+function MOI.delete(
+    model::MOI.ModelLike,
+    bridge::ComplementsToScalarNonlinearFunctionBridge,
+)
+    MOI.delete.(model, bridge.ci)
+    empty!(bridge.bounds)
+    return
+end
+
+function MOI.get(
+    ::ComplementsToScalarNonlinearFunctionBridge,
+    ::MOI.NumberOfVariables,
+)::Int64
+    return 0
+end
+
+function MOI.get(
+    ::ComplementsToScalarNonlinearFunctionBridge,
+    ::MOI.ListOfVariableIndices,
+)::Vector{MOI.VariableIndex}
+    return MOI.VariableIndex[]
+end
+
+function MOI.get(
+    bridge::ComplementsToScalarNonlinearFunctionBridge{T},
+    ::MOI.NumberOfConstraints{MOI.ScalarNonlinearFunction,MOI.LessThan{T}},
+)::Int64 where {T}
+    return length(bridge.ci)
+end
+
+function MOI.get(
+    bridge::ComplementsToScalarNonlinearFunctionBridge{T},
+    ::MOI.ListOfConstraintIndices{MOI.ScalarNonlinearFunction,MOI.LessThan{T}},
+) where {T}
+    return copy(bridge.ci)
+end
+
+function MOI.Bridges.needs_final_touch(
+    ::ComplementsToScalarNonlinearFunctionBridge,
+)
+    return true
+end
+
+function MOI.Bridges.final_touch(
+    bridge::ComplementsToScalarNonlinearFunctionBridge{T},
+    model::MOI.ModelLike,
+) where {T}
+    f = collect(MOI.Utilities.eachscalar(bridge.f))
+    N = div(length(f), 2)
+    final_touch_called_previously = isempty(bridge.bounds)
+    for i in 1:N
+        x = convert(MOI.VariableIndex, f[i+N])
+        ret = MOI.Utilities.get_bounds(model, T, x)
+        ret = something(ret, (typemin(T), typemax(T)))
+        if length(bridge.bounds) < i
+            # This is the first time calling final_touch
+            push!(bridge.bounds, ret)
+        elseif bridge.bounds[i] == ret
+            # We've called final_touch before, and the bounds match. No need to
+            # reformulate a second time.
+            continue
+        elseif bridge.bounds[i] != ret
+            # There is a stored bound, and the current bounds do not match. This
+            # means the model has been modified since the previous call to
+            # final_touch. We need to delete the bridge and start again.
+            MOI.delete(model, bridge)
+            MOI.Bridges.final_touch(bridge, model)
+            return
+        end
+    end
+    if final_touch_called_previously
+        return  # Nothing to be done
+    end
+    for i in 1:N
+        (l, u), F = bridge.bounds[i], f[i]
+        x = convert(MOI.VariableIndex, f[N+i])
+        g_l = if isfinite(l) && iszero(l)
+            MOI.ScalarNonlinearFunction(:*, Any[x, F])
+        elseif isfinite(l)
+            x_l = MOI.ScalarNonlinearFunction(:-, Any[x, l])
+            MOI.ScalarNonlinearFunction(:*, Any[x_l, F])
+        elseif F isa MOI.ScalarNonlinearFunction
+            F
+        else
+            MOI.ScalarNonlinearFunction(:+, Any[F])
+        end
+        push!(bridge.ci, MOI.add_constraint(model, g_l, MOI.LessThan(zero(T))))
+        g_u = if isfinite(u) && iszero(u)
+            MOI.ScalarNonlinearFunction(:*, Any[x, F])
+        elseif isfinite(u)
+            x_u = MOI.ScalarNonlinearFunction(:-, Any[x, u])
+            MOI.ScalarNonlinearFunction(:*, Any[x_u, F])
+        else
+            MOI.ScalarNonlinearFunction(:*, Any[-one(T), F])
+        end
+        push!(bridge.ci, MOI.add_constraint(model, g_u, MOI.LessThan(zero(T))))
+    end
+    return
+end

--- a/src/Bridges/Constraint/bridges/ComplementsToScalarNonlinearFunctionBridge.jl
+++ b/src/Bridges/Constraint/bridges/ComplementsToScalarNonlinearFunctionBridge.jl
@@ -54,7 +54,7 @@ mutable struct ComplementsToScalarNonlinearFunctionBridge{
     y::Vector{MOI.VariableIndex}
     ci_eq::Vector{MOI.ConstraintIndex{G,MOI.EqualTo{T}}}
     ci_lt::Vector{
-        MOI.ConstraintIndex{MOI.ScalarQuadraticFunction{T},MOI.LessThan{T}}
+        MOI.ConstraintIndex{MOI.ScalarQuadraticFunction{T},MOI.LessThan{T}},
     }
     bounds::Vector{NTuple{2,T}}
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -68,6 +68,9 @@ constant(::VariableIndex, ::Type{T}) where {T} = zero(T)
 
 Base.copy(x::VariableIndex) = x
 
+Base.isapprox(::Number, ::AbstractScalarFunction; kwargs...) = false
+Base.isapprox(::AbstractScalarFunction, ::Number; kwargs...) = false
+
 Base.isapprox(x::VariableIndex, y::VariableIndex; kwargs...) = x == y
 
 """
@@ -971,6 +974,16 @@ function Base.convert(
     f::ScalarQuadraticFunction{T},
 ) where {T}
     return convert(VariableIndex, convert(ScalarAffineFunction{T}, f))
+end
+
+function Base.convert(
+    ::Type{VariableIndex},
+    f::ScalarNonlinearFunction,
+) where {T}
+    if f.head != :+ && length(f.args) != 1
+        throw(InexactError(:convert, VariableIndex, f))
+    end
+    return convert(VariableIndex, only(f.args))
 end
 
 # ScalarAffineFunction

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -976,10 +976,7 @@ function Base.convert(
     return convert(VariableIndex, convert(ScalarAffineFunction{T}, f))
 end
 
-function Base.convert(
-    ::Type{VariableIndex},
-    f::ScalarNonlinearFunction,
-) where {T}
+function Base.convert(::Type{VariableIndex}, f::ScalarNonlinearFunction)
     if f.head != :+ && length(f.args) != 1
         throw(InexactError(:convert, VariableIndex, f))
     end

--- a/test/Bridges/Constraint/ComplementsToScalarNonlinearFunctionBridge.jl
+++ b/test/Bridges/Constraint/ComplementsToScalarNonlinearFunctionBridge.jl
@@ -35,7 +35,7 @@ function test_runtests_VectorOfVariables()
         1.0 * x * y <= 0.0
         y in Interval(0.0, Inf)
         x >= 0.0
-        """
+        """,
     )
     MOI.Bridges.runtests(
         MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,

--- a/test/Bridges/Constraint/ComplementsToScalarNonlinearFunctionBridge.jl
+++ b/test/Bridges/Constraint/ComplementsToScalarNonlinearFunctionBridge.jl
@@ -30,11 +30,12 @@ function test_runtests_VectorOfVariables()
         x >= 0.0
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction(x * f) <= 0.0
-        ScalarNonlinearFunction(*(-1.0, f)) <= 0.0
+        variables: f, x, y
+        1.0 * f + -1.0 * y == 0.0
+        1.0 * x * y <= 0.0
+        y in Interval(0.0, Inf)
         x >= 0.0
-        """,
+        """
     )
     MOI.Bridges.runtests(
         MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
@@ -44,9 +45,10 @@ function test_runtests_VectorOfVariables()
         x >= 1.0
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction((x - 1.0) * f) <= 0.0
-        ScalarNonlinearFunction(-1.0 * f) <= 0.0
+        variables: f, x, y
+        1.0 * f + -1.0 * y == 0.0
+        1.0 * x * y + -1.0 * y <= 0.0
+        y in Interval(0.0, Inf)
         x >= 1.0
         """,
     )
@@ -58,9 +60,10 @@ function test_runtests_VectorOfVariables()
         x <= 1.0
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction((x - 1.0) * f) <= 0.0
-        ScalarNonlinearFunction(+(f)) <= 0.0
+        variables: f, x, y
+        1.0 * f + -1.0 * y == 0.0
+        1.0 * x * y + -1.0 * y <= 0.0
+        y in Interval(-Inf, 0.0)
         x <= 1.0
         """,
     )
@@ -73,9 +76,11 @@ function test_runtests_VectorOfVariables()
         x <= 2.0
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction((x - 2.0) * f) <= 0.0
-        ScalarNonlinearFunction((x - 1.0) * f) <= 0.0
+        variables: f, x, y
+        1.0 * f + -1.0 * y == 0.0
+        1.0 * x * y + -2.0 * y <= 0.0
+        1.0 * x * y + -1.0 * y <= 0.0
+        y in Interval(-Inf, Inf)
         x >= 1.0
         x <= 2.0
         """,
@@ -87,9 +92,9 @@ function test_runtests_VectorOfVariables()
         [f, x] in Complements(2)
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction(+(f)) <= 0.0
-        ScalarNonlinearFunction(-1.0 * f) <= 0.0
+        variables: f, x, y
+        1.0 * f + -1.0 * y == 0.0
+        y in Interval(0.0, 0.0)
         """,
     )
     MOI.Bridges.runtests(
@@ -103,15 +108,17 @@ function test_runtests_VectorOfVariables()
         x2 >= 4.0
         """,
         """
-        variables: f1, f2, x1, x2
+        variables: f1, f2, x1, x2, y1, y2
         f1 >= 1.0
         f2 >= 2.0
         x1 >= 3.0
         x2 >= 4.0
-        ScalarNonlinearFunction((x1 - 3.0) * f1) <= 0.0
-        ScalarNonlinearFunction(-1.0 * f1) <= 0.0
-        ScalarNonlinearFunction((x2 - 4.0) * f2) <= 0.0
-        ScalarNonlinearFunction(-1.0 * f2) <= 0.0
+        1.0 * f1 + -1.0 * y1 == 0.0
+        1.0 * f2 + -1.0 * y2 == 0.0
+        1.0 * x1 * y1 + -3.0 * y1 <= 0.0
+        y1 in Interval(0.0, Inf)
+        1.0 * x2 * y2 + -4.0 * y2 <= 0.0
+        y2 in Interval(0.0, Inf)
         """,
     )
     return
@@ -126,9 +133,10 @@ function test_runtests_ScalarAffineFunction()
         x >= 0.0
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction(x * esc(2.0 * f + 1.0)) <= 0.0
-        ScalarNonlinearFunction(*(-1.0, esc(2.0 * f + 1.0))) <= 0.0
+        variables: f, x, y
+        2.0 * f + 1.0 + -1.0 * y == 0.0
+        1.0 * x * y <= 0.0
+        y in Interval(0.0, Inf)
         x >= 0.0
         """,
     )
@@ -139,9 +147,9 @@ function test_runtests_ScalarAffineFunction()
         [2.0 * f + 1.0, x] in Complements(2)
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction(+(esc(2.0 * f + 1.0))) <= 0.0
-        ScalarNonlinearFunction(-1.0 * esc(2.0 * f + 1.0)) <= 0.0
+        variables: f, x, y
+        2.0 * f + 1.0 + -1.0 * y == 0.0
+        y in Interval(0.0, 0.0)
         """,
     )
     return
@@ -156,9 +164,10 @@ function test_runtests_ScalarQuadraticFunction()
         x >= 0.0
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction(x * esc(2.0 * f * f + 1.0)) <= 0.0
-        ScalarNonlinearFunction(*(-1.0, esc(2.0 * f * f + 1.0))) <= 0.0
+        variables: f, x, y
+        2.0 * f * f + 1.0 + -1.0 * y == 0.0
+        1.0 * x * y <= 0.0
+        y in Interval(0.0, Inf)
         x >= 0.0
         """,
     )
@@ -169,9 +178,9 @@ function test_runtests_ScalarQuadraticFunction()
         [2.0 * f * f + 1.0, x] in Complements(2)
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction(+(esc(2.0 * f * f + 1.0))) <= 0.0
-        ScalarNonlinearFunction(-1.0 * esc(2.0 * f * f + 1.0)) <= 0.0
+        variables: f, x, y
+        2.0 * f * f + 1.0 + -1.0 * y == 0.0
+        y in Interval(0.0, 0.0)
         """,
     )
     return
@@ -186,9 +195,10 @@ function test_runtests_ScalarNonlinearFunction()
         x >= 0.0
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction(x * sin(f)) <= 0.0
-        ScalarNonlinearFunction(*(-1.0, sin(f))) <= 0.0
+        variables: f, x, y
+        ScalarNonlinearFunction(sin(f) - y) == 0.0
+        1.0 * x * y <= 0.0
+        y in Interval(0.0, Inf)
         x >= 0.0
         """,
     )
@@ -199,9 +209,9 @@ function test_runtests_ScalarNonlinearFunction()
         VectorNonlinearFunction([sin(f), x]) in Complements(2)
         """,
         """
-        variables: f, x
-        ScalarNonlinearFunction(sin(f)) <= 0.0
-        ScalarNonlinearFunction(-1.0 * sin(f)) <= 0.0
+        variables: f, x, y
+        ScalarNonlinearFunction(sin(f) - y) == 0.0
+        y in Interval(0.0, 0.0)
         """,
     )
     return

--- a/test/Bridges/Constraint/ComplementsToScalarNonlinearFunctionBridge.jl
+++ b/test/Bridges/Constraint/ComplementsToScalarNonlinearFunctionBridge.jl
@@ -1,0 +1,212 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestConstraintComplementsToScalarNonlinearFunctionBridge
+
+using Test
+
+import MathOptInterface as MOI
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function test_runtests_VectorOfVariables()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        [f, x] in Complements(2)
+        x >= 0.0
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction(x * f) <= 0.0
+        ScalarNonlinearFunction(*(-1.0, f)) <= 0.0
+        x >= 0.0
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        [f, x] in Complements(2)
+        x >= 1.0
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction((x - 1.0) * f) <= 0.0
+        ScalarNonlinearFunction(-1.0 * f) <= 0.0
+        x >= 1.0
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        [f, x] in Complements(2)
+        x <= 1.0
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction((x - 1.0) * f) <= 0.0
+        ScalarNonlinearFunction(+(f)) <= 0.0
+        x <= 1.0
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        [f, x] in Complements(2)
+        x >= 1.0
+        x <= 2.0
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction((x - 2.0) * f) <= 0.0
+        ScalarNonlinearFunction((x - 1.0) * f) <= 0.0
+        x >= 1.0
+        x <= 2.0
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        [f, x] in Complements(2)
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction(+(f)) <= 0.0
+        ScalarNonlinearFunction(-1.0 * f) <= 0.0
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f1, f2, x1, x2
+        [f1, f2, x1, x2] in Complements(4)
+        f1 >= 1.0
+        f2 >= 2.0
+        x1 >= 3.0
+        x2 >= 4.0
+        """,
+        """
+        variables: f1, f2, x1, x2
+        f1 >= 1.0
+        f2 >= 2.0
+        x1 >= 3.0
+        x2 >= 4.0
+        ScalarNonlinearFunction((x1 - 3.0) * f1) <= 0.0
+        ScalarNonlinearFunction(-1.0 * f1) <= 0.0
+        ScalarNonlinearFunction((x2 - 4.0) * f2) <= 0.0
+        ScalarNonlinearFunction(-1.0 * f2) <= 0.0
+        """,
+    )
+    return
+end
+
+function test_runtests_ScalarAffineFunction()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        [2.0 * f + 1.0, x] in Complements(2)
+        x >= 0.0
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction(x * esc(2.0 * f + 1.0)) <= 0.0
+        ScalarNonlinearFunction(*(-1.0, esc(2.0 * f + 1.0))) <= 0.0
+        x >= 0.0
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        [2.0 * f + 1.0, x] in Complements(2)
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction(+(esc(2.0 * f + 1.0))) <= 0.0
+        ScalarNonlinearFunction(-1.0 * esc(2.0 * f + 1.0)) <= 0.0
+        """,
+    )
+    return
+end
+
+function test_runtests_ScalarQuadraticFunction()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        [2.0 * f * f + 1.0, x] in Complements(2)
+        x >= 0.0
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction(x * esc(2.0 * f * f + 1.0)) <= 0.0
+        ScalarNonlinearFunction(*(-1.0, esc(2.0 * f * f + 1.0))) <= 0.0
+        x >= 0.0
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        [2.0 * f * f + 1.0, x] in Complements(2)
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction(+(esc(2.0 * f * f + 1.0))) <= 0.0
+        ScalarNonlinearFunction(-1.0 * esc(2.0 * f * f + 1.0)) <= 0.0
+        """,
+    )
+    return
+end
+
+function test_runtests_ScalarNonlinearFunction()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        VectorNonlinearFunction([sin(f), x]) in Complements(2)
+        x >= 0.0
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction(x * sin(f)) <= 0.0
+        ScalarNonlinearFunction(*(-1.0, sin(f))) <= 0.0
+        x >= 0.0
+        """,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.ComplementsToScalarNonlinearFunctionBridge,
+        """
+        variables: f, x
+        VectorNonlinearFunction([sin(f), x]) in Complements(2)
+        """,
+        """
+        variables: f, x
+        ScalarNonlinearFunction(sin(f)) <= 0.0
+        ScalarNonlinearFunction(-1.0 * sin(f)) <= 0.0
+        """,
+    )
+    return
+end
+
+end  # module
+
+TestConstraintComplementsToScalarNonlinearFunctionBridge.runtests()


### PR DESCRIPTION
Closes #2589

This would be a replacement for Complementarity.jl (cc @chkwon). It's not a perfect replacement because there's no flexibility in how we reformulate, but it's good enough for basic stuff:
```julia
julia> using JuMP, Ipopt

julia> begin
           model = Model(Ipopt.Optimizer)
           set_silent(model)
           @variable(model, x)
           @variable(model, z)
           @variable(model, w >= 0)
           @objective(model, Min, (x - 3.5)^2 + (z + 4)^2)
           @constraint(model, z - 3 + 2*z*w == 0)
           @constraint(model, -(z^2 - x) ⟂  w)
           optimize!(model)
           solution_summary(model)
       end
* Solver : Ipopt

* Status
  Result count       : 1
  Termination status : LOCALLY_SOLVED
  Message from the solver:
  "Solve_Succeeded"

* Candidate solution (result #1)
  Primal status      : FEASIBLE_POINT
  Dual status        : FEASIBLE_POINT
  Objective value    : 2.82500e+01

* Work counters
  Solve time (sec)   : 8.78320e-02
  Barrier iterations : 303
```

Current reformulation is really just a proof of concept to check things work. Numerically, we might be better off doing this reformulation though. It just required more lines of code so I didn't do it to begin with.

```julia
y - F == 0  # G-in-EqualTo
if isfinite(l)
    (x - l) * y <= 0.0  # ScalarQuadratic-in-LessThan
else
    y <= 0.0  # VariableIndex-in-LessThan
end
if isfinite(u)
    (x - u) * y <= 0.0  # ScalarQuadratic-in-LessThan
else
    y >= 0.0.  # VariableIndex-in-GreaterThan
end
```