### PR TITLE
[Bridges] make attribute_value_type(::ListOfNonstandardBridges) less strict

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -136,7 +136,9 @@ end
 """
 struct ListOfNonstandardBridges{T} <: MOI.AbstractOptimizerAttribute end
 
-MOI.attribute_value_type(::ListOfNonstandardBridges) = Vector{Type}
+# This should be Vector{Type}, but MOI <=v1.37.0 had a bug that meant this was
+# not implemented. To maintain backwards compatibility, we make this `Vector`.
+MOI.attribute_value_type(::ListOfNonstandardBridges) = Vector
 
 MOI.is_copyable(::ListOfNonstandardBridges) = false
 


### PR DESCRIPTION
Closes #2677

There are actually multiple existing implementations in the wild that I broke with the "bug fix" https://github.com/jump-dev/MathOptInterface.jl/pull/2665

In addition to SCS and ECOS, there are:

https://github.com/jump-dev/SeDuMi.jl/blob/b69a1a664060216fabf0f101a8c21a3cf2df49f7/src/MOI_wrapper.jl#L69-L71

https://github.com/jump-dev/PolyJuMP.jl/blob/b28143bb2f68ff31b3c34d129ff2f403eb1752b4/src/model.jl#L109-L116

Perhaps we should just relax the type check.