### PR TITLE
Simplify _eval_hessian_inner

### DIFF
--- a/src/Nonlinear/ReverseAD/ReverseAD.jl
+++ b/src/Nonlinear/ReverseAD/ReverseAD.jl
@@ -7,7 +7,6 @@
 module ReverseAD
 
 import ForwardDiff
-import MutableArithmetics as MA
 import MathOptInterface as MOI
 import ..Nonlinear
 import SparseArrays

--- a/src/Nonlinear/ReverseAD/ReverseAD.jl
+++ b/src/Nonlinear/ReverseAD/ReverseAD.jl
@@ -7,6 +7,7 @@
 module ReverseAD
 
 import ForwardDiff
+import MutableArithmetics as MA
 import MathOptInterface as MOI
 import ..Nonlinear
 import SparseArrays

--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -61,7 +61,13 @@ function _eval_hessian_inner(
     # leftover chunk
     remaining = num_products - CHUNK * num_chunks
     if remaining > 0
-        _eval_hessian_chunk(d, ex, CHUNK * num_chunks + 1, remaining, Val(CHUNK))
+        _eval_hessian_chunk(
+            d,
+            ex,
+            CHUNK * num_chunks + 1,
+            remaining,
+            Val(CHUNK),
+        )
     end
     want, got = nzcount + length(ex.hess_I), length(H)
     if want > got

--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -101,7 +101,6 @@ function _eval_hessian_chunk(
             d.input_ϵ[(idx-1)*CHUNK+s] = ex.seed_matrix[r, offset+s-1]
         end
     end
-    fill!(d.output_ϵ, 0.0)
     _hessian_slice_inner(d, ex, Val(CHUNK))
     fill!(d.input_ϵ, 0.0)
     # collect directional derivatives
@@ -118,6 +117,7 @@ end
 function _hessian_slice_inner(d, ex, ::Val{CHUNK}) where {CHUNK}
     T = ForwardDiff.Partials{CHUNK,Float64}  # This is our element type.
     input_ϵ = _reinterpret_unsafe(T, d.input_ϵ)
+    fill!(d.output_ϵ, 0.0)
     output_ϵ = _reinterpret_unsafe(T, d.output_ϵ)
     subexpr_forward_values_ϵ =
         _reinterpret_unsafe(T, d.subexpression_forward_values_ϵ)

--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -97,7 +97,6 @@ function _eval_hessian_chunk(
     chunk::Int,
     ::Val{CHUNK},
 ) where {CHUNK}
-    MA.operate!(zero, d.input_ϵ)
     for r in eachindex(ex.rinfo.local_indices)
         # set up directional derivatives
         @inbounds idx = ex.rinfo.local_indices[r]
@@ -107,8 +106,9 @@ function _eval_hessian_chunk(
             d.input_ϵ[(idx-1)*CHUNK+s] = ex.seed_matrix[r, offset+s-1]
         end
     end
-    MA.operate!(zero, d.output_ϵ)
+    fill!(d.output_ϵ, 0.0)
     _hessian_slice_inner(d, ex, Val(CHUNK))
+    fill!(d.input_ϵ, 0.0)
     # collect directional derivatives
     for r in eachindex(ex.rinfo.local_indices)
         @inbounds idx = ex.rinfo.local_indices[r]

--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -55,19 +55,14 @@ function _eval_hessian_inner(
     num_products = size(ex.seed_matrix, 2) # number of hessian-vector products
     num_chunks = div(num_products, CHUNK)
     @assert size(ex.seed_matrix, 1) == length(ex.rinfo.local_indices)
-    for k in 1:CHUNK:CHUNK*num_chunks
-        _eval_hessian_chunk(d, ex, k, CHUNK, Val(CHUNK))
+    for offset in 1:CHUNK:CHUNK*num_chunks
+        _eval_hessian_chunk(d, ex, offset, CHUNK, Val(CHUNK))
     end
     # leftover chunk
     remaining = num_products - CHUNK * num_chunks
     if remaining > 0
-        _eval_hessian_chunk(
-            d,
-            ex,
-            CHUNK * num_chunks + 1,
-            remaining,
-            Val(CHUNK),
-        )
+        offset = CHUNK * num_chunks + 1
+        _eval_hessian_chunk(d, ex, offset, remaining, Val(CHUNK))
     end
     want, got = nzcount + length(ex.hess_I), length(H)
     if want > got

--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -55,7 +55,7 @@ function _eval_hessian_inner(
     num_products = size(ex.seed_matrix, 2) # number of hessian-vector products
     num_chunks = div(num_products, CHUNK)
     @assert size(ex.seed_matrix, 1) == length(ex.rinfo.local_indices)
-    for offset in 1:CHUNK:CHUNK*num_chunks
+    for offset in 1:CHUNK:(CHUNK*num_chunks)
         _eval_hessian_chunk(d, ex, offset, CHUNK, Val(CHUNK))
     end
     # leftover chunk


### PR DESCRIPTION
A large of code was almost copy-pasted so I think a sub-function is a win for readability.
Doing the `_reinterpret` magic inside `_hessian_slice_inner` along with the other `_reinterpret` calls also allows to simplify logic quite a bit by keeping these contained inside this function only.