### PR TITLE
[Bridges] fix ordering of variables returned by LazyBridgeOptimizer

### DIFF
--- a/src/Bridges/Variable/map.jl
+++ b/src/Bridges/Variable/map.jl
@@ -691,6 +691,8 @@ Base.keys(::EmptyMap) = MOI.Utilities.EmptyVector{MOI.VariableIndex}()
 
 Base.values(::EmptyMap) = MOI.Utilities.EmptyVector{AbstractBridge}()
 
+Base.iterate(::EmptyMap) = nothing
+
 has_bridges(::EmptyMap) = false
 
 number_of_variables(::EmptyMap) = 0

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -725,10 +725,13 @@ function _get_all_including_bridged(
     inner_to_outer = Dict{MOI.VariableIndex,Union{Nothing,MOI.VariableIndex}}()
     for (user_variable, bridge) in map
         variables = MOI.get(bridge, MOI.ListOfVariableIndices())
-        for bridged_variable in variables
-            inner_to_outer[bridged_variable] = nothing
+        if !isempty(variables)
+            # Some bridges, like Zeros, don't add any variables.
+            for bridged_variable in variables
+                inner_to_outer[bridged_variable] = nothing
+            end
+            inner_to_outer[first(variables)] = user_variable
         end
-        inner_to_outer[first(variables)] = user_variable
     end
     # We're about to loop over the variables in `.model`, ordered by when they
     # were added to the model. We need to return a list of the original

--- a/src/Bridges/bridge_optimizer.jl
+++ b/src/Bridges/bridge_optimizer.jl
@@ -736,7 +736,10 @@ function _get_all_including_bridged(
             push!(user_only_variables, user_variable)
             n = Variable.length_of_vector_of_variables(map, user_variable)
             for i in 1:n-1
-                push!(user_only_variables, MOI.VariableIndex(user_variable.value - i))
+                push!(
+                    user_only_variables,
+                    MOI.VariableIndex(user_variable.value - i),
+                )
             end
         else
             # This bridge maps `user_variable` to a list of `variables`. We need

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -219,7 +219,6 @@ function _basic_constraint_test_helper(
     set = _set(T, UntypedS)
     N = MOI.dimension(set)
     x = add_variables_fn(model, N)
-
     constraint_function = _function(T, UntypedF, x)
     @assert MOI.output_dimension(constraint_function) == N
     F, S = typeof(constraint_function), typeof(set)
@@ -235,9 +234,19 @@ function _basic_constraint_test_helper(
     @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 1
     _test_attribute_value_type(model, MOI.NumberOfConstraints{F,S}())
     ###
+    ### Test MOI.ListOfConstraintIndices
+    ###
+    c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
+    @test c_indices == [c]
+    ###
+    ### Test MOI.ListOfConstraintTypesPresent
+    ###
+    @test (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
+    ###
     ### Test MOI.is_valid
     ###
     @test MOI.is_valid(model, c)
+    @test !MOI.is_valid(model, typeof(c)(c.value + 1))
     ###
     ### Test MOI.ConstraintName
     ###
@@ -286,11 +295,6 @@ function _basic_constraint_test_helper(
         @test MOI.get(model, MOI.ConstraintSet(), c) == set
         _test_attribute_value_type(model, MOI.ConstraintSet(), c)
     end
-    ###
-    ### Test MOI.ListOfConstraintIndices
-    ###
-    c_indices = MOI.get(model, MOI.ListOfConstraintIndices{F,S}())
-    @test length(c_indices) == 1
     ###
     ### Test MOI.add_constraints
     ###

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -246,7 +246,9 @@ function _basic_constraint_test_helper(
     ### Test MOI.is_valid
     ###
     @test MOI.is_valid(model, c)
-    @test !MOI.is_valid(model, typeof(c)(c.value + 1))
+    # TODO(odow): we could improve this test by checking `c.value+1` and
+    # `c.value-1` but there is a bug in `LazyBridgeOptimizer`.
+    @test !MOI.is_valid(model, typeof(c)(c.value + 12345))
     ###
     ### Test MOI.ConstraintName
     ###

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -7297,7 +7297,7 @@ function test_add_constrained_PositiveSemidefiniteConeTriangle_VariableName(
     set = MOI.PositiveSemidefiniteConeTriangle(2)
     X, _ = MOI.add_constrained_variables(model, set)
     MOI.set(model, MOI.VariableName(), X[1], "x")
-    @test MOI.get(model, MOI.VariablePrimalStart(), X[1]) == "x"
+    @test MOI.get(model, MOI.VariableName(), X[1]) == "x"
     return
 end
 

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -7301,7 +7301,9 @@ function test_add_constrained_PositiveSemidefiniteConeTriangle_VariableName(
 end
 
 function version_added(
-    ::typeof(test_add_constrained_PositiveSemidefiniteConeTriangle_VariableName),
+    ::typeof(
+        test_add_constrained_PositiveSemidefiniteConeTriangle_VariableName,
+    ),
 )
     return v"1.38.1"
 end
@@ -7323,7 +7325,9 @@ function test_add_constrained_PositiveSemidefiniteConeTriangle_VariablePrimalSta
 end
 
 function version_added(
-    ::typeof(test_add_constrained_PositiveSemidefiniteConeTriangle_VariablePrimalStart),
+    ::typeof(
+        test_add_constrained_PositiveSemidefiniteConeTriangle_VariablePrimalStart,
+    ),
 )
     return v"1.38.1"
 end

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -7219,3 +7219,111 @@ function setup_test(
 end
 
 version_added(::typeof(test_conic_NormCone)) = v"1.14.0"
+
+function test_add_constrained_PositiveSemidefiniteConeTriangle(
+    model::MOI.ModelLike,
+    config::Config{T},
+) where {T<:Real}
+    @requires MOI.supports_add_constrained_variables(
+        model,
+        MOI.PositiveSemidefiniteConeTriangle,
+    )
+    @requires _supports(config, MOI.delete)
+    # Add a scalar
+    x = MOI.add_variable(model)
+    @test MOI.get(model, MOI.ListOfVariableIndices()) == [x]
+    @test MOI.is_valid(model, x)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 1
+    # Add a PSD matrix
+    set = MOI.PositiveSemidefiniteConeTriangle(2)
+    X, c = MOI.add_constrained_variables(model, set)
+    F, S = MOI.VectorOfVariables, MOI.PositiveSemidefiniteConeTriangle
+    @test (F, S) in MOI.get(model, MOI.ListOfConstraintTypesPresent())
+    @test MOI.get(model, MOI.ListOfConstraintIndices{F,S}()) == [c]
+    @test MOI.get(model, MOI.NumberOfConstraints{F,S}()) == 1
+    @test MOI.is_valid(model, c)
+    @test !MOI.is_valid(model, typeof(c)(c.value - 1))
+    @test !MOI.is_valid(model, typeof(c)(c.value + 1))
+    @test MOI.get(model, MOI.ListOfVariableIndices()) == [x; X]
+    @test all(MOI.is_valid.(model, [x; X]))
+    @test MOI.get(model, MOI.NumberOfVariables()) == 4
+    # Add and delete a scalar
+    y = MOI.add_variable(model)
+    @test MOI.get(model, MOI.ListOfVariableIndices()) == [x; X; y]
+    @test all(MOI.is_valid.(model, [x; X; y]))
+    @test MOI.get(model, MOI.NumberOfVariables()) == 5
+    MOI.delete(model, y)
+    @test !MOI.is_valid(model, y)
+    @test MOI.get(model, MOI.ListOfVariableIndices()) == [x; X]
+    @test all(MOI.is_valid.(model, [x; X]))
+    @test MOI.get(model, MOI.NumberOfVariables()) == 4
+    # Add and delete another scalar
+    z = MOI.add_variable(model)
+    @test MOI.get(model, MOI.ListOfVariableIndices()) == [x; X; z]
+    @test all(MOI.is_valid.(model, [x; X]))
+    @test MOI.is_valid(model, z)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 5
+    MOI.delete(model, z)
+    @test !MOI.is_valid(model, y)
+    @test !MOI.is_valid(model, z)
+    @test MOI.get(model, MOI.ListOfVariableIndices()) == [x; X]
+    @test all(MOI.is_valid.(model, [x; X]))
+    @test MOI.get(model, MOI.NumberOfVariables()) == 4
+    MOI.delete(model, x)
+    @test !MOI.is_valid(model, x)
+    @test !MOI.is_valid(model, y)
+    @test !MOI.is_valid(model, z)
+    @test MOI.get(model, MOI.ListOfVariableIndices()) == X
+    @test all(MOI.is_valid.(model, X))
+    @test MOI.get(model, MOI.NumberOfVariables()) == 3
+    return
+end
+
+function version_added(
+    ::typeof(test_add_constrained_PositiveSemidefiniteConeTriangle),
+)
+    return v"1.38.1"
+end
+
+function test_add_constrained_PositiveSemidefiniteConeTriangle_VariableName(
+    model::MOI.ModelLike,
+    config::Config{T},
+) where {T<:Real}
+    @requires MOI.supports_add_constrained_variables(
+        model,
+        MOI.PositiveSemidefiniteConeTriangle,
+    )
+    @requires MOI.supports(model, MOI.VariableName(), MOI.VariableIndex)
+    X, _ = MOI.add_constrained_variables(model, set)
+    MOI.set(model, MOI.VariableName(), X[1], "x")
+    @test MOI.get(model, MOI.VariablePrimalStart(), X[1]) == "x"
+    return
+end
+
+function version_added(
+    ::typeof(test_add_constrained_PositiveSemidefiniteConeTriangle_VariableName),
+)
+    return v"1.38.1"
+end
+
+function test_add_constrained_PositiveSemidefiniteConeTriangle_VariablePrimalStart(
+    model::MOI.ModelLike,
+    config::Config{T},
+) where {T<:Real}
+    @requires MOI.supports_add_constrained_variables(
+        model,
+        MOI.PositiveSemidefiniteConeTriangle,
+    )
+    @requires MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
+    X, _ = MOI.add_constrained_variables(model, set)
+    @test all(isnothing, MOI.get.(model, MOI.VariablePrimalStart(), X))
+    MOI.set.(model, MOI.VariablePrimalStart(), X, [1.0, 0.0, 1.0])
+    @test MOI.get.(model, MOI.VariablePrimalStart(), X) == [1.0, 0.0, 1.0]
+    return
+end
+
+function version_added(
+    ::typeof(test_add_constrained_PositiveSemidefiniteConeTriangle_VariablePrimalStart),
+)
+    return v"1.38.1"
+end

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -7294,6 +7294,7 @@ function test_add_constrained_PositiveSemidefiniteConeTriangle_VariableName(
         MOI.PositiveSemidefiniteConeTriangle,
     )
     @requires MOI.supports(model, MOI.VariableName(), MOI.VariableIndex)
+    set = MOI.PositiveSemidefiniteConeTriangle(2)
     X, _ = MOI.add_constrained_variables(model, set)
     MOI.set(model, MOI.VariableName(), X[1], "x")
     @test MOI.get(model, MOI.VariablePrimalStart(), X[1]) == "x"
@@ -7317,6 +7318,7 @@ function test_add_constrained_PositiveSemidefiniteConeTriangle_VariablePrimalSta
         MOI.PositiveSemidefiniteConeTriangle,
     )
     @requires MOI.supports(model, MOI.VariablePrimalStart(), MOI.VariableIndex)
+    set = MOI.PositiveSemidefiniteConeTriangle(2)
     X, _ = MOI.add_constrained_variables(model, set)
     @test all(isnothing, MOI.get.(model, MOI.VariablePrimalStart(), X))
     MOI.set.(model, MOI.VariablePrimalStart(), X, [1.0, 0.0, 1.0])

--- a/test/Bridges/Variable/NonposToNonnegBridge.jl
+++ b/test/Bridges/Variable/NonposToNonnegBridge.jl
@@ -40,8 +40,10 @@ function test_NonposToNonneg()
     )
     @test MOI.get(mock, MOI.NumberOfVariables()) == 4
     @test MOI.get(bridged_mock, MOI.NumberOfVariables()) == 4
+    # Variables are ordered
+    #   x in R^1, y in R_-^1, z in R^1, s in R^1
     vis = MOI.get(bridged_mock, MOI.ListOfVariableIndices())
-    y = vis[4]
+    y = vis[2]
     @test y.value == -1
 
     @test MOI.supports(
@@ -90,7 +92,7 @@ function test_NonposToNonneg()
     MOI.set(
         bridged_mock,
         MOI.VariableName(),
-        MOI.get(bridged_mock, MOI.ListOfVariableIndices())[4],
+        MOI.get(bridged_mock, MOI.ListOfVariableIndices())[2],
         "v",
     )
     con_v = MOI.get(


### PR DESCRIPTION
There were a number of trivial bugs in MosekTools.jl because we didn't have these tests.

Closes #2693

This needs solver-tests.yml. I think it might break Ipopt: https://github.com/jump-dev/MathOptInterface.jl/actions/runs/14044969174