### PR TITLE
[Test] make variable bounded in test_nonlinear_constraint_log

### DIFF
--- a/src/Test/test_nonlinear.jl
+++ b/src/Test/test_nonlinear.jl
@@ -1902,6 +1902,7 @@ function test_nonlinear_constraint_log(
     x = MOI.add_variable(model)
     t = MOI.add_variable(model)
     MOI.add_constraint(model, x, MOI.LessThan(T(2)))
+    MOI.add_constraint(model, x, MOI.GreaterThan(T(1)))
     MOI.set(model, MOI.VariablePrimalStart(), x, T(1))
     MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
     f = 1.0 * t


### PR DESCRIPTION
MAiNGO has trouble with this, and so did EAGO. It seems reasonable to add a lower bound for `log(x)`:

<img width="1037" alt="image" src="https://github.com/user-attachments/assets/63f0c4e4-e963-42b8-9cd9-ab8ed9f480b2" />
