### PR TITLE
Use variable_start in Bridges.runtests

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -300,7 +300,7 @@ function runtests(
         x = MOI.get(model, MOI.ListOfVariableIndices())
         MOI.set(model, attr, x, fill(nothing, length(x)))
         Test.@test all(isnothing, MOI.get(model, attr, x))
-        primal_start = fill(constraint_start, length(x))
+        primal_start = fill(variable_start, length(x))
         MOI.set(model, attr, x, primal_start)
         if !isempty(x)
             # ≈ does not work if x is empty because the return of get is Any[]


### PR DESCRIPTION
Looks like it was just an oversight