### PR TITLE
[Nonlinear] fix performance of evaluating univariate operators

### DIFF
--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -376,7 +376,7 @@ function _forward_eval_ϵ(
                 @inbounds child_idx = children_arr[ex.adj.colptr[k]]
                 f′′ = Nonlinear.eval_univariate_hessian(
                     user_operators,
-                    user_operators.univariate_operators[node.index],
+                    node.index,
                     ex.forward_storage[child_idx],
                 )
                 partials_storage_ϵ[child_idx] = f′′ * storage_ϵ[child_idx]

--- a/src/Nonlinear/ReverseAD/reverse_mode.jl
+++ b/src/Nonlinear/ReverseAD/reverse_mode.jl
@@ -248,16 +248,13 @@ function _forward_eval(
             end
         elseif node.type == Nonlinear.NODE_CALL_UNIVARIATE
             child_idx = children_arr[f.adj.colptr[k]]
-            f.forward_storage[k] = Nonlinear.eval_univariate_function(
+            ret_f, ret_f′ =  Nonlinear.eval_univariate_function_and_gradient(
                 operators,
-                operators.univariate_operators[node.index],
+                node.index,
                 f.forward_storage[child_idx],
             )
-            f.partials_storage[child_idx] = Nonlinear.eval_univariate_gradient(
-                operators,
-                operators.univariate_operators[node.index],
-                f.forward_storage[child_idx],
-            )
+            f.forward_storage[k] = ret_f
+            f.partials_storage[child_idx] = ret_f′
         elseif node.type == Nonlinear.NODE_COMPARISON
             children_idx = SparseArrays.nzrange(f.adj, k)
             result = true

--- a/src/Nonlinear/ReverseAD/reverse_mode.jl
+++ b/src/Nonlinear/ReverseAD/reverse_mode.jl
@@ -248,7 +248,7 @@ function _forward_eval(
             end
         elseif node.type == Nonlinear.NODE_CALL_UNIVARIATE
             child_idx = children_arr[f.adj.colptr[k]]
-            ret_f, ret_f′ =  Nonlinear.eval_univariate_function_and_gradient(
+            ret_f, ret_f′ = Nonlinear.eval_univariate_function_and_gradient(
                 operators,
                 node.index,
                 f.forward_storage[child_idx],

--- a/src/Nonlinear/model.jl
+++ b/src/Nonlinear/model.jl
@@ -377,7 +377,7 @@ function evaluate(
             child_idx = children_arr[adj.colptr[k]]
             storage[k] = eval_univariate_function(
                 model.operators,
-                model.operators.univariate_operators[node.index],
+                node.index,
                 storage[child_idx],
             )
         elseif node.type == NODE_COMPARISON

--- a/src/Nonlinear/operators.jl
+++ b/src/Nonlinear/operators.jl
@@ -63,6 +63,33 @@ struct _UnivariateOperator{F,F′,F′′}
     end
 end
 
+function eval_univariate_function(operator::_UnivariateOperator, x::T) where {T}
+    ret = operator.f(x)
+    check_return_type(T, ret)
+    return ret::T
+end
+
+function eval_univariate_gradient(operator::_UnivariateOperator, x::T) where {T}
+    ret = operator.f′(x)
+    check_return_type(T, ret)
+    return ret::T
+end
+
+function eval_univariate_hessian(operator::_UnivariateOperator, x::T) where {T}
+    ret = operator.f′′(x)
+    check_return_type(T, ret)
+    return ret::T
+end
+
+function eval_univariate_function_and_gradient(
+    operator::_UnivariateOperator,
+    x::T,
+) where {T}
+    ret_f = eval_univariate_function(operator, x)
+    ret_f′ = eval_univariate_gradient(operator, x)
+    return ret_f, ret_f′
+end
+
 struct _MultivariateOperator{F,F′,F′′}
     N::Int
     f::F
@@ -564,9 +591,7 @@ function eval_univariate_function(
     end
     offset = id - registry.univariate_user_operator_start
     operator = registry.registered_univariate_operators[offset]
-    ret = operator.f(x)
-    check_return_type(T, ret)
-    return ret::T
+    return eval_univariate_function(operator, x)
 end
 
 """
@@ -619,9 +644,7 @@ function eval_univariate_gradient(
     end
     offset = id - registry.univariate_user_operator_start
     operator = registry.registered_univariate_operators[offset]
-    ret = operator.f′(x)
-    check_return_type(T, ret)
-    return ret::T
+    return eval_univariate_gradient(operator, x)
 end
 
 """
@@ -673,11 +696,7 @@ function eval_univariate_function_and_gradient(
     end
     offset = id - registry.univariate_user_operator_start
     operator = registry.registered_univariate_operators[offset]
-    ret_f = operator.f(x)
-    check_return_type(T, ret_f)
-    ret_f′ = operator.f′(x)
-    check_return_type(T, ret_f′)
-    return ret_f::T, ret_f′::T
+    return eval_univariate_function_and_gradient(operator, x)
 end
 
 """
@@ -732,9 +751,7 @@ function eval_univariate_hessian(
     end
     offset = id - registry.univariate_user_operator_start
     operator = registry.registered_univariate_operators[offset]
-    ret = operator.f′′(x)
-    check_return_type(T, ret)
-    return ret::T
+    return eval_univariate_hessian(operator, x)
 end
 
 """

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -365,6 +365,7 @@ function test_eval_univariate_function()
         (:-, 1.0, -1.0),
         (:abs, -1.1, 1.1),
         (:abs, 1.1, 1.1),
+        (:sin, 1.1, sin(1.1)),
     ]
         id = r.univariate_operator_to_id[op]
         @test Nonlinear.eval_univariate_function(r, op, x) == y
@@ -380,6 +381,7 @@ function test_eval_univariate_gradient()
         (:-, 1.2, -1.0),
         (:abs, -1.1, -1.0),
         (:abs, 1.1, 1.0),
+        (:sin, 1.1, cos(1.1)),
     ]
         id = r.univariate_operator_to_id[op]
         @test Nonlinear.eval_univariate_gradient(r, op, x) == y
@@ -395,6 +397,7 @@ function test_eval_univariate_function_and_gradient()
         (:-, 1.2, (-1.2, -1.0)),
         (:abs, -1.1, (1.1, -1.0)),
         (:abs, 1.1, (1.1, 1.0)),
+        (:sin, 1.1, (sin(1.1), cos(1.1))),
     ]
         id = r.univariate_operator_to_id[op]
         @test Nonlinear.eval_univariate_function_and_gradient(r, op, x) == y

--- a/test/Nonlinear/Nonlinear.jl
+++ b/test/Nonlinear/Nonlinear.jl
@@ -360,28 +360,62 @@ end
 
 function test_eval_univariate_function()
     r = Nonlinear.OperatorRegistry()
-    @test Nonlinear.eval_univariate_function(r, :+, 1.0) == 1.0
-    @test Nonlinear.eval_univariate_function(r, :-, 1.0) == -1.0
-    @test Nonlinear.eval_univariate_function(r, :abs, -1.1) == 1.1
-    @test Nonlinear.eval_univariate_function(r, :abs, 1.1) == 1.1
+    for (op, x, y) in [
+        (:+, 1.0, 1.0),
+        (:-, 1.0, -1.0),
+        (:abs, -1.1, 1.1),
+        (:abs, 1.1, 1.1),
+    ]
+        id = r.univariate_operator_to_id[op]
+        @test Nonlinear.eval_univariate_function(r, op, x) == y
+        @test Nonlinear.eval_univariate_function(r, id, x) == y
+    end
     return
 end
 
 function test_eval_univariate_gradient()
     r = Nonlinear.OperatorRegistry()
-    @test Nonlinear.eval_univariate_gradient(r, :+, 1.2) == 1.0
-    @test Nonlinear.eval_univariate_gradient(r, :-, 1.2) == -1.0
-    @test Nonlinear.eval_univariate_gradient(r, :abs, -1.1) == -1.0
-    @test Nonlinear.eval_univariate_gradient(r, :abs, 1.1) == 1.0
+    for (op, x, y) in [
+        (:+, 1.2, 1.0),
+        (:-, 1.2, -1.0),
+        (:abs, -1.1, -1.0),
+        (:abs, 1.1, 1.0),
+    ]
+        id = r.univariate_operator_to_id[op]
+        @test Nonlinear.eval_univariate_gradient(r, op, x) == y
+        @test Nonlinear.eval_univariate_gradient(r, id, x) == y
+    end
+    return
+end
+
+function test_eval_univariate_function_and_gradient()
+    r = Nonlinear.OperatorRegistry()
+    for (op, x, y) in [
+        (:+, 1.2, (1.2, 1.0)),
+        (:-, 1.2, (-1.2, -1.0)),
+        (:abs, -1.1, (1.1, -1.0)),
+        (:abs, 1.1, (1.1, 1.0)),
+    ]
+        id = r.univariate_operator_to_id[op]
+        @test Nonlinear.eval_univariate_function_and_gradient(r, op, x) == y
+        @test Nonlinear.eval_univariate_function_and_gradient(r, id, x) == y
+    end
     return
 end
 
 function test_eval_univariate_hessian()
     r = Nonlinear.OperatorRegistry()
-    @test Nonlinear.eval_univariate_hessian(r, :+, 1.2) == 0.0
-    @test Nonlinear.eval_univariate_hessian(r, :-, 1.2) == 0.0
-    @test Nonlinear.eval_univariate_hessian(r, :abs, -1.1) == 0.0
-    @test Nonlinear.eval_univariate_hessian(r, :abs, 1.1) == 0.0
+    for (op, x, y) in [
+        (:+, 1.2, 0.0),
+        (:-, 1.2, 0.0),
+        (:abs, -1.1, 0.0),
+        (:abs, 1.1, 0.0),
+        (:sin, 1.0, -sin(1.0)),
+    ]
+        id = r.univariate_operator_to_id[op]
+        @test Nonlinear.eval_univariate_hessian(r, op, x) == y
+        @test Nonlinear.eval_univariate_hessian(r, id, x) == y
+    end
     return
 end
 


### PR DESCRIPTION
With the energy modeling benchmarking that @joaquimg has been doing, we've been talking about how small things never show up in a flame graph until you look at their aggregate across multiple call sites. 

One thing that shows up is `getindex`

<img width="366" alt="image" src="https://github.com/user-attachments/assets/c13bf398-11bb-4e5f-8c13-47acce1acce7" />

With the only giveaway being the `ht_keyindex(::Dict{Symbol,Int}, ::Symbol)` method.

It's because we're calling `operators.univariate_operators[node.index]` in multiple places, which is a `Dict` lookup.

These calls don't show much because of inlining etc. Even in the code view, you're kinda like "call is expensive. Sure"

<img width="1394" alt="image" src="https://github.com/user-attachments/assets/d6be3087-38fc-46fa-b00c-f8b66f57ca07" />

## Before

```Julia
julia> @benchmark(
           MOI.Nonlinear.ReverseAD._reverse_mode($(evaluator.backend), x),
           setup=(x=rand(num_variables(model))),
       )
BenchmarkTools.Trial: 44 samples with 1 evaluation per sample.
 Range (min … max):  112.457 ms … 132.677 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     113.303 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   115.478 ms ±   4.641 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

   █▂                                                            
  ▇███▆▃▁▄▁▁▁▁▁▃▁▁▁▁▁▃▁▁▁▁▃▃▄▃▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▃ ▁
  112 ms           Histogram: frequency by time          133 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

## After

```Julia
julia> @benchmark(
           MOI.Nonlinear.ReverseAD._reverse_mode($(evaluator.backend), x),
           setup=(x=rand(num_variables(model))),
       )
BenchmarkTools.Trial: 48 samples with 1 evaluation per sample.
 Range (min … max):  102.579 ms … 115.444 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     104.459 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   105.355 ms ±   2.961 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ███▆█ ▁                                                   
  ▄▁▁▄▄█████▇█▄▇▄▄▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▁▄▁▄▁▁▁▁▄ ▁
  103 ms           Histogram: frequency by time          115 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

## Script

```Julia
using JuMP, PowerModels, BenchmarkTools
case = "test/data/pglib_opf_case13659_pegase.m"
backend = MOI.Nonlinear.SparseReverseMode()
begin
    pm = PowerModels.instantiate_model(
        case,
        PowerModels.ACPPowerModel,
        PowerModels.build_opf,
    );
    model = pm.model
    nlp = MOI.Nonlinear.Model()
    for (F, S) in list_of_constraint_types(model)
        if F != NonlinearExpr
            continue
        end
        for ci in all_constraints(model, F, S)
            o = constraint_object(ci)
            MOI.Nonlinear.add_constraint(nlp, o.func, o.set)
        end
    end
    evaluator = MOI.Nonlinear.Evaluator(
        nlp,
        backend,
        index.(all_variables(model)),
    )
end;
MOI.initialize(evaluator, [:Grad, :Jac, :Hess])
```