### PR TITLE
[Nonlinear.ReverseAD] Fix use of reinterpret instead _reinterpret_unsafe

### DIFF
--- a/src/Nonlinear/ReverseAD/forward_over_reverse.jl
+++ b/src/Nonlinear/ReverseAD/forward_over_reverse.jl
@@ -190,7 +190,7 @@ function _forward_eval_ϵ(
     partials_storage_ϵ::AbstractVector{P},
 ) where {N,T,P<:ForwardDiff.Partials{N,T}}
     storage_ϵ = _reinterpret_unsafe(P, d.storage_ϵ)
-    x_values_ϵ = reinterpret(P, d.input_ϵ)
+    x_values_ϵ = _reinterpret_unsafe(P, d.input_ϵ)
     subexpression_values_ϵ =
         _reinterpret_unsafe(P, d.subexpression_forward_values_ϵ)
     @assert length(storage_ϵ) >= length(ex.nodes)


### PR DESCRIPTION
Introduced by https://github.com/jump-dev/MathOptInterface.jl/pull/2736, specifically:

https://github.com/jump-dev/MathOptInterface.jl/pull/2736/files#diff-fd2e1ad4a6c5ea5294c6e338afffbb76c837b6c4a868d949007a0229ad846ec0R187

<img width="622" alt="image" src="https://github.com/user-attachments/assets/48848ea0-e7f4-4c48-a549-9fa2b751e996" />

I found the test case by taking the failed Juniper run, and reducing.