### PR TITLE
Fix Bridge test for non-invertible constraint bridge

### DIFF
--- a/docs/src/reference/errors.md
+++ b/docs/src/reference/errors.md
@@ -66,6 +66,7 @@ The different [`UnsupportedError`](@ref) and [`NotAllowedError`](@ref) are the
 following errors:
 ```@docs
 UnsupportedAttribute
+GetAttributeNotAllowed
 SetAttributeNotAllowed
 AddVariableNotAllowed
 UnsupportedConstraint

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -251,9 +251,11 @@ Run a series of tests that check the correctness of `Bridge`.
 `input_fn` and `output_fn` are functions such that `input_fn(model)`
 and `output_fn(model)` load the corresponding model into `model`.
 
-Set `cannot_unbridge` to `true` if the bridge is a variable bridge
-for which [`Variable.unbridged_map`](@ref) returns `nothing` so that
-the tests allow errors that can be raised due to this.
+Set `cannot_unbridge` to `true` if the bridge transformation is not invertible.
+If `Bridge` is a variable bridge this allows [`Variable.unbridged_map`](@ref)
+to returns `nothing` so that the tests allow errors that can be raised due to this.
+If `Bridge` is a constraint bridge this allows the getter of [`MOI.ConstraintFunction`](@ref)
+and [`MOI.ConstraintPrimalStart`](@ref) to throw [`MOI.GetAttributeNotAllowed`](@ref).
 
 ## Example
 

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -334,7 +334,11 @@ function runtests(
                     catch err
                         # For a Constraint bridge for which the map is not invertible, the constraint primal cannot
                         # be inverted
-                        _runtests_error_handler(err, Bridge <: MOI.Bridges.Constraint.AbstractBridge && cannot_unbridge)
+                        _runtests_error_handler(
+                            err,
+                            Bridge <: MOI.Bridges.Constraint.AbstractBridge &&
+                                cannot_unbridge,
+                        )
                         continue
                     end
                     Test.@test returned_start ≈ start


### PR DESCRIPTION
This is needed for https://github.com/blegat/LowRankOpt.jl/pull/10. The getters for ConstraintFunction and ConstrainPrimalStart are not so important as there is often a cache so bridges corresponding to non-invertible transformations are fine and being able to use these tests for these bridges would be useful.