### PR TITLE
[Utilities] fix operate(vcat for VectorNonlinearFunction

### DIFF
--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -991,7 +991,11 @@ function operate(
             append!(out, scalarize(a))
         end
     end
-    return MOI.VectorNonlinearFunction(out)
+    # We need to `copy` the rows hre, because if `a` are mutable
+    # AbstractScalarFunction then mutating the return value will mutate the
+    # inputs. This _is_ what Base.vcat does, but it doesn't fit with the general
+    # assumption that `Utilities.operate(` returns a new object.
+    return MOI.VectorNonlinearFunction(copy.(out))
 end
 
 ### 6a: operate(::typeof(imag), ::Type{T}, ::F)

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -992,7 +992,7 @@ function operate(
         end
     end
     _to_new_snf(f::MOI.ScalarNonlinearFunction) = copy(f)
-    _to_new_snf(f) = convert(MMOI.ScalarNonlinearFunction, f)
+    _to_new_snf(f) = convert(MOI.ScalarNonlinearFunction, f)
     # We need to `copy` the ScalarNonlinearFunction rows here, everything else
     # will be `convert(ScalarNonlinearFunction, row)` into a new object, but the
     # ScalarNonlinearFunction rows won't be, so mutating the return value of

--- a/src/Utilities/operate.jl
+++ b/src/Utilities/operate.jl
@@ -991,11 +991,15 @@ function operate(
             append!(out, scalarize(a))
         end
     end
-    # We need to `copy` the rows hre, because if `a` are mutable
-    # AbstractScalarFunction then mutating the return value will mutate the
-    # inputs. This _is_ what Base.vcat does, but it doesn't fit with the general
-    # assumption that `Utilities.operate(` returns a new object.
-    return MOI.VectorNonlinearFunction(copy.(out))
+    _to_new_snf(f::MOI.ScalarNonlinearFunction) = copy(f)
+    _to_new_snf(f) = convert(MMOI.ScalarNonlinearFunction, f)
+    # We need to `copy` the ScalarNonlinearFunction rows here, everything else
+    # will be `convert(ScalarNonlinearFunction, row)` into a new object, but the
+    # ScalarNonlinearFunction rows won't be, so mutating the return value of
+    # this `operate` method will mutate the inputs. This _is_ what Base.vcat
+    # does, but it doesn't fit with the general assumption that
+    # `Utilities.operate(` returns a new object.
+    return MOI.VectorNonlinearFunction(_to_new_snf.(out))
 end
 
 ### 6a: operate(::typeof(imag), ::Type{T}, ::F)

--- a/test/Utilities/test_operate!.jl
+++ b/test/Utilities/test_operate!.jl
@@ -399,6 +399,26 @@ function test_operate_5a()
     return
 end
 
+function test_operate_5a_VectorNonlinearFunction()
+    x = MOI.ScalarNonlinearFunction(:+, Any[])
+    f = MOI.VectorNonlinearFunction([x])
+    g = MOI.Utilities.operate(vcat, Float64, f, f, x)
+    h = MOI.VectorNonlinearFunction(
+        [MOI.ScalarNonlinearFunction(:+, Any[]) for _ in 1:3],
+    )
+    @test g ≈ h
+    push!(x.args, 0.0)
+    @test g ≈ h
+    @test g.rows[1] !== g.rows[2]
+    @test g.rows[1] !== g.rows[3]
+    @test g.rows[2] !== g.rows[3]
+    f_new = MOI.VectorNonlinearFunction(
+        [MOI.ScalarNonlinearFunction(:+, Any[0.0])],
+    )
+    @test f ≈ f_new
+    return
+end
+
 function test_operate_6a()
     T = Float64
     @test MOI.Utilities.operate(imag, T, _test_function((0.0, 0.0, 0.0))) ≈

--- a/test/Utilities/test_operate!.jl
+++ b/test/Utilities/test_operate!.jl
@@ -403,18 +403,16 @@ function test_operate_5a_VectorNonlinearFunction()
     x = MOI.ScalarNonlinearFunction(:+, Any[])
     f = MOI.VectorNonlinearFunction([x])
     g = MOI.Utilities.operate(vcat, Float64, f, f, x)
-    h = MOI.VectorNonlinearFunction(
-        [MOI.ScalarNonlinearFunction(:+, Any[]) for _ in 1:3],
-    )
+    rows = [MOI.ScalarNonlinearFunction(:+, Any[]) for _ in 1:3]
+    h = MOI.VectorNonlinearFunction(rows)
     @test g ≈ h
     push!(x.args, 0.0)
     @test g ≈ h
     @test g.rows[1] !== g.rows[2]
     @test g.rows[1] !== g.rows[3]
     @test g.rows[2] !== g.rows[3]
-    f_new = MOI.VectorNonlinearFunction(
-        [MOI.ScalarNonlinearFunction(:+, Any[0.0])],
-    )
+    rows = [MOI.ScalarNonlinearFunction(:+, Any[0.0])]
+    f_new = MOI.VectorNonlinearFunction(rows)
     @test f ≈ f_new
     return
 end


### PR DESCRIPTION
https://github.com/jump-dev/MathOptInterface.jl/issues/2553 got complicated to debug because of this :smile:

Without this PR, this code:

https://github.com/jump-dev/MathOptInterface.jl/blob/927c58bb2e157813c3d71de754c8bd07374963b6/src/Bridges/Constraint/bridges/NormInfinityBridge.jl#L61-L68

modifies the user's input function.