### PR TITLE
VectorAffineFunction easy constructor

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -2207,14 +2207,7 @@ Returns the vector of scalar affine functions in the form of a
 `MOI.VectorAffineFunction{T}`.
 """
 function vectorize(funcs::AbstractVector{MOI.ScalarAffineFunction{T}}) where {T}
-    nterms =
-        mapreduce(func -> number_of_affine_terms(T, func), +, funcs, init = 0)
-    out_dim = mapreduce(func -> output_dim(T, func), +, funcs, init = 0)
-    terms = Vector{MOI.VectorAffineTerm{T}}(undef, nterms)
-    constant = zeros(T, out_dim)
-    fill_vector(terms, T, fill_terms, number_of_affine_terms, funcs)
-    fill_vector(constant, T, fill_constant, output_dim, funcs)
-    return MOI.VectorAffineFunction(terms, constant)
+    return MOI.VectorAffineFunction(funcs)
 end
 
 """

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -578,6 +578,19 @@ function VectorAffineFunction{T}(f::VectorOfVariables) where {T}
     return VectorAffineFunction(terms, constants)
 end
 
+
+function VectorAffineFunction(elements::Vector{ScalarAffineFunction{T}}) where {T}
+    terms = Vector{VectorAffineTerm{T}}()
+    constants = Vector{T}()
+    for (idx, saf) in enumerate(elements)
+        push!(constants, saf.constant)
+        for term in saf.terms
+            push!(terms, VectorAffineTerm(idx, term))
+        end
+    end
+    return VectorAffineFunction{T}(terms, constants)
+end
+
 """
     VectorQuadraticTerm{T}(
         output_index::Int64,

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -578,8 +578,9 @@ function VectorAffineFunction{T}(f::VectorOfVariables) where {T}
     return VectorAffineFunction(terms, constants)
 end
 
-
-function VectorAffineFunction(elements::Vector{ScalarAffineFunction{T}}) where {T}
+function VectorAffineFunction(
+    elements::Vector{ScalarAffineFunction{T}},
+) where {T}
     terms = Vector{VectorAffineTerm{T}}()
     constants = Vector{T}()
     for (idx, saf) in enumerate(elements)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -579,7 +579,7 @@ function VectorAffineFunction{T}(f::VectorOfVariables) where {T}
 end
 
 function VectorAffineFunction(
-    elements::Vector{ScalarAffineFunction{T}},
+    elements::AbstractVector{ScalarAffineFunction{T}},
 ) where {T}
     terms = Vector{VectorAffineTerm{T}}()
     constants = Vector{T}()

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -579,7 +579,7 @@ function VectorAffineFunction{T}(f::VectorOfVariables) where {T}
 end
 
 function VectorAffineFunction(
-    rows::AbstractVector{ScalarAffineFunction{T}}
+    rows::AbstractVector{ScalarAffineFunction{T}},
 ) where {T}
     ret = VectorAffineFunction{T}(VectorAffineTerm{T}[], T[])
     for (row, f) in enumerate(rows)

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -130,7 +130,7 @@ function test_functions_convert_ScalarQuadraticFunction()
 end
 
 function test_vectoraffinefunction_creation()
-    x =  MOI.VariableIndex(1)
+    x = MOI.VariableIndex(1)
     f = MOI.VectorAffineFunction([1.0 * x, 2.0 * x])
     @test f.constants == [0.0, 0.0]
     @test f.terms[1].scalar_term.coefficient == 1.0

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -129,6 +129,14 @@ function test_functions_convert_ScalarQuadraticFunction()
     )
 end
 
+function test_vectoraffinefunction_creation()
+    x =  MOI.VariableIndex(1)
+    f = MOI.VectorAffineFunction([1.0 * x, 2.0 * x])
+    @test f.constants == [0.0, 0.0]
+    @test f.terms[1].scalar_term.coefficient == 1.0
+    @test f.terms[2].scalar_term.coefficient == 2.0
+end
+
 function test_isapprox_VectorOfVariables()
     x = MOI.VariableIndex(1)
     y = MOI.VariableIndex(2)


### PR DESCRIPTION
VectorAffineFunction has always been a massive pain to construct.
This added constructor builds one from a vector of scalar affine functions, which is the mental model most people will have from a VAF.

This can drastically simplify a lot of code