### PR TITLE
[Bridges] fix deleting bridges before final touch

### DIFF
--- a/src/Bridges/Constraint/bridges/IndicatorToMILPBridge.jl
+++ b/src/Bridges/Constraint/bridges/IndicatorToMILPBridge.jl
@@ -126,6 +126,9 @@ function MOI.delete(
     model::MOI.ModelLike,
     bridge::IndicatorToMILPBridge{T},
 ) where {T}
+    if bridge.slack === nothing
+        return  # We're deleting the bridge before final_touch
+    end
     MOI.delete.(model, bridge.slack_bounds)
     MOI.delete(model, bridge.constraint)
     MOI.delete(model, bridge.slack::MOI.VariableIndex)

--- a/src/Bridges/Constraint/bridges/SOS1ToMILPBridge.jl
+++ b/src/Bridges/Constraint/bridges/SOS1ToMILPBridge.jl
@@ -117,7 +117,6 @@ end
 
 function MOI.delete(model::MOI.ModelLike, bridge::SOS1ToMILPBridge)
     if isempty(bridge.variables)
-        println("HHello")
         return  # We're deleting the bridge before final_touch
     end
     MOI.delete(model, bridge.equal_to)

--- a/src/Bridges/Constraint/bridges/SOS1ToMILPBridge.jl
+++ b/src/Bridges/Constraint/bridges/SOS1ToMILPBridge.jl
@@ -116,6 +116,10 @@ function MOI.get(::MOI.ModelLike, ::MOI.ConstraintSet, bridge::SOS1ToMILPBridge)
 end
 
 function MOI.delete(model::MOI.ModelLike, bridge::SOS1ToMILPBridge)
+    if isempty(bridge.variables)
+        println("HHello")
+        return  # We're deleting the bridge before final_touch
+    end
     MOI.delete(model, bridge.equal_to)
     for ci in bridge.less_than
         MOI.delete(model, ci)

--- a/src/Bridges/Constraint/bridges/SOS2ToMILPBridge.jl
+++ b/src/Bridges/Constraint/bridges/SOS2ToMILPBridge.jl
@@ -116,6 +116,9 @@ function MOI.get(::MOI.ModelLike, ::MOI.ConstraintSet, bridge::SOS2ToMILPBridge)
 end
 
 function MOI.delete(model::MOI.ModelLike, bridge::SOS2ToMILPBridge)
+    if isempty(bridge.variables)
+        return  # We're deleting the bridge before final_touch
+    end
     MOI.delete(model, bridge.equal_to)
     for ci in bridge.less_than
         MOI.delete(model, ci)

--- a/test/Bridges/Constraint/IndicatorToMILPBridge.jl
+++ b/test/Bridges/Constraint/IndicatorToMILPBridge.jl
@@ -288,6 +288,22 @@ function test_runtests_error_affine()
     return
 end
 
+function test_delete_before_final_touch()
+    model = MOI.Bridges.Constraint.IndicatorToMILP{Float64}(
+        MOI.Utilities.Model{Float64}(),
+    )
+    x = MOI.add_variables(model, 2)
+    MOI.add_constraint(model, x[1], MOI.ZeroOne())
+    c = MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables(x),
+        MOI.Indicator{MOI.ACTIVATE_ON_ZERO}(MOI.GreaterThan(2.0)),
+    )
+    MOI.delete(model, c)
+    @test !MOI.is_valid(model, c)
+    return
+end
+
 end  # module
 
 TestConstraintIndicatorToMILP.runtests()

--- a/test/Bridges/Constraint/SOS1ToMILPBridge.jl
+++ b/test/Bridges/Constraint/SOS1ToMILPBridge.jl
@@ -119,6 +119,21 @@ function test_runtests_error_affine()
     return
 end
 
+function test_delete_before_final_touch()
+    model = MOI.Bridges.Constraint.SOS1ToMILP{Float64}(
+        MOI.Utilities.Model{Float64}(),
+    )
+    x = MOI.add_variables(model, 2)
+    c = MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables(x),
+        MOI.SOS1([1.0, 2.0]),
+    )
+    MOI.delete(model, c)
+    @test !MOI.is_valid(model, c)
+    return
+end
+
 end  # module
 
 TestConstraintSOS1ToMILP.runtests()

--- a/test/Bridges/Constraint/SOS2ToMILPBridge.jl
+++ b/test/Bridges/Constraint/SOS2ToMILPBridge.jl
@@ -129,6 +129,21 @@ function test_runtests_error_affine()
     return
 end
 
+function test_delete_before_final_touch()
+    model = MOI.Bridges.Constraint.SOS2ToMILP{Float64}(
+        MOI.Utilities.Model{Float64}(),
+    )
+    x = MOI.add_variables(model, 2)
+    c = MOI.add_constraint(
+        model,
+        MOI.VectorOfVariables(x),
+        MOI.SOS2([1.0, 2.0]),
+    )
+    MOI.delete(model, c)
+    @test !MOI.is_valid(model, c)
+    return
+end
+
 end  # module
 
 TestConstraintSOS2ToMILP.runtests()


### PR DESCRIPTION
I broke these bridges in https://github.com/jump-dev/MathOptInterface.jl/pull/2661 because they weren't tested, and I couldn't figure out a way to hit them because I assumed one had to call `final_touch` before we were allowed to delete something, but I guess that is not the case.

https://github.com/jump-dev/MathOptInterface.jl/actions/runs/13639825780