### PR TITLE
[Test] add basic Integer tests

### DIFF
--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -336,6 +336,7 @@ for s in [
     :LessThan,
     :EqualTo,
     :Interval,
+    :Integer,
     :ZeroOne,
     :Semicontinuous,
     :Semiinteger,


### PR DESCRIPTION
I don't know if this was intentional or a bug.

I'll need to run solver-tests to see if this is disruptive: https://github.com/jump-dev/MathOptInterface.jl/actions/runs/13445063692