### PR TITLE
Simplify test_conic_linear with forced bridging

### DIFF
--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -19,8 +19,8 @@ Opt obj = -11, soln x = 1, y = 0, z = 2
 """
 function test_conic_linear_VectorOfVariables(
     model::MOI.ModelLike,
-    config::Config,
-)
+    config::Config{T},
+) where {T}
     @requires MOI.supports_incremental_interface(model)
     @requires MOI.supports(
         model,


### PR DESCRIPTION
A lot of these helpers could be simplified with `SingleBridgeOptimizer`. What we are doing is basically hardcoding a bridge so adding a `SingleBridgeOptimizer` would be equivalent since this bridge optimizer layer always applies the bridge, even if the constraint is supported (which is why I call it *forced* bridging).
This PR just does it for one test as a proof of concept.