### PR TITLE
Prep for v1.35.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.34.0"
+version = "1.35.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.35.0 (January 7, 2025)
+## v1.35.0 (January 9, 2025)
 
 ### Added
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,36 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.35.0 (January 6, 2025)
+
+### Added
+
+ - Added [`Bridges.Constraint.InequalityToComplementsBridge`](@ref). This
+   bridge is not added by default (#2582)
+ - Added [`Bridges.Constraint.ExponentialConeToScalarNonlinearFunctionBridge`](@ref).
+   This bridge is not added by default (#2587)
+ - Added support for `SetMap` bridges to use the value of a bridge in
+   `map_function` instead of the type (#2198)
+
+### Fixed
+
+ - Fixed a bug querying result attributes in a bridge with `result_index != 1`
+   (#2583)
+ - Fixed various nonlinear tests to add a starting point (#2585)
+ - Fixed a bug with `variable_start` in [`Bridges.runtests`](@ref) (#2592)
+ - Fixed `test_basic_` tests for [`Indicator`](@ref) sets to make the first
+   variable [`ZeroOne`](@ref) (#2600)
+ - Changed the weights of the `SOCtoPSD` and `RSOCtoPSD` bridges so that they
+   are used only if necessary. Previously, these depended on the order in which
+   they were added to a `LazyBridgeOptimizer` (#2596) (#2598) (#2599)
+
+### Other
+
+ - Added more tests for nonlinear programs (#2584)
+ - Renamed files in `Bridges` to reflect the type of the bridge (#2586)
+ - Added more tests for [`DualObjectiveValue`](@ref) (#2588)
+ - Added a test for multiple PSD variables in the same constraint (#2594)
+
 ## v1.34.0 (November 7, 2024)
 
 ### Added

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.35.0 (January 6, 2025)
+## v1.35.0 (January 7, 2025)
 
 ### Added
 


### PR DESCRIPTION
## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

https://github.com/jump-dev/MathOptInterface.jl/actions/runs/12622888300

 - [x] DiffOpt https://github.com/jump-dev/DiffOpt.jl/pull/264
 - [x] MiniZinc https://github.com/jump-dev/MiniZinc.jl/pull/91
 - [x] NLopt https://github.com/jump-dev/NLopt.jl/pull/251
 - [x] PolyJuMP: installation issues
 - [x] SumOfSquares: installation issues
 - [x] Xpress https://github.com/jump-dev/Xpress.jl/pull/284
 - [x] Clarabel same issue as COSMO
 - [x] COSMO https://github.com/oxfordcontrol/COSMO.jl/issues/195
 - [x] DSDP tolerance issues
 - [x] EAGO https://github.com/PSORLab/EAGO.jl/issues/142