### PR TITLE
[Nonlinear] make _(Function|Subexpression)Storage immutable

### DIFF
--- a/src/Nonlinear/ReverseAD/types.jl
+++ b/src/Nonlinear/ReverseAD/types.jl
@@ -4,7 +4,7 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-mutable struct _SubexpressionStorage
+struct _SubexpressionStorage
     nodes::Vector{Nonlinear.Node}
     adj::SparseArrays.SparseMatrixCSC{Bool,Int}
     const_values::Vector{Float64}
@@ -41,7 +41,7 @@ mutable struct _SubexpressionStorage
     end
 end
 
-mutable struct _FunctionStorage
+struct _FunctionStorage
     nodes::Vector{Nonlinear.Node}
     adj::SparseArrays.SparseMatrixCSC{Bool,Int}
     const_values::Vector{Float64}


### PR DESCRIPTION
Follow up to https://github.com/jump-dev/MathOptInterface.jl/pull/2620 that brings things down to
```Julia
julia> @benchmark(
           MOI.Nonlinear.ReverseAD._reverse_mode($(evaluator.backend), x),
           setup=(x=rand(num_variables(model))),
       )
BenchmarkTools.Trial: 50 samples with 1 evaluation per sample.
 Range (min … max):   97.891 ms … 117.640 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):      98.921 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   100.545 ms ±   3.878 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █ ▁▂                                                           
  ████▆▁▄▃▃▃▁▁▁▃▄▁▄▁▁▃▃▁▁▁▁▁▃▃▁▁▁▃▁▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃ ▁
  97.9 ms          Histogram: frequency by time          118 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

I can't find the reason I made these mutable.

They didn't exist in the original JuMP code:
https://github.com/jump-dev/JuMP.jl/blob/0a6b1e426425e69234f073079c3ebe6301a43f25/src/_Derivatives/forward.jl#L30-L31
so when I created them in https://github.com/jump-dev/MathOptInterface.jl/pull/1803 I guess I had a reason for making them mutable at some point that didn't survive the final factoring.