### PR TITLE
[Test] use SymbolicAD.simplify when comparing ConstraintFunction

### DIFF
--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -262,15 +262,19 @@ function _basic_constraint_test_helper(
     ###
     ### Test MOI.ConstraintFunction
     ###
+    function _isapprox_simplified(f, g, config)
+        return isapprox(
+            MOI.Nonlinear.SymbolicAD.simplify(f),
+            MOI.Nonlinear.SymbolicAD.simplify(g),
+            config,
+        )
+    end
     if _supports(config, MOI.ConstraintFunction)
         # Don't compare directly, because `f` might not be canonicalized.
         f = MOI.get(model, MOI.ConstraintFunction(), c)
-        @test isapprox(MOI.Utilities.canonical(f), constraint_function, config)
-        @test isapprox(
-            MOI.get(model, MOI.CanonicalConstraintFunction(), c),
-            constraint_function,
-            config,
-        )
+        @test _isapprox_simplified(f, constraint_function, config)
+        cf = MOI.get(model, MOI.CanonicalConstraintFunction(), c)
+        @test _isapprox_simplified(cf, constraint_function, config)
         _test_attribute_value_type(model, MOI.ConstraintFunction(), c)
         _test_attribute_value_type(model, MOI.CanonicalConstraintFunction(), c)
         _test_function_modification(model, config, c, f)

--- a/test/Bridges/Constraint/NormInfinityBridge.jl
+++ b/test/Bridges/Constraint/NormInfinityBridge.jl
@@ -36,6 +36,7 @@ function test_NormInfinity()
             "test_basic_VectorOfVariables_NormInfinityCone",
             "test_basic_VectorAffineFunction_NormInfinityCone",
             "test_basic_VectorQuadraticFunction_NormInfinityCone",
+            "test_basic_VectorNonlinearFunction_NormInfinityCone",
         ],
     )
     return

--- a/test/Bridges/Constraint/NormOneBridge.jl
+++ b/test/Bridges/Constraint/NormOneBridge.jl
@@ -36,7 +36,7 @@ function test_NormOne()
             "test_basic_VectorOfVariables_NormOneCone",
             "test_basic_VectorAffineFunction_NormOneCone",
             "test_basic_VectorQuadraticFunction_NormOneCone",
-            # "test_basic_VectorNonlinearFunction_NormOneCone",
+            "test_basic_VectorNonlinearFunction_NormOneCone",
         ],
     )
     return


### PR DESCRIPTION
Closes #2553 

I've checked that these now pass with EAGO
https://github.com/PSORLab/EAGO.jl/blob/9f94746c1262bfc650adf867259dbb91a20a1b84/test/moit_tests.jl#L84-L89