### PR TITLE
[docs] filter varying width Time column in doctest

### DIFF
--- a/docs/src/submodules/Bridges/implementation.md
+++ b/docs/src/submodules/Bridges/implementation.md
@@ -66,7 +66,7 @@ arguments: the type of the bridge, the input model as a string, and the output
 model as a string.
 
 Here is an example:
-```jldoctest; filter=[r"[0-9.]+s", r"\\s+Time"]
+```jldoctest; filter=[r"[0-9.]+s", r"\s+Time"]
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.GreaterToLessBridge,
            """
@@ -100,7 +100,7 @@ There are a number of other useful keyword arguments.
 
 Here is an example:
 
-```jldoctest; filter=[r"[0-9.]+s", r"\\s+Time"]
+```jldoctest; filter=[r"[0-9.]+s", r"\s+Time"]
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.GreaterToLessBridge,
            """

--- a/docs/src/submodules/Bridges/implementation.md
+++ b/docs/src/submodules/Bridges/implementation.md
@@ -66,7 +66,7 @@ arguments: the type of the bridge, the input model as a string, and the output
 model as a string.
 
 Here is an example:
-```jldoctest; filter=r"[0-9.]+s"
+```jldoctest; filter=[r"[0-9.]+s", r"\s+Time"]
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.GreaterToLessBridge,
            """
@@ -100,7 +100,7 @@ There are a number of other useful keyword arguments.
 
 Here is an example:
 
-```jldoctest; filter=r"[0-9.]+s"
+```jldoctest; filter=[r"[0-9.]+s", r"\s+Time"]
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.GreaterToLessBridge,
            """

--- a/docs/src/submodules/Bridges/implementation.md
+++ b/docs/src/submodules/Bridges/implementation.md
@@ -66,7 +66,7 @@ arguments: the type of the bridge, the input model as a string, and the output
 model as a string.
 
 Here is an example:
-```jldoctest; filter=[r"[0-9.]+s", r"\s+Time"]
+```jldoctest; filter=[r"[0-9.]+s", r"\\s+Time"]
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.GreaterToLessBridge,
            """
@@ -100,7 +100,7 @@ There are a number of other useful keyword arguments.
 
 Here is an example:
 
-```jldoctest; filter=[r"[0-9.]+s", r"\s+Time"]
+```jldoctest; filter=[r"[0-9.]+s", r"\\s+Time"]
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.GreaterToLessBridge,
            """

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -273,7 +273,7 @@ and [`MOI.ConstraintPrimalStart`](@ref) to throw [`MOI.GetAttributeNotAllowed`](
 
 ## Example
 
-```jldoctest; filter=r"[0-9.]+s"
+```jldoctest; filter=[r"[0-9.]+s", r"\s+Time"]
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.ZeroOneBridge,
            model -> MOI.add_constrained_variable(model, MOI.ZeroOne()),
@@ -423,7 +423,7 @@ Run a series of tests that check the correctness of `Bridge`.
 
 ## Example
 
-```jldoctest; filter=r"[0-9.]+s"
+```jldoctest; filter=[r"[0-9.]+s", r"\s+Time"]
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.ZeroOneBridge,
            \"\"\"

--- a/src/Bridges/Bridges.jl
+++ b/src/Bridges/Bridges.jl
@@ -273,7 +273,7 @@ and [`MOI.ConstraintPrimalStart`](@ref) to throw [`MOI.GetAttributeNotAllowed`](
 
 ## Example
 
-```jldoctest; filter=[r"[0-9.]+s", r"\s+Time"]
+```jldoctest; filter=[r"[0-9.]+s", r"\\s+Time"]
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.ZeroOneBridge,
            model -> MOI.add_constrained_variable(model, MOI.ZeroOne()),
@@ -423,7 +423,7 @@ Run a series of tests that check the correctness of `Bridge`.
 
 ## Example
 
-```jldoctest; filter=[r"[0-9.]+s", r"\s+Time"]
+```jldoctest; filter=[r"[0-9.]+s", r"\\s+Time"]
 julia> MOI.Bridges.runtests(
            MOI.Bridges.Constraint.ZeroOneBridge,
            \"\"\"


### PR DESCRIPTION
I didn't explicitly verify this, but I think this should hopefully avoid the doctest failure we sometimes see  (https://github.com/JuliaDocs/Documenter.jl/issues/2704).