### PR TITLE
[FileFormats.MOF] make use_nlp_block=false the default if SNF in model

### DIFF
--- a/src/FileFormats/MOF/MOF.jl
+++ b/src/FileFormats/MOF/MOF.jl
@@ -112,14 +112,14 @@ struct Options
     print_compact::Bool
     warn::Bool
     differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation
-    use_nlp_block::Bool
+    use_nlp_block::Union{Bool,Nothing}
 end
 
 function get_options(m::Model)
     return get(
         m.model.ext,
         :MOF_OPTIONS,
-        Options(false, false, MOI.Nonlinear.SparseReverseMode(), true),
+        Options(false, false, MOI.Nonlinear.SparseReverseMode(), nothing),
     )
 end
 
@@ -144,7 +144,7 @@ function Model(;
     print_compact::Bool = false,
     warn::Bool = false,
     differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation = MOI.Nonlinear.SparseReverseMode(),
-    use_nlp_block::Bool = true,
+    use_nlp_block::Union{Bool,Nothing} = nothing,
 )
     model = MOI.Utilities.UniversalFallback(InnerModel{Float64}())
     model.model.ext[:MOF_OPTIONS] =

--- a/src/FileFormats/MOF/read.jl
+++ b/src/FileFormats/MOF/read.jl
@@ -27,7 +27,15 @@ function Base.read!(io::IO, model::Model)
     read_objective(model, object, name_map)
     read_constraints(model, object, name_map)
     options = get_options(model)
-    if options.use_nlp_block
+    # We should convert to NLPBlock if...
+    #                                        |  options.use_nlp_block
+    #                                        | true    false   nothing
+    # object["has_scalar_nonlinear"] = false |   1       0        1
+    #                                = true  |   1       0        0
+    if something(
+           options.use_nlp_block,
+           !get(object, "has_scalar_nonlinear", false),
+       )
         _convert_to_nlpblock(model)
     end
     return

--- a/src/FileFormats/MOF/read.jl
+++ b/src/FileFormats/MOF/read.jl
@@ -33,9 +33,9 @@ function Base.read!(io::IO, model::Model)
     # object["has_scalar_nonlinear"] = false |   1       0        1
     #                                = true  |   1       0        0
     if something(
-           options.use_nlp_block,
-           !get(object, "has_scalar_nonlinear", false),
-       )
+        options.use_nlp_block,
+        !get(object, "has_scalar_nonlinear", false),
+    )
         _convert_to_nlpblock(model)
     end
     return


### PR DESCRIPTION
Closes https://github.com/jump-dev/MathOptInterface.jl/issues/2687

The underlying issue is that we supported nonlinear file formats before the introduction of ScalarNonlinearFunction. Thus, `.mof.json` and `.nl` that contain nonlinear get parsed into a `MOI.NLPBlock`. This is the "old" nonlinear interface, and it means that Ipopt etc run into problems if the user wants to read in a file and then do some "new" stuff with it.

The current work-around is to use `read_from_file(model; use_nlp_block = false)`. 

But we could add a tag to the file on write if we detect `MOI.ScalarNonlinearFunction`. This would all "new" stuff to round-trip as new, and "old" stuff to round-trip as old.

The alternative would be to change the default to `use_nlp_block = false`, but this is technically breaking. Although this is also breaking, but arguably a bug-fix, because currently "new" models get written and then read back in as "old".

Once we agree on what to do, we should make a similar fix to the `.nl` file module. It probably means adding a header comment about whether we had `ScalarNonlinearFunction`s.