### PR TITLE
[docs] remove experimental warning from Nonlinear module docstring

### DIFF
--- a/docs/src/submodules/Nonlinear/reference.md
+++ b/docs/src/submodules/Nonlinear/reference.md
@@ -12,7 +12,6 @@ More information can be found in the [Nonlinear](@ref nonlinear_developers)
 section of the manual.
 
 ```@docs
-Nonlinear
 Nonlinear.Model
 ```
 

--- a/src/Nonlinear/Nonlinear.jl
+++ b/src/Nonlinear/Nonlinear.jl
@@ -4,14 +4,6 @@
 # Use of this source code is governed by an MIT-style license that can be found
 # in the LICENSE.md file or at https://opensource.org/licenses/MIT.
 
-"""
-    Nonlinear
-
-!!! warning
-    The Nonlinear submodule is experimental. Until this message is removed,
-    breaking changes may be introduced in any minor or patch release of
-    MathOptInterface.
-"""
 module Nonlinear
 
 import ForwardDiff


### PR DESCRIPTION
Follow up from https://github.com/jump-dev/MathOptInterface.jl/pull/2625 for consistency

We actually still have the warning in the docs:
https://jump.dev/MathOptInterface.jl/v1.40/submodules/Nonlinear/reference/#MathOptInterface.Nonlinear