### PR TITLE
Add all linear indicator constraints in the Utilities.Model

### DIFF
--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -771,6 +771,17 @@ const LessThanIndicatorOne{T} =
 const LessThanIndicatorZero{T} =
     MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.LessThan{T}}
 
+const GreaterThanIndicatorOne{T} =
+    MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.GreaterThan{T}}
+
+const GreaterThanIndicatorZero{T} =
+    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.GreaterThan{T}}
+
+const EqualToIndicatorOne{T} = MOI.Indicator{MOI.ACTIVATE_ON_ONE,MOI.EqualTo{T}}
+
+const EqualToIndicatorZero{T} =
+    MOI.Indicator{MOI.ACTIVATE_ON_ZERO,MOI.EqualTo{T}}
+
 @model(
     Model,
     (MOI.ZeroOne, MOI.Integer),
@@ -824,6 +835,10 @@ const LessThanIndicatorZero{T} =
         MOI.SOS2,
         LessThanIndicatorOne,
         LessThanIndicatorZero,
+        GreaterThanIndicatorOne,
+        GreaterThanIndicatorZero,
+        EqualToIndicatorOne,
+        EqualToIndicatorZero,
         MOI.Table,
         MOI.BinPacking,
         MOI.HyperRectangle,


### PR DESCRIPTION
For some reason only indicator less than was added to MOI.Utilities.Model, which prevents copying models with that constraint