### PR TITLE
Implement adjacency_matrix and expression in _FunctionStorage

### DIFF
--- a/src/Nonlinear/ReverseAD/types.jl
+++ b/src/Nonlinear/ReverseAD/types.jl
@@ -43,10 +43,7 @@ struct _SubexpressionStorage
 end
 
 function MOI.Nonlinear.expression(expr::_SubexpressionStorage)
-    return MOI.Nonlinear.Expression(
-        expr.nodes,
-        expr.const_values,
-    )
+    return MOI.Nonlinear.Expression(expr.nodes, expr.const_values)
 end
 
 MOI.Nonlinear.adjacency_matrix(expr::_SubexpressionStorage) = expr.adj
@@ -146,10 +143,7 @@ struct _FunctionStorage
 end
 
 function MOI.Nonlinear.expression(expr::_FunctionStorage)
-    return MOI.Nonlinear.Expression(
-        expr.nodes,
-        expr.const_values,
-    )
+    return MOI.Nonlinear.Expression(expr.nodes, expr.const_values)
 end
 
 MOI.Nonlinear.adjacency_matrix(expr::_FunctionStorage) = expr.adj

--- a/src/Nonlinear/ReverseAD/types.jl
+++ b/src/Nonlinear/ReverseAD/types.jl
@@ -42,6 +42,15 @@ struct _SubexpressionStorage
     end
 end
 
+function MOI.Nonlinear.expression(expr::_SubexpressionStorage)
+    return MOI.Nonlinear.Expression(
+        expr.nodes,
+        expr.const_values,
+    )
+end
+
+MOI.Nonlinear.adjacency_matrix(expr::_SubexpressionStorage) = expr.adj
+
 struct _FunctionStorage
     nodes::Vector{Nonlinear.Node}
     adj::SparseArrays.SparseMatrixCSC{Bool,Int}
@@ -135,6 +144,15 @@ struct _FunctionStorage
         end
     end
 end
+
+function MOI.Nonlinear.expression(expr::_FunctionStorage)
+    return MOI.Nonlinear.Expression(
+        expr.nodes,
+        expr.const_values,
+    )
+end
+
+MOI.Nonlinear.adjacency_matrix(expr::_FunctionStorage) = expr.adj
 
 """
     NLPEvaluator(

--- a/src/Nonlinear/types.jl
+++ b/src/Nonlinear/types.jl
@@ -76,8 +76,9 @@ tree.
 struct Expression
     nodes::Vector{Node}
     values::Vector{Float64}
-    Expression() = new(Node[], Float64[])
 end
+
+Expression() = Expression(Node[], Float64[])
 
 function Base.:(==)(x::Expression, y::Expression)
     return x.nodes == y.nodes && x.values == y.values
@@ -106,6 +107,8 @@ struct Constraint
         MOI.Interval{Float64},
     }
 end
+
+expression(c::Constraint) = c.expression
 
 """
     ParameterIndex


### PR DESCRIPTION
EAGO is accessing the `objective` and `constraints` fields of `ReverseAD.NLPEvaluator` which is ok since it's not starting with a `_`.
But then it is accessing internal fields of `_FunctionStorage` and `_SubexpressionStorage` which it shouldn't since these start with an `_`.
Actually, all they need are the `nodes` and `const_values` which are part of `MOI.Nonlinear.Expression` and the adjacency matrix so by implementing `adjacency_matrix` and adding a `expression` function that it implements, it allows EAGO to stop using internal fields and stick to the public API.

See the corresponding EAGO PR here : https://github.com/PSORLab/EAGO.jl/pull/147