### PR TITLE
[Utilities] add fallbacks for scalar_type and vector_type

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -592,7 +592,7 @@ end
 Type of functions obtained by indexing objects obtained by calling `eachscalar`
 on functions of type `F`.
 """
-function scalar_type end
+scalar_type(::Type{F}) where {F} = Any  # A default fallback
 
 scalar_type(::Type{<:AbstractVector{T}}) where {T} = T
 
@@ -614,7 +614,7 @@ scalar_type(::Type{MOI.VectorNonlinearFunction}) = MOI.ScalarNonlinearFunction
 Return the [`MOI.AbstractVectorFunction`](@ref) associated with the scalar type
 `F`.
 """
-function vector_type end
+vector_type(::Type{F}) where {F} = Any  # A default fallback
 
 vector_type(::Type{T}) where {T} = Vector{T}
 

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -592,7 +592,7 @@ end
 Type of functions obtained by indexing objects obtained by calling `eachscalar`
 on functions of type `F`.
 """
-scalar_type(::Type{F}) where {F} = Any  # A default fallback
+scalar_type(::Type{<:MOI.AbstractVectorFunction}) = Any  # A default fallback
 
 scalar_type(::Type{<:AbstractVector{T}}) where {T} = T
 
@@ -614,7 +614,7 @@ scalar_type(::Type{MOI.VectorNonlinearFunction}) = MOI.ScalarNonlinearFunction
 Return the [`MOI.AbstractVectorFunction`](@ref) associated with the scalar type
 `F`.
 """
-vector_type(::Type{F}) where {F} = Any  # A default fallback
+function vector_type end
 
 vector_type(::Type{T}) where {T} = Vector{T}
 


### PR DESCRIPTION
https://github.com/jump-dev/MathOptInterface.jl/pull/2198 broke DiffOpt because it adds a call to `scalar_type`:
https://github.com/jump-dev/MathOptInterface.jl/pull/2601#issuecomment-2571845947

Ideally, we should have something that works always (but might be sub-optimal), and then DiffOpt can implement `scalar_type` if it wants better performance.