### PR TITLE
Remove dynamic dispatch in Hessian evaluation

### DIFF
--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -6,6 +6,13 @@
 
 const TAG = :ReverseAD
 
+"""
+    const MAX_CHUNK::Int = 10
+
+An upper bound on the chunk sie for forward-over-reverse. Increasing this could
+improve performance at the cost of extra memory allocation. It has been 10 for a
+long time, and nobody seems to have complained.
+"""
 const MAX_CHUNK = 10
 
 """

--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -112,7 +112,7 @@ function _generate_hessian_slice_inner()
     exprs = map(1:MAX_CHUNK) do id
         return :(_hessian_slice_inner(d, ex, ForwardDiff.Partials{$id,Float64}))
     end
-    return _create_binary_switch(1:MAX_CHUNK, exprs)
+    return MOI.Nonlinear._create_binary_switch(1:MAX_CHUNK, exprs)
 end
 
 @eval function _hessian_slice_inner(d, ex, id::Int)

--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -110,7 +110,8 @@ end
 # A wrapper function to avoid dynamic dispatch.
 function _generate_hessian_slice_inner()
     exprs = map(1:MAX_CHUNK) do id
-        return :(_hessian_slice_inner(d, ex, ForwardDiff.Partials{$id,Float64}))
+        T = ForwardDiff.Partials{id,Float64}
+        return :(return _hessian_slice_inner(d, ex, $T))
     end
     return MOI.Nonlinear._create_binary_switch(1:MAX_CHUNK, exprs)
 end

--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -6,11 +6,13 @@
 
 const TAG = :ReverseAD
 
+const MAX_CHUNK = 10
+
 function _generate_eval_hessian()
-    exprs = map(1:10) do chunk
+    exprs = map(1:MAX_CHUNK) do chunk
         return :(return _eval_hessian_inner(d, f, H, λ, offset, Val($chunk)))
     end
-    return Nonlinear._create_binary_switch(1:10, exprs)
+    return Nonlinear._create_binary_switch(1:MAX_CHUNK, exprs)
 end
 
 @eval begin

--- a/src/Nonlinear/ReverseAD/mathoptinterface_api.jl
+++ b/src/Nonlinear/ReverseAD/mathoptinterface_api.jl
@@ -140,8 +140,7 @@ function MOI.initialize(d::NLPEvaluator, requested_features::Vector{Symbol})
         max_expr_length = max(max_expr_length, length(d.constraints[end].nodes))
         max_chunk = max(max_chunk, size(d.constraints[end].seed_matrix, 2))
     end
-    # 10 is hardcoded upper bound to avoid excess memory allocation
-    max_chunk = min(max_chunk, 10)
+    max_chunk = min(max_chunk, MAX_CHUNK)
     max_expr_with_sub_length = max(max_expr_with_sub_length, max_expr_length)
     if d.want_hess || want_hess_storage
         d.input_ϵ = zeros(max_chunk * N)

--- a/test/Nonlinear/ReverseAD.jl
+++ b/test/Nonlinear/ReverseAD.jl
@@ -1385,6 +1385,20 @@ function test_eval_user_defined_operator_type_mismatch()
     return
 end
 
+function test_generate_hessian_slice_inner()
+    # Test that it evaluates without error. The code contents are tested
+    # elsewhere.
+    MOI.Nonlinear.ReverseAD._generate_hessian_slice_inner()
+    d = ex = nothing  # These arguments are untyped and not needed for this test
+    for id in [0, MAX_CHUNK + 1]
+        @test_throws(
+            ErrorException("Invalid chunk size: $id"),
+            MOI.Nonlinear.ReverseAD._hessian_slice_inner(d, ex, id),
+        )
+    end
+    return
+end
+
 end  # module
 
 TestReverseAD.runtests()

--- a/test/Nonlinear/ReverseAD.jl
+++ b/test/Nonlinear/ReverseAD.jl
@@ -156,6 +156,7 @@ function test_objective_quadratic_multivariate_subexpressions()
     H = [NaN, NaN, NaN]
     μ = Float64[]
     MOI.eval_hessian_lagrangian(evaluator, H, val, 1.5, μ)
+    @test 0 == @allocated MOI.eval_hessian_lagrangian(evaluator, H, val, 1.5, μ)
     @test H == 1.5 .* [2.0, 2.0, 1.0]
     v = [0.3, 0.4]
     hv = [NaN, NaN]

--- a/test/Nonlinear/ReverseAD.jl
+++ b/test/Nonlinear/ReverseAD.jl
@@ -1390,7 +1390,7 @@ function test_generate_hessian_slice_inner()
     # elsewhere.
     MOI.Nonlinear.ReverseAD._generate_hessian_slice_inner()
     d = ex = nothing  # These arguments are untyped and not needed for this test
-    for id in [0, MAX_CHUNK + 1]
+    for id in [0, MOI.Nonlinear.ReverseAD.MAX_CHUNK + 1]
         @test_throws(
             ErrorException("Invalid chunk size: $id"),
             MOI.Nonlinear.ReverseAD._hessian_slice_inner(d, ex, id),

--- a/test/Nonlinear/ReverseAD.jl
+++ b/test/Nonlinear/ReverseAD.jl
@@ -150,16 +150,7 @@ function test_objective_quadratic_multivariate_subexpressions()
     MOI.eval_hessian_objective(evaluator, H, val)
     @test H == [2.0, 2.0, 1.0]
     @test evaluator.backend.max_chunk == 2
-    # The call of `_eval_hessian_inner` from `_eval_hessian` needs dynamic dispatch for `Val(chunk)` so it allocates.
-    # We call directly `_eval_hessian_inner` to check that the rest does not allocates.
-    @test 0 == @allocated MOI.Nonlinear.ReverseAD._eval_hessian_inner(
-        evaluator.backend,
-        evaluator.backend.objective,
-        H,
-        1.0,
-        0,
-        Val(2),
-    )
+    @test 0 == @allocated MOI.eval_hessian_objective(evaluator, H, val)
     @test MOI.hessian_lagrangian_structure(evaluator) ==
           [(1, 1), (2, 2), (2, 1)]
     H = [NaN, NaN, NaN]


### PR DESCRIPTION
As `chunk` is maximum 10, we can reuse the `_create_binary_switch` we use for type-stable evaluation of our list of operators to call `_eval_hessian_inner` in a type-stable way.
On this benchmark https://github.com/jump-dev/MathOptInterface.jl/pull/2739#issuecomment-2833683884
Before this PR
```
5.959426 seconds (158.26 k allocations: 11.273 MiB)
5.973144 seconds (158.26 k allocations: 11.273 MiB)
6.078342 seconds (158.26 k allocations: 11.273 MiB)
6.031799 seconds (158.26 k allocations: 11.273 MiB, 0.23% gc time)
6.022742 seconds (158.26 k allocations: 11.273 MiB)
6.013003 seconds (158.26 k allocations: 11.273 MiB)
6.021324 seconds (158.26 k allocations: 11.273 MiB)
```
After this PR:
```
5.925775 seconds
5.820862 seconds
5.865539 seconds
5.823728 seconds
5.848671 seconds
5.864283 seconds
5.876498 seconds
5.911389 seconds
5.894025 seconds
```