### PR TITLE
[Bridges.Variable] add bridges in alphabetical order and change weight

### DIFF
--- a/src/Bridges/Variable/Variable.jl
+++ b/src/Bridges/Variable/Variable.jl
@@ -25,15 +25,15 @@ Add all bridges defined in the `Bridges.Variable` submodule to `model`.
 The coefficient type used is `T`.
 """
 function add_all_bridges(model, ::Type{T}) where {T}
-    MOI.Bridges.add_bridge(model, ZerosBridge{T})
     MOI.Bridges.add_bridge(model, FreeBridge{T})
-    MOI.Bridges.add_bridge(model, NonposToNonnegBridge{T})
-    MOI.Bridges.add_bridge(model, VectorizeBridge{T})
-    MOI.Bridges.add_bridge(model, SOCtoRSOCBridge{T})
-    MOI.Bridges.add_bridge(model, RSOCtoSOCBridge{T})
-    MOI.Bridges.add_bridge(model, RSOCtoPSDBridge{T})
     MOI.Bridges.add_bridge(model, HermitianToSymmetricPSDBridge{T})
+    MOI.Bridges.add_bridge(model, NonposToNonnegBridge{T})
     MOI.Bridges.add_bridge(model, ParameterToEqualToBridge{T})
+    MOI.Bridges.add_bridge(model, RSOCtoPSDBridge{T})
+    MOI.Bridges.add_bridge(model, RSOCtoSOCBridge{T})
+    MOI.Bridges.add_bridge(model, SOCtoRSOCBridge{T})
+    MOI.Bridges.add_bridge(model, VectorizeBridge{T})
+    MOI.Bridges.add_bridge(model, ZerosBridge{T})
     return
 end
 

--- a/src/Bridges/Variable/bridges/RSOCtoPSDBridge.jl
+++ b/src/Bridges/Variable/bridges/RSOCtoPSDBridge.jl
@@ -56,6 +56,8 @@ end
 const RSOCtoPSD{T,OT<:MOI.ModelLike} =
     SingleBridgeOptimizer{RSOCtoPSDBridge{T},OT}
 
+MOI.Bridges.bridging_cost(::Type{<:RSOCtoPSDBridge}) = 1.5
+
 function bridge_constrained_variable(
     ::Type{RSOCtoPSDBridge{T}},
     model::MOI.ModelLike,

--- a/src/Bridges/Variable/bridges/RSOCtoPSDBridge.jl
+++ b/src/Bridges/Variable/bridges/RSOCtoPSDBridge.jl
@@ -56,7 +56,10 @@ end
 const RSOCtoPSD{T,OT<:MOI.ModelLike} =
     SingleBridgeOptimizer{RSOCtoPSDBridge{T},OT}
 
-MOI.Bridges.bridging_cost(::Type{<:RSOCtoPSDBridge}) = 1.5
+# This bridge destorys a lot of structure and adding PSD variables is almost
+# always undesirable. We give this bridge an arbitrarily hight cost so that it
+# is used only if necessary.
+MOI.Bridges.bridging_cost(::Type{<:RSOCtoPSDBridge}) = 10.0
 
 function bridge_constrained_variable(
     ::Type{RSOCtoPSDBridge{T}},

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -1041,13 +1041,13 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
             """
 Bridge graph with 2 variable nodes, 5 constraint nodes and 2 objective nodes.
  [1] constrained variables in `MOI.Reals` are bridged (distance 1) by $(MOI.Bridges.Variable.FreeBridge{T}).
- [2] constrained variables in `MOI.RotatedSecondOrderCone` are bridged (distance 2.5) by $(MOI.Bridges.Variable.RSOCtoPSDBridge{T}).
- (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are bridged (distance 5.5) by $(MOI.Bridges.Constraint.QuadtoSOCBridge{T}).
- (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are bridged (distance 4.5) by $(MOI.Bridges.Constraint.VectorSlackBridge{T,MOI.VectorAffineFunction{T},MOI.RotatedSecondOrderCone}).
+ [2] constrained variables in `MOI.RotatedSecondOrderCone` are bridged (distance 11) by $(MOI.Bridges.Variable.RSOCtoPSDBridge{T}).
+ (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are bridged (distance 14) by $(MOI.Bridges.Constraint.QuadtoSOCBridge{T}).
+ (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are bridged (distance 13) by $(MOI.Bridges.Constraint.VectorSlackBridge{T,MOI.VectorAffineFunction{T},MOI.RotatedSecondOrderCone}).
  (3) `MOI.VariableIndex`-in-`MOI.EqualTo{$T}` constraints are bridged (distance 1) by $(MOI.Bridges.Constraint.ScalarFunctionizeBridge{T,MOI.EqualTo{T}}).
  (4) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are bridged (distance 1) by $(MOI.Bridges.Constraint.ScalarizeBridge{T,MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}).
- (5) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are bridged (distance 5.5) by $(MOI.Bridges.Constraint.QuadtoSOCBridge{T}).
- |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is bridged (distance 14) by $(MOI.Bridges.Objective.SlackBridge{T,MOI.ScalarQuadraticFunction{T},MOI.ScalarQuadraticFunction{T}}).
+ (5) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are bridged (distance 14) by $(MOI.Bridges.Constraint.QuadtoSOCBridge{T}).
+ |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is bridged (distance 31) by $(MOI.Bridges.Objective.SlackBridge{T,MOI.ScalarQuadraticFunction{T},MOI.ScalarQuadraticFunction{T}}).
  |2| objective function of type `MOI.VariableIndex` is bridged (distance 1) by $(MOI.Bridges.Objective.FunctionizeBridge{T,MOI.VariableIndex}).
 """,
         )

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -1041,13 +1041,13 @@ Objective function of type `MOI.ScalarQuadraticFunction{$T}` is not supported an
             """
 Bridge graph with 2 variable nodes, 5 constraint nodes and 2 objective nodes.
  [1] constrained variables in `MOI.Reals` are bridged (distance 1) by $(MOI.Bridges.Variable.FreeBridge{T}).
- [2] constrained variables in `MOI.RotatedSecondOrderCone` are bridged (distance 2) by $(MOI.Bridges.Variable.RSOCtoPSDBridge{T}).
- (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are bridged (distance 5) by $(MOI.Bridges.Constraint.QuadtoSOCBridge{T}).
- (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are bridged (distance 4) by $(MOI.Bridges.Constraint.VectorSlackBridge{T,MOI.VectorAffineFunction{T},MOI.RotatedSecondOrderCone}).
+ [2] constrained variables in `MOI.RotatedSecondOrderCone` are bridged (distance 2.5) by $(MOI.Bridges.Variable.RSOCtoPSDBridge{T}).
+ (1) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.GreaterThan{$T}` constraints are bridged (distance 5.5) by $(MOI.Bridges.Constraint.QuadtoSOCBridge{T}).
+ (2) `MOI.VectorAffineFunction{$T}`-in-`MOI.RotatedSecondOrderCone` constraints are bridged (distance 4.5) by $(MOI.Bridges.Constraint.VectorSlackBridge{T,MOI.VectorAffineFunction{T},MOI.RotatedSecondOrderCone}).
  (3) `MOI.VariableIndex`-in-`MOI.EqualTo{$T}` constraints are bridged (distance 1) by $(MOI.Bridges.Constraint.ScalarFunctionizeBridge{T,MOI.EqualTo{T}}).
  (4) `MOI.VectorAffineFunction{$T}`-in-`MOI.Zeros` constraints are bridged (distance 1) by $(MOI.Bridges.Constraint.ScalarizeBridge{T,MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}).
- (5) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are bridged (distance 5) by $(MOI.Bridges.Constraint.QuadtoSOCBridge{T}).
- |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is bridged (distance 13) by $(MOI.Bridges.Objective.SlackBridge{T,MOI.ScalarQuadraticFunction{T},MOI.ScalarQuadraticFunction{T}}).
+ (5) `MOI.ScalarQuadraticFunction{$T}`-in-`MOI.LessThan{$T}` constraints are bridged (distance 5.5) by $(MOI.Bridges.Constraint.QuadtoSOCBridge{T}).
+ |1| objective function of type `MOI.ScalarQuadraticFunction{$T}` is bridged (distance 14) by $(MOI.Bridges.Objective.SlackBridge{T,MOI.ScalarQuadraticFunction{T},MOI.ScalarQuadraticFunction{T}}).
  |2| objective function of type `MOI.VariableIndex` is bridged (distance 1) by $(MOI.Bridges.Objective.FunctionizeBridge{T,MOI.VariableIndex}).
 """,
         )


### PR DESCRIPTION
Extracted from #2596 

The behaviour should, where possible, not depend on this somewhat arbitrary order of bridges in this function. That is too brittle and the behaviour is undocumented.