### PR TITLE
[Bridges] fix including files which are not .jl files

### DIFF
--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -18,7 +18,9 @@ include("set_map.jl")
 include("single_bridge_optimizer.jl")
 
 for filename in readdir(joinpath(@__DIR__, "bridges"); join = true)
-    include(filename)
+    if endswith(filename, ".jl")
+        include(filename)
+    end
 end
 
 """

--- a/src/Bridges/Objective/Objective.jl
+++ b/src/Bridges/Objective/Objective.jl
@@ -13,7 +13,9 @@ include("map.jl")
 include("single_bridge_optimizer.jl")
 
 for filename in readdir(joinpath(@__DIR__, "bridges"); join = true)
-    include(filename)
+    if endswith(filename, ".jl")
+        include(filename)
+    end
 end
 
 """

--- a/src/Bridges/Variable/Variable.jl
+++ b/src/Bridges/Variable/Variable.jl
@@ -14,7 +14,9 @@ include("set_map.jl")
 include("single_bridge_optimizer.jl")
 
 for filename in readdir(joinpath(@__DIR__, "bridges"); join = true)
-    include(filename)
+    if endswith(filename, ".jl")
+        include(filename)
+    end
 end
 
 """


### PR DESCRIPTION
This broke SDDP.jl (and I've seen it somewhere else too): https://github.com/odow/SDDP.jl/actions/runs/13017930580/job/36311572225?pr=827#step:6:412

The issue is that `julia-actions/cache` runs after we have generated the `.cov` files, so if the cache is loaded in a new run, then precompile will attempt to load the `.cov` files. We jus need to skip them.