### PR TITLE
[Nonlinear] fix _UnsafeVectorView with ForwardDiff@1.0.0

### DIFF
--- a/src/Nonlinear/ReverseAD/utils.jl
+++ b/src/Nonlinear/ReverseAD/utils.jl
@@ -53,11 +53,11 @@ function Base.setindex!(x::_UnsafeVectorView{T}, value::T, i::Integer) where {T}
     return value
 end
 
-function Base.setindex!(
-    x::_UnsafeVectorView{T},
-    value::T,
-    i::CartesianIndex{1},
-) where {T}
+function Base.setindex!(x::_UnsafeVectorView{T}, value, i::Integer) where {T}
+    return setindex!(x, convert(T, value), i)
+end
+
+function Base.setindex!(x::_UnsafeVectorView, value, i::CartesianIndex{1})
     return setindex!(x, value, i[1])
 end
 

--- a/src/Nonlinear/ReverseAD/utils.jl
+++ b/src/Nonlinear/ReverseAD/utils.jl
@@ -42,11 +42,23 @@ struct _UnsafeVectorView{T} <: DenseVector{T}
     ptr::Ptr{T}
 end
 
-Base.getindex(x::_UnsafeVectorView, i) = unsafe_load(x.ptr, i + x.offset)
+function Base.getindex(x::_UnsafeVectorView, i::Integer)
+    return unsafe_load(x.ptr, i + x.offset)
+end
 
-function Base.setindex!(x::_UnsafeVectorView, value, i)
+Base.getindex(x::_UnsafeVectorView, i::CartesianIndex{1}) = getindex(x, i[1])
+
+function Base.setindex!(x::_UnsafeVectorView{T}, value::T, i::Integer) where {T}
     unsafe_store!(x.ptr, value, i + x.offset)
     return value
+end
+
+function Base.setindex!(
+    x::_UnsafeVectorView{T},
+    value::T,
+    i::CartesianIndex{1},
+) where {T}
+    return setindex!(x, value, i[1])
 end
 
 Base.length(v::_UnsafeVectorView) = v.len

--- a/src/Nonlinear/ReverseAD/utils.jl
+++ b/src/Nonlinear/ReverseAD/utils.jl
@@ -48,13 +48,13 @@ end
 
 Base.getindex(x::_UnsafeVectorView, i::CartesianIndex{1}) = getindex(x, i[1])
 
-function Base.setindex!(x::_UnsafeVectorView{T}, value::T, i::Integer) where {T}
+function Base.setindex!(x::_UnsafeVectorView, value, i::Integer)
+    # We don't need to worry about `value` being the right type here because
+    # x.ptr is a `::Ptr{T}`, so even though it is called `unsafe_store!`, there
+    # is still a type convertion that happens so that we're not just chucking
+    # the bits of value into `x.ptr`.
     unsafe_store!(x.ptr, value, i + x.offset)
     return value
-end
-
-function Base.setindex!(x::_UnsafeVectorView{T}, value, i::Integer) where {T}
-    return setindex!(x, convert(T, value), i)
 end
 
 function Base.setindex!(x::_UnsafeVectorView, value, i::CartesianIndex{1})

--- a/test/Nonlinear/ReverseAD.jl
+++ b/test/Nonlinear/ReverseAD.jl
@@ -1339,11 +1339,11 @@ function test_eval_user_defined_operator_type_mismatch()
     ψ(x) = sin(x)
     t(x, y) = x + 3y
     function ∇t(ret, x, y)
-        ret[1] = 1      # These are intentionall the wrong type
-        ret[2] = 3 // 1 # These are intentionall the wrong type
+        ret[1] = 1      # These are intentionally the wrong type
+        ret[2] = 3 // 1 # These are intentionally the wrong type
         return
     end
-    MOI.Nonlinear.register_operator(model, :ψ, 1, ψ, x -> -cos(x))
+    MOI.Nonlinear.register_operator(model, :ψ, 1, ψ, cos)
     MOI.Nonlinear.register_operator(model, :t, 2, t, ∇t)
     MOI.Nonlinear.add_constraint(
         model,

--- a/test/Nonlinear/ReverseAD.jl
+++ b/test/Nonlinear/ReverseAD.jl
@@ -1331,6 +1331,38 @@ function test_eval_user_defined_operator_ForwardDiff_gradient!()
     return
 end
 
+function test_eval_user_defined_operator_type_mismatch()
+    model = MOI.Nonlinear.Model()
+    x = MOI.VariableIndex.(1:4)
+    p = MOI.Nonlinear.add_parameter(model, 2.0)
+    ex = MOI.Nonlinear.add_expression(model, :($p * $(x[1])))
+    ψ(x) = sin(x)
+    t(x, y) = x + 3y
+    function ∇t(ret, x, y)
+        ret[1] = 1      # These are intentionall the wrong type
+        ret[2] = 3 // 1 # These are intentionall the wrong type
+        return
+    end
+    MOI.Nonlinear.register_operator(model, :ψ, 1, ψ, x -> -cos(x))
+    MOI.Nonlinear.register_operator(model, :t, 2, t, ∇t)
+    MOI.Nonlinear.add_constraint(
+        model,
+        :($ex^3 + sin($(x[2])) / ψ($(x[2])) + t($(x[3]), $(x[4]))),
+        MOI.LessThan(0.0),
+    )
+    d = MOI.Nonlinear.Evaluator(model, MOI.Nonlinear.SparseReverseMode(), x)
+    MOI.initialize(d, [:Jac])
+    X = [1.1, 1.2, 1.3, 1.4]
+    g = [NaN]
+    MOI.eval_constraint(d, g, X)
+    @test only(g) ≈ 17.148
+    @test MOI.jacobian_structure(d) == [(1, 1), (1, 2), (1, 3), (1, 4)]
+    J = [NaN, NaN, NaN, NaN]
+    MOI.eval_constraint_jacobian(d, J, X)
+    @test J ≈ [2.0^3 * 3.0 * 1.1^2, 0.0, 1.0, 3.0]
+    return
+end
+
 end  # module
 
 TestReverseAD.runtests()


### PR DESCRIPTION
ForwardDiff@1 changed to use `CartesianIndex`, which we hadn't supported.

We also never tested this, because we tested only that the operator could be called, but never end-to-end through the ReverseAD system. Nasty.

https://github.com/jump-dev/MathOptInterface.jl/actions/runs/14232574450