### PR TITLE
Fix SetMapBridge with complex type

### DIFF
--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -299,11 +299,12 @@ function _runtests(
     variable_start = 1.2,
     constraint_start = 1.2,
     eltype = Float64,
+    model_eltype = eltype,
     print_inner_model::Bool = false,
     cannot_unbridge::Bool = false,
 )
     # Load model and bridge it
-    inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{eltype}())
+    inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{model_eltype}())
     model = _bridged_model(Bridge{eltype}, inner)
     input_fn(model)
     final_touch(model)
@@ -313,7 +314,7 @@ function _runtests(
         print(inner)
     end
     Test.@testset "Test outer bridged model appears like the input" begin       # COV_EXCL_LINE
-        test = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{eltype}())
+        test = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{model_eltype}())
         input_fn(test)
         _test_structural_identical(
             test,
@@ -322,7 +323,7 @@ function _runtests(
         )
     end
     Test.@testset "Test inner bridged model appears like the target" begin      # COV_EXCL_LINE
-        target = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{eltype}())
+        target = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{model_eltype}())
         output_fn(target)
         _test_structural_identical(target, inner)
     end

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -314,7 +314,8 @@ function _runtests(
         print(inner)
     end
     Test.@testset "Test outer bridged model appears like the input" begin       # COV_EXCL_LINE
-        test = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{model_eltype}())
+        test =
+            MOI.Utilities.UniversalFallback(MOI.Utilities.Model{model_eltype}())
         input_fn(test)
         _test_structural_identical(
             test,
@@ -323,7 +324,8 @@ function _runtests(
         )
     end
     Test.@testset "Test inner bridged model appears like the target" begin      # COV_EXCL_LINE
-        target = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{model_eltype}())
+        target =
+            MOI.Utilities.UniversalFallback(MOI.Utilities.Model{model_eltype}())
         output_fn(target)
         _test_structural_identical(target, inner)
     end

--- a/src/Bridges/Constraint/bridges/AbstractFunctionConversionBridge.jl
+++ b/src/Bridges/Constraint/bridges/AbstractFunctionConversionBridge.jl
@@ -282,7 +282,8 @@ function MOI.supports_constraint(
     ::Type{G},
     ::Type{<:MOI.AbstractSet},
 ) where {T,F,G<:MOI.AbstractFunction}
-    return MOI.Utilities.is_coefficient_type(G, T) && isfinite(conversion_cost(F, G))
+    return MOI.Utilities.is_coefficient_type(G, T) &&
+           isfinite(conversion_cost(F, G))
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/bridges/AbstractFunctionConversionBridge.jl
+++ b/src/Bridges/Constraint/bridges/AbstractFunctionConversionBridge.jl
@@ -282,7 +282,7 @@ function MOI.supports_constraint(
     ::Type{G},
     ::Type{<:MOI.AbstractSet},
 ) where {T,F,G<:MOI.AbstractFunction}
-    return !MOI.Utilities.is_complex(G) && isfinite(conversion_cost(F, G))
+    return MOI.Utilities.is_coefficient_type(G, T) && isfinite(conversion_cost(F, G))
 end
 
 function concrete_bridge_type(

--- a/src/Bridges/Constraint/bridges/InequalityToComplementsBridge.jl
+++ b/src/Bridges/Constraint/bridges/InequalityToComplementsBridge.jl
@@ -71,7 +71,7 @@ function MOI.supports_constraint(
     ::Type{F},
     ::Type{<:Union{MOI.GreaterThan{T},MOI.LessThan{T},MOI.EqualTo{T}}},
 ) where {T,F<:MOI.AbstractScalarFunction}
-    return MOI.Utilities.is_coefficient_type(F, T)
+    return MOI.Utilities.is_coefficient_type(F, T) && !MOI.Utilities.is_complex(F)
 end
 
 function MOI.Bridges.added_constrained_variable_types(

--- a/src/Bridges/Constraint/bridges/InequalityToComplementsBridge.jl
+++ b/src/Bridges/Constraint/bridges/InequalityToComplementsBridge.jl
@@ -71,7 +71,8 @@ function MOI.supports_constraint(
     ::Type{F},
     ::Type{<:Union{MOI.GreaterThan{T},MOI.LessThan{T},MOI.EqualTo{T}}},
 ) where {T,F<:MOI.AbstractScalarFunction}
-    return MOI.Utilities.is_coefficient_type(F, T) && !MOI.Utilities.is_complex(F)
+    return MOI.Utilities.is_coefficient_type(F, T) &&
+           !MOI.Utilities.is_complex(F)
 end
 
 function MOI.Bridges.added_constrained_variable_types(

--- a/src/Bridges/Constraint/bridges/InequalityToComplementsBridge.jl
+++ b/src/Bridges/Constraint/bridges/InequalityToComplementsBridge.jl
@@ -71,7 +71,7 @@ function MOI.supports_constraint(
     ::Type{F},
     ::Type{<:Union{MOI.GreaterThan{T},MOI.LessThan{T},MOI.EqualTo{T}}},
 ) where {T,F<:MOI.AbstractScalarFunction}
-    return !MOI.Utilities.is_complex(F)
+    return MOI.Utilities.is_coefficient_type(F, T)
 end
 
 function MOI.Bridges.added_constrained_variable_types(

--- a/src/Bridges/Constraint/bridges/NormOneBridge.jl
+++ b/src/Bridges/Constraint/bridges/NormOneBridge.jl
@@ -56,7 +56,8 @@ function MOI.supports_constraint(
     ::Type{F},
     ::Type{MOI.NormOneCone},
 ) where {T,F<:MOI.AbstractVectorFunction}
-    return MOI.Utilities.is_coefficient_type(F, T)
+    return MOI.Utilities.is_coefficient_type(F, T) &&
+           !MOI.Utilities.is_complex(F)       
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:NormOneBridge})

--- a/src/Bridges/Constraint/bridges/NormOneBridge.jl
+++ b/src/Bridges/Constraint/bridges/NormOneBridge.jl
@@ -57,7 +57,7 @@ function MOI.supports_constraint(
     ::Type{MOI.NormOneCone},
 ) where {T,F<:MOI.AbstractVectorFunction}
     return MOI.Utilities.is_coefficient_type(F, T) &&
-           !MOI.Utilities.is_complex(F)       
+           !MOI.Utilities.is_complex(F)
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:NormOneBridge})

--- a/src/Bridges/Constraint/bridges/NormOneBridge.jl
+++ b/src/Bridges/Constraint/bridges/NormOneBridge.jl
@@ -56,7 +56,7 @@ function MOI.supports_constraint(
     ::Type{F},
     ::Type{MOI.NormOneCone},
 ) where {T,F<:MOI.AbstractVectorFunction}
-    return !MOI.Utilities.is_complex(F)
+    return MOI.Utilities.is_coefficient_type(F, T)
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:NormOneBridge})

--- a/src/Bridges/Constraint/bridges/SetDotScalingBridge.jl
+++ b/src/Bridges/Constraint/bridges/SetDotScalingBridge.jl
@@ -193,11 +193,11 @@ end
 # Since the set type is not defined, the default `MOI.supports_constraint`
 # for `SetMapBridge` does not work
 function MOI.supports_constraint(
-    ::Type{<:SetDotScalingBridge},
+    ::Type{<:SetDotScalingBridge{T}},
     F::Type{<:MOI.AbstractVectorFunction},
     S::Type{<:MOI.AbstractVectorSet},
-)
-    return !MOI.Utilities.is_complex(F) && MOI.is_set_dot_scaled(S)
+) where {T}
+    return MOI.Utilities.is_coefficient_type(F, T) && MOI.is_set_dot_scaled(S)
 end
 
 function MOI.supports_constraint(

--- a/src/Bridges/Constraint/bridges/VectorizeBridge.jl
+++ b/src/Bridges/Constraint/bridges/VectorizeBridge.jl
@@ -64,7 +64,7 @@ function MOI.supports_constraint(
     ::Type{F},
     ::Type{<:MOI.Utilities.ScalarLinearSet{T}},
 ) where {T,F<:MOI.AbstractScalarFunction}
-    return !MOI.Utilities.is_complex(F)
+    return MOI.Utilities.is_coefficient_type(F, T)
 end
 
 function MOI.Bridges.added_constrained_variable_types(::Type{<:VectorizeBridge})

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -51,7 +51,7 @@ function MOI.supports_constraint(
     ::Type{F},
     ::Type{S1},
 ) where {T,S1<:MOI.AbstractScalarSet,F<:MOI.AbstractScalarFunction}
-    return !MOI.Utilities.is_complex(F)
+    return MOI.Utilities.is_complex(F) == (T <: Complex)
 end
 
 function MOI.supports_constraint(
@@ -59,7 +59,7 @@ function MOI.supports_constraint(
     ::Type{F},
     ::Type{S1},
 ) where {T,S1<:MOI.AbstractVectorSet,F<:MOI.AbstractVectorFunction}
-    return !MOI.Utilities.is_complex(F)
+    return MOI.Utilities.is_complex(F) == (T <: Complex)
 end
 
 function MOI.Bridges.added_constrained_variable_types(

--- a/src/Bridges/Constraint/set_map.jl
+++ b/src/Bridges/Constraint/set_map.jl
@@ -51,7 +51,7 @@ function MOI.supports_constraint(
     ::Type{F},
     ::Type{S1},
 ) where {T,S1<:MOI.AbstractScalarSet,F<:MOI.AbstractScalarFunction}
-    return MOI.Utilities.is_complex(F) == (T <: Complex)
+    return MOI.Utilities.is_coefficient_type(F, T)
 end
 
 function MOI.supports_constraint(
@@ -59,7 +59,7 @@ function MOI.supports_constraint(
     ::Type{F},
     ::Type{S1},
 ) where {T,S1<:MOI.AbstractVectorSet,F<:MOI.AbstractVectorFunction}
-    return MOI.Utilities.is_complex(F) == (T <: Complex)
+    return MOI.Utilities.is_coefficient_type(F, T)
 end
 
 function MOI.Bridges.added_constrained_variable_types(

--- a/test/Bridges/Constraint/SetDotScalingBridge.jl
+++ b/test/Bridges/Constraint/SetDotScalingBridge.jl
@@ -111,6 +111,33 @@ function test_inverse_scaling_quadratic()
     return
 end
 
+function test_scaling_complex()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.SetDotScalingBridge,
+        model -> begin
+            x, y, z = MOI.add_variables(model, 3)
+            MOI.add_constraint(
+                model,
+                MOI.Utilities.vectorize([(1.0 + 0im) * x, (1.0 * im) * y, (1.0 + 0im) * z]),
+                MOI.PositiveSemidefiniteConeTriangle(2),
+            )
+        end,
+        model -> begin
+            x, y, z = MOI.add_variables(model, 3)
+            MOI.add_constraint(
+                model,
+                MOI.Utilities.vectorize([(1.0 + 0im) * x, (√2 * im) * y, (1.0 + 0im) * z]),
+                MOI.ScaledPositiveSemidefiniteConeTriangle(2),
+            )
+        end,
+        eltype = ComplexF64,
+        model_eltype = Float64,
+        constraint_start = 1.2 * im
+    )
+    return
+end
+
+
 function test_set_dot_scaling_constraint_dual_start()
     inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
     model = MOI.Bridges.Constraint.SetDotScaling{Float64}(inner)

--- a/test/Bridges/Constraint/SetDotScalingBridge.jl
+++ b/test/Bridges/Constraint/SetDotScalingBridge.jl
@@ -118,7 +118,11 @@ function test_scaling_complex()
             x, y, z = MOI.add_variables(model, 3)
             MOI.add_constraint(
                 model,
-                MOI.Utilities.vectorize([(1.0 + 0im) * x, (1.0 * im) * y, (1.0 + 0im) * z]),
+                MOI.Utilities.vectorize([
+                    (1.0 + 0im) * x,
+                    (1.0 * im) * y,
+                    (1.0 + 0im) * z,
+                ]),
                 MOI.PositiveSemidefiniteConeTriangle(2),
             )
         end,
@@ -126,17 +130,20 @@ function test_scaling_complex()
             x, y, z = MOI.add_variables(model, 3)
             MOI.add_constraint(
                 model,
-                MOI.Utilities.vectorize([(1.0 + 0im) * x, (√2 * im) * y, (1.0 + 0im) * z]),
+                MOI.Utilities.vectorize([
+                    (1.0 + 0im) * x,
+                    (√2 * im) * y,
+                    (1.0 + 0im) * z,
+                ]),
                 MOI.ScaledPositiveSemidefiniteConeTriangle(2),
             )
         end,
         eltype = ComplexF64,
         model_eltype = Float64,
-        constraint_start = 1.2 * im
+        constraint_start = 1.2 * im,
     )
     return
 end
-
 
 function test_set_dot_scaling_constraint_dual_start()
     inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -2254,11 +2254,30 @@ function test_issue_2696()
 end
 
 function test_wrong_coefficient()
-    model = MOI.instantiate(MOI.Utilities.Model{Float64}, with_bridge_type=Float64)
-    @test !MOI.supports_constraint(model, MOI.VectorAffineFunction{Int}, MOI.Nonnegatives)
-    @test !MOI.supports_constraint(model, MOI.VectorAffineFunction{Int}, MOI.PositiveSemidefiniteConeTriangle)
-    @test !MOI.supports_constraint(model, MOI.ScalarAffineFunction{Int}, MOI.EqualTo{Int})
-    @test !MOI.supports_constraint(model, MOI.VectorQuadraticFunction{Int}, MOI.Zeros)
+    model = MOI.instantiate(
+        MOI.Utilities.Model{Float64},
+        with_bridge_type = Float64,
+    )
+    @test !MOI.supports_constraint(
+        model,
+        MOI.VectorAffineFunction{Int},
+        MOI.Nonnegatives,
+    )
+    @test !MOI.supports_constraint(
+        model,
+        MOI.VectorAffineFunction{Int},
+        MOI.PositiveSemidefiniteConeTriangle,
+    )
+    @test !MOI.supports_constraint(
+        model,
+        MOI.ScalarAffineFunction{Int},
+        MOI.EqualTo{Int},
+    )
+    @test !MOI.supports_constraint(
+        model,
+        MOI.VectorQuadraticFunction{Int},
+        MOI.Zeros,
+    )
     return
 end
 

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -2253,6 +2253,15 @@ function test_issue_2696()
     return
 end
 
+function test_wrong_coefficient()
+    model = MOI.instantiate(MOI.Utilities.Model{Float64}, with_bridge_type=Float64)
+    @test !MOI.supports_constraint(model, MOI.VectorAffineFunction{Int}, MOI.Nonnegatives)
+    @test !MOI.supports_constraint(model, MOI.VectorAffineFunction{Int}, MOI.PositiveSemidefiniteConeTriangle)
+    @test !MOI.supports_constraint(model, MOI.ScalarAffineFunction{Int}, MOI.EqualTo{Int})
+    @test !MOI.supports_constraint(model, MOI.VectorQuadraticFunction{Int}, MOI.Zeros)
+    return
+end
+
 end  # module
 
 TestBridgesLazyBridgeOptimizer.runtests()


### PR DESCRIPTION
The bridges don't support dealing with a function that is not of coefficient type `T`. So with `ComplexF64`, we had these errors but actually we get the same with `Int` for instance. So we might as well check it with `MOI.is_coefficient_type`

Before the PR
```julia
julia> model = MOI.instantiate(MOI.Utilities.Model{Float64}, with_bridge_type=Float64)

julia> MOI.supports_constraint(model, MOI.VectorAffineFunction{Int}, MOI.Nonnegatives)
ERROR: MethodError: no method matching promote_operation(::typeof(-), ::Type{Float64}, ::Type{MathOptInterface.VectorAffineFunction{Int64}})
The function `promote_operation` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  promote_operation(::typeof(-), ::Type{T}, ::Type{MathOptInterface.VectorNonlinearFunction}) where T<:Number
   @ MathOptInterface ~/.julia/dev/MathOptInterface/src/Utilities/promote_operation.jl:177
  promote_operation(::typeof(-), ::Type{T}, ::Type{MathOptInterface.VectorOfVariables}) where T<:Number
   @ MathOptInterface ~/.julia/dev/MathOptInterface/src/Utilities/promote_operation.jl:169
  promote_operation(::typeof(-), ::Type{T}, ::Type{F}) where {T, F<:Union{AbstractVector{T}, MathOptInterface.ScalarAffineFunction{T}, MathOptInterface.ScalarNonlinearFunction, MathOptInterface.ScalarQuadraticFunction{T}, MathOptInterface.VectorAffineFunction{T}, MathOptInterface.VectorQuadraticFunction{T}, T}}
   @ MathOptInterface ~/.julia/dev/MathOptInterface/src/Utilities/promote_operation.jl:142
  ...

Stacktrace:
 [1] concrete_bridge_type(::Type{…}, G::Type{…}, ::Type{…})
   @ MathOptInterface.Bridges.Constraint ~/.julia/dev/MathOptInterface/src/Bridges/Constraint/bridges/FlipSignBridge.jl:238
 [2] node(b::MathOptInterface.Bridges.LazyBridgeOptimizer{…}, F::Type{…}, S::Type{…})
   @ MathOptInterface.Bridges ~/.julia/dev/MathOptInterface/src/Bridges/lazy_bridge_optimizer.jl:327
 [3] bridge_index
   @ ~/.julia/dev/MathOptInterface/src/Bridges/lazy_bridge_optimizer.jl:464 [inlined]
 [4] supports_bridging_constraint
   @ ~/.julia/dev/MathOptInterface/src/Bridges/lazy_bridge_optimizer.jl:491 [inlined]
 [5] supports_constraint(b::MathOptInterface.Bridges.LazyBridgeOptimizer{…}, F::Type{…}, S::Type{…})
   @ MathOptInterface.Bridges ~/.julia/dev/MathOptInterface/src/Bridges/bridge_optimizer.jl:1837
 [6] top-level scope
   @ REPL[22]:1
Some type information was truncated. Use `show(err)` to see complete types.
```
After the PR:
```julia
julia> MOI.supports_constraint(model, MOI.VectorAffineFunction{Int}, MOI.Nonnegatives)
false
```

Needed for https://github.com/jump-dev/SeDuMi.jl/pull/28