### PR TITLE
Prep for v1.38.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.38.0"
+version = "1.38.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,23 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.38.1 (April 7, 2025)
+
+### Fixed
+
+ - Fixed a redundant constraint in [`Bridges.Constraint.CircuitToMILPBridge`](@ref)
+   (#2694)
+ - Fixed the ordering of [`ListOfVariableIndices`](@ref) returned by
+   [`Bridges.LazyBridgeOptimizer`](@ref) (#2695)
+ - Fix `Test.test_nonlinear_constraint_log` to exclude undefined points (#2704)
+
+### Other
+
+ - Improve various docstrings (#2698), (#2699), (#2700), (#2701), (#2712)
+ - Add support for `ForwardDiff@1` (#2703), (#2708)
+ - Update `solver-tests.yml` (#2697), (#2709)
+ - Add a `@test_broken` for issue #2696 (#2705)
+
 ## v1.38.0 (March 13, 2025)
 
 ### Added


### PR DESCRIPTION
## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/14253627565
 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/14298510627
 - [x] If new tests were added, ensure that `MOI.Test.version_added` is implemented.