### PR TITLE
[Bridges] add a test_broken test for #2696

### DIFF
--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -246,8 +246,12 @@ function _basic_constraint_test_helper(
     ### Test MOI.is_valid
     ###
     @test MOI.is_valid(model, c)
-    # TODO(odow): we could improve this test by checking `c.value+1` and
-    # `c.value-1` but there is a bug in `LazyBridgeOptimizer`.
+    # We could improve this test by checking these are `== true` instead of
+    # `isa Bool`, but there is a bug in `LazyBridgeOptimizer`. See
+    # MathOptInterface.jl#2696 for details. At the very least, this test checks
+    # that they do not error, and hopefully helps hit some code paths.
+    @test !MOI.is_valid(model, typeof(c)(c.value + 1)) isa Bool
+    @test !MOI.is_valid(model, typeof(c)(c.value - 1)) isa Bool
     @test !MOI.is_valid(model, typeof(c)(c.value + 12345))
     ###
     ### Test MOI.ConstraintName

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -2238,6 +2238,21 @@ function test_bridge_complex_greatertoless()
     return
 end
 
+function test_issue_2696()
+    b = MOI.instantiate(StandardSDPAModel{Float64}; with_bridge_type = Float64)
+    x = MOI.add_variables(b, 2)
+    c = MOI.add_constraint(b, MOI.VectorOfVariables(x), MOI.Nonpositives(2))
+    @test MOI.is_valid(b, c)
+    F, S = MOI.VectorOfVariables, MOI.Nonpositives
+    # See MathOptInterface.jl#2696
+    d = MOI.ConstraintIndex{F,S}(c.value + 1)
+    @test_broken !MOI.is_valid(b, d)
+    @test MOI.get(b, MOI.ListOfConstraintTypesPresent()) == [(F, S)]
+    @test only(MOI.get(b, MOI.ListOfConstraintIndices{F,S}())) == c
+    @test MOI.get(b, MOI.NumberOfConstraints{F,S}()) == 1
+    return
+end
+
 end  # module
 
 TestBridgesLazyBridgeOptimizer.runtests()


### PR DESCRIPTION
@blegat I don't understand https://github.com/jump-dev/MathOptInterface.jl/issues/2696.

As far as I can tell, the only issue is that we may return a false positive (`is_valid -> true`) if there is a `VectorOfVariables` constraint on a vector of variables that were bridged, and the bridge happened to add a constraint with the same index.