### PR TITLE
[Bridges] Add Interval to HyperRectangle constraint bridge

### DIFF
--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -137,6 +137,7 @@ function add_all_bridges(model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(model, ToVectorQuadraticBridge{T})
     MOI.Bridges.add_bridge(model, VectorFunctionizeBridge{T})
     MOI.Bridges.add_bridge(model, VectorizeBridge{T})
+    MOI.Bridges.add_bridge(model, IntervalToHyperRectangleBridge{T})
     MOI.Bridges.add_bridge(model, VectorSlackBridge{T})
     MOI.Bridges.add_bridge(model, ZeroOneBridge{T})
     return

--- a/src/Bridges/Constraint/bridges/IntervalToHyperRectangleBridge.jl
+++ b/src/Bridges/Constraint/bridges/IntervalToHyperRectangleBridge.jl
@@ -1,0 +1,214 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+"""
+    IntervalToHyperRectangleBridge{T,F,G} <: Bridges.Constraint.AbstractBridge
+
+`IntervalToHyperRectangleBridge` implements the following reformulations:
+
+  * ``l \\le g(x) \\le u`` into ``[g(x)] \\in `` `MOI.HyperRectangle([l], [u])`
+
+where `T` is the coefficient type of `g(x)` and the type of `l` and `u`.
+
+See also [`VectorizeBridge`](@ref) for equality and single-sided bound
+constraints.
+
+## Source node
+
+`IntervalToHyperRectangleBridge` supports:
+
+  * `G` in [`MOI.Interval{T}`](@ref)
+
+## Target nodes
+
+`IntervalToHyperRectangleBridge` creates:
+
+  * `F` in [`MOI.HyperRectangle{T}`](@ref).
+"""
+mutable struct IntervalToHyperRectangleBridge{T,F,G} <: AbstractBridge
+    vector_constraint::MOI.ConstraintIndex{F,MOI.HyperRectangle{T}}
+end
+
+const IntervalToHyperRectangle{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{IntervalToHyperRectangleBridge{T},OT}
+
+function bridge_constraint(
+    ::Type{IntervalToHyperRectangleBridge{T,F,G}},
+    model::MOI.ModelLike,
+    scalar_f::G,
+    set::MOI.Interval{T},
+) where {T,F,G}
+    MOI.throw_if_scalar_and_constant_not_zero(scalar_f, typeof(set))
+    vector_f = MOI.Utilities.operate(vcat, T, scalar_f)
+    rect = MOI.HyperRectangle([set.lower], [set.upper])
+    vector_constraint = MOI.add_constraint(model, vector_f, rect)
+    return IntervalToHyperRectangleBridge{T,F,G}(vector_constraint)
+end
+
+function MOI.supports_constraint(
+    ::Type{IntervalToHyperRectangleBridge{T}},
+    ::Type{F},
+    ::Type{MOI.Interval{T}},
+) where {T,F<:MOI.AbstractScalarFunction}
+    return MOI.Utilities.is_coefficient_type(F, T)
+end
+
+function MOI.Bridges.added_constrained_variable_types(::Type{<:IntervalToHyperRectangleBridge})
+    return Tuple{Type}[]
+end
+
+function MOI.Bridges.added_constraint_types(
+    ::Type{<:IntervalToHyperRectangleBridge{T,F}},
+) where {T,F}
+    return Tuple{Type,Type}[(F, MOI.HyperRectangle{T})]
+end
+
+function concrete_bridge_type(
+    ::Type{<:IntervalToHyperRectangleBridge{T}},
+    G::Type{<:MOI.AbstractScalarFunction},
+    S::Type{MOI.Interval{T}},
+) where {T}
+    F = MOI.Utilities.promote_operation(vcat, T, G)
+    return IntervalToHyperRectangleBridge{T,F,G}
+end
+
+function MOI.get(
+    ::IntervalToHyperRectangleBridge{T,F},
+    ::MOI.NumberOfConstraints{F,MOI.HyperRectangle{T}},
+)::Int64 where {T,F}
+    return 1
+end
+
+function MOI.get(
+    bridge::IntervalToHyperRectangleBridge{T,F},
+    ::MOI.ListOfConstraintIndices{F,MOI.HyperRectangle{T}},
+) where {T,F}
+    return [bridge.vector_constraint]
+end
+
+function MOI.delete(model::MOI.ModelLike, bridge::IntervalToHyperRectangleBridge)
+    MOI.delete(model, bridge.vector_constraint)
+    return
+end
+
+function MOI.supports(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintPrimalStart,MOI.ConstraintDualStart},
+    ::Type{IntervalToHyperRectangleBridge{T,F,G}},
+) where {T,F,G}
+    return MOI.supports(model, attr, MOI.ConstraintIndex{F,MOI.HyperRectangle{T}})
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintPrimal,MOI.ConstraintPrimalStart},
+    bridge::IntervalToHyperRectangleBridge,
+)
+    x = MOI.get(model, attr, bridge.vector_constraint)
+    if isnothing(x)
+        return nothing
+    end
+    return only(x)
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintPrimalStart,
+    bridge::IntervalToHyperRectangleBridge,
+    value,
+)
+    MOI.set(
+        model,
+        attr,
+        bridge.vector_constraint,
+        [value],
+    )
+    return
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintPrimalStart,
+    bridge::IntervalToHyperRectangleBridge,
+    ::Nothing,
+)
+    MOI.set(model, attr, bridge.vector_constraint, nothing)
+    return
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::Union{MOI.ConstraintDual,MOI.ConstraintDualStart},
+    bridge::IntervalToHyperRectangleBridge,
+)
+    x = MOI.get(model, attr, bridge.vector_constraint)
+    if isnothing(x)
+        return nothing
+    end
+    return only(x)
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintDualStart,
+    bridge::IntervalToHyperRectangleBridge,
+    value,
+)
+    if isnothing(value)
+        MOI.set(model, attr, bridge.vector_constraint, nothing)
+    else
+        MOI.set(model, attr, bridge.vector_constraint, [value])
+    end
+    return
+end
+
+function MOI.modify(
+    model::MOI.ModelLike,
+    bridge::IntervalToHyperRectangleBridge,
+    change::MOI.ScalarCoefficientChange,
+)
+    MOI.modify(
+        model,
+        bridge.vector_constraint,
+        MOI.MultirowChange(change.variable, [(1, change.new_coefficient)]),
+    )
+    @show @__LINE__
+    return
+end
+
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintSet,
+    bridge::IntervalToHyperRectangleBridge,
+    new_set::MOI.Interval,
+)
+    MOI.set(
+        model,
+        attr,
+        bridge.vector_constraint,
+        MOI.HyperRectangle([new_set.lower], [new_set.upper]),
+    )
+    return
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintFunction,
+    bridge::IntervalToHyperRectangleBridge{T,F,G},
+) where {T,F,G}
+    return convert(G, only(MOI.Utilities.scalarize(
+        MOI.get(model, attr, bridge.vector_constraint),
+    )))
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    ::MOI.ConstraintSet,
+    bridge::IntervalToHyperRectangleBridge,
+)
+    rect = MOI.get(model, MOI.ConstraintSet(), bridge.vector_constraint)
+    return MOI.Interval(only(rect.lower), only(rect.upper))
+end

--- a/src/Bridges/Constraint/bridges/IntervalToHyperRectangleBridge.jl
+++ b/src/Bridges/Constraint/bridges/IntervalToHyperRectangleBridge.jl
@@ -56,7 +56,9 @@ function MOI.supports_constraint(
     return MOI.Utilities.is_coefficient_type(F, T)
 end
 
-function MOI.Bridges.added_constrained_variable_types(::Type{<:IntervalToHyperRectangleBridge})
+function MOI.Bridges.added_constrained_variable_types(
+    ::Type{<:IntervalToHyperRectangleBridge},
+)
     return Tuple{Type}[]
 end
 
@@ -89,7 +91,10 @@ function MOI.get(
     return [bridge.vector_constraint]
 end
 
-function MOI.delete(model::MOI.ModelLike, bridge::IntervalToHyperRectangleBridge)
+function MOI.delete(
+    model::MOI.ModelLike,
+    bridge::IntervalToHyperRectangleBridge,
+)
     MOI.delete(model, bridge.vector_constraint)
     return
 end
@@ -99,7 +104,11 @@ function MOI.supports(
     attr::Union{MOI.ConstraintPrimalStart,MOI.ConstraintDualStart},
     ::Type{IntervalToHyperRectangleBridge{T,F,G}},
 ) where {T,F,G}
-    return MOI.supports(model, attr, MOI.ConstraintIndex{F,MOI.HyperRectangle{T}})
+    return MOI.supports(
+        model,
+        attr,
+        MOI.ConstraintIndex{F,MOI.HyperRectangle{T}},
+    )
 end
 
 function MOI.get(
@@ -120,12 +129,7 @@ function MOI.set(
     bridge::IntervalToHyperRectangleBridge,
     value,
 )
-    MOI.set(
-        model,
-        attr,
-        bridge.vector_constraint,
-        [value],
-    )
+    MOI.set(model, attr, bridge.vector_constraint, [value])
     return
 end
 
@@ -199,9 +203,14 @@ function MOI.get(
     attr::MOI.ConstraintFunction,
     bridge::IntervalToHyperRectangleBridge{T,F,G},
 ) where {T,F,G}
-    return convert(G, only(MOI.Utilities.scalarize(
-        MOI.get(model, attr, bridge.vector_constraint),
-    )))
+    return convert(
+        G,
+        only(
+            MOI.Utilities.scalarize(
+                MOI.get(model, attr, bridge.vector_constraint),
+            ),
+        ),
+    )
 end
 
 function MOI.get(

--- a/src/Bridges/Constraint/bridges/IntervalToHyperRectangleBridge.jl
+++ b/src/Bridges/Constraint/bridges/IntervalToHyperRectangleBridge.jl
@@ -179,7 +179,6 @@ function MOI.modify(
         bridge.vector_constraint,
         MOI.MultirowChange(change.variable, [(1, change.new_coefficient)]),
     )
-    @show @__LINE__
     return
 end
 

--- a/src/Bridges/Constraint/bridges/VectorizeBridge.jl
+++ b/src/Bridges/Constraint/bridges/VectorizeBridge.jl
@@ -15,6 +15,9 @@
 
 where `T` is the coefficient type of `g(x) - a`.
 
+See also [`IntervalToHyperRectangleBridge`](@ref) for double-sided bound
+constraints.
+
 ## Source node
 
 `VectorizeBridge` supports:

--- a/test/Bridges/Constraint/IntervalToHyperRectangleBridge.jl
+++ b/test/Bridges/Constraint/IntervalToHyperRectangleBridge.jl
@@ -1,0 +1,114 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestConstraintIntervalToHyperRectangle
+
+using Test
+
+import MathOptInterface as MOI
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name) $T" for T in [Float32, Float64]
+                getfield(@__MODULE__, name)(T)
+            end
+        end
+    end
+    return
+end
+
+include("../utilities.jl")
+
+function test_ScalarFunctionConstantNotZero(T)
+    mock = MOI.Utilities.MockOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}()),
+    )
+    bridged_mock = MOI.Bridges.Constraint.IntervalToHyperRectangle{T}(mock)
+    config = MOI.Test.Config(T)
+    MOI.Test.test_model_ScalarFunctionConstantNotZero(bridged_mock, config)
+    return
+end
+
+function test_basic(T)
+    mock = MOI.Utilities.MockOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}()),
+    )
+    bridged_mock = MOI.Bridges.Constraint.IntervalToHyperRectangle{T}(mock)
+    config = MOI.Test.Config()
+    MOI.Test.runtests(
+        bridged_mock,
+        config,
+        include = ["test_basic_ScalarAffineFunction_Interval"],
+    )
+    return
+end
+
+function test_linear_integration(T)
+    mock = MOI.Utilities.MockOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{T}()),
+    )
+    bridged_mock = MOI.Bridges.Constraint.IntervalToHyperRectangle{T}(mock)
+    config = MOI.Test.Config(T, exclude = Any[MOI.ConstraintBasisStatus])
+    MOI.Utilities.set_mock_optimize!(
+        mock,
+        (mock::MOI.Utilities.MockOptimizer) -> MOI.Utilities.mock_optimize!(
+            mock,
+            T[5, 5],
+            (MOI.VectorAffineFunction{T}, MOI.HyperRectangle{T}) => [T[-1]],
+        ),
+        (mock::MOI.Utilities.MockOptimizer) -> MOI.Utilities.mock_optimize!(
+            mock,
+            T[5//2, 5//2],
+            (MOI.VectorAffineFunction{T}, MOI.HyperRectangle{T}) => [T[1]],
+        ),
+        (mock::MOI.Utilities.MockOptimizer) -> MOI.Utilities.mock_optimize!(
+            mock,
+            T[1, 1],
+            (MOI.VectorAffineFunction{T}, MOI.HyperRectangle{T}) => [T[1]],
+        ),
+        (mock::MOI.Utilities.MockOptimizer) -> MOI.Utilities.mock_optimize!(
+            mock,
+            T[6, 6],
+            (MOI.VectorAffineFunction{T}, MOI.HyperRectangle{T}) => [T[-1]],
+        ),
+    )
+    MOI.Test.test_linear_integration_Interval(bridged_mock, config)
+    return
+end
+
+
+function test_runtests(T)
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.IntervalToHyperRectangleBridge,
+        model -> begin
+            x = MOI.add_variable(model)
+            MOI.add_constraint(model, x, MOI.Interval{T}(3, 5))
+        end,
+        model -> begin
+            x = MOI.add_variable(model)
+            MOI.add_constraint(model, MOI.VectorOfVariables([x]), MOI.HyperRectangle(T[3], T[5]))
+        end,
+        eltype = T,
+    )
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.IntervalToHyperRectangleBridge,
+        model -> begin
+            x = MOI.add_variable(model)
+            MOI.add_constraint(model, T(2) * x, MOI.Interval{T}(3, 5))
+        end,
+        model -> begin
+            x = MOI.add_variable(model)
+            MOI.add_constraint(model, MOI.Utilities.vectorize([T(2) * x]), MOI.HyperRectangle(T[3], T[5]))
+        end,
+        eltype = T,
+    )
+    return
+end
+
+end  # module
+
+TestConstraintIntervalToHyperRectangle.runtests()

--- a/test/Bridges/Constraint/IntervalToHyperRectangleBridge.jl
+++ b/test/Bridges/Constraint/IntervalToHyperRectangleBridge.jl
@@ -80,7 +80,6 @@ function test_linear_integration(T)
     return
 end
 
-
 function test_runtests(T)
     MOI.Bridges.runtests(
         MOI.Bridges.Constraint.IntervalToHyperRectangleBridge,
@@ -90,7 +89,11 @@ function test_runtests(T)
         end,
         model -> begin
             x = MOI.add_variable(model)
-            MOI.add_constraint(model, MOI.VectorOfVariables([x]), MOI.HyperRectangle(T[3], T[5]))
+            MOI.add_constraint(
+                model,
+                MOI.VectorOfVariables([x]),
+                MOI.HyperRectangle(T[3], T[5]),
+            )
         end,
         eltype = T,
     )
@@ -102,7 +105,11 @@ function test_runtests(T)
         end,
         model -> begin
             x = MOI.add_variable(model)
-            MOI.add_constraint(model, MOI.Utilities.vectorize([T(2) * x]), MOI.HyperRectangle(T[3], T[5]))
+            MOI.add_constraint(
+                model,
+                MOI.Utilities.vectorize([T(2) * x]),
+                MOI.HyperRectangle(T[3], T[5]),
+            )
         end,
         eltype = T,
     )

--- a/test/Bridges/debug.jl
+++ b/test/Bridges/debug.jl
@@ -98,22 +98,13 @@ function test_print_active_bridges()
  |   * Supported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.Zeros
  * Unsupported constraint: MOI.ScalarAffineFunction{Float64}-in-MOI.Interval{Float64}
  |  bridged by:
- |   MOIB.Constraint.SplitIntervalBridge{Float64, MOI.ScalarAffineFunction{Float64}, MOI.Interval{Float64}, MOI.GreaterThan{Float64}, MOI.LessThan{Float64}}
+ |   MOIB.Constraint.IntervalToHyperRectangleBridge{Float64, MOI.VectorAffineFunction{Float64}, MOI.ScalarAffineFunction{Float64}}
  |  may introduce:
- |   * Unsupported constraint: MOI.ScalarAffineFunction{Float64}-in-MOI.GreaterThan{Float64}
+ |   * Unsupported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.HyperRectangle{Float64}
  |   |  bridged by:
- |   |   MOIB.Constraint.VectorizeBridge{Float64, MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives, MOI.ScalarAffineFunction{Float64}}
+ |   |   MOIB.Constraint.SplitHyperRectangleBridge{Float64, MOI.VectorAffineFunction{Float64}, MOI.VectorAffineFunction{Float64}}
  |   |  may introduce:
  |   |   * Supported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.Nonnegatives
- |   * Unsupported constraint: MOI.ScalarAffineFunction{Float64}-in-MOI.LessThan{Float64}
- |   |  bridged by:
- |   |   MOIB.Constraint.VectorizeBridge{Float64, MOI.VectorAffineFunction{Float64}, MOI.Nonpositives, MOI.ScalarAffineFunction{Float64}}
- |   |  may introduce:
- |   |   * Unsupported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.Nonpositives
- |   |   |  bridged by:
- |   |   |   MOIB.Constraint.NonposToNonnegBridge{Float64, MOI.VectorAffineFunction{Float64}, MOI.VectorAffineFunction{Float64}}
- |   |   |  may introduce:
- |   |   |   * Supported constraint: MOI.VectorAffineFunction{Float64}-in-MOI.Nonnegatives
  * Unsupported constraint: MOI.ScalarQuadraticFunction{Float64}-in-MOI.LessThan{Float64}
  |  bridged by:
  |   MOIB.Constraint.QuadtoSOCBridge{Float64}

--- a/test/Bridges/lazy_bridge_optimizer.jl
+++ b/test/Bridges/lazy_bridge_optimizer.jl
@@ -2056,6 +2056,13 @@ function test_ToScalarQuadraticBridge_used()
         model,
         MOI.Bridges.Constraint.VectorizeBridge{Float64},
     )
+    @test MOI.Bridges.bridging_cost(model, F, S) == 3.0
+    @test MOI.Bridges.bridge_type(model, F, S) <:
+          MOI.Bridges.Constraint.LessToIntervalBridge{Float64}
+    MOI.Bridges.remove_bridge(
+        model,
+        MOI.Bridges.Constraint.LessToIntervalBridge{Float64},
+    )
     @test MOI.Bridges.bridging_cost(model, F, S) == 10.0
     @test MOI.Bridges.bridge_type(model, F, S) <:
           MOI.Bridges.Constraint.ToScalarQuadraticBridge{Float64}


### PR DESCRIPTION
Needed to use `MatrixOfConstraints` in the COSMO MOI wrapper (see https://github.com/oxfordcontrol/COSMO.jl/pull/198)

Requires

- [x] https://github.com/jump-dev/MathOptInterface.jl/pull/2755

## Basic

 - [x] Create a new file in `src/Bridges/XXX/bridges` named after the type of
       the bridge
 - [x] Define the bridge, following existing examples. The name of the bridge
       struct must end in `Bridge`
 - [x] Check if your bridge can be a subtype of [`MOI.Bridges.Constraint.SetMapBridge`](@ref)
 - [x] Define a new `const` that is a `SingleBridgeOptimizer` wrapping the
       new bridge. The name of the const must be the name of the bridge, less
       the `Bridge` suffix
 - [x] If the bridge should be enabled by default, add the bridge to
       `add_all_bridges` at the bottom of `src/Bridges/XXX/XXX.jl`

## Tests

 - [x] Create a new file in the appropriate subdirectory of `tests/Bridges/XXX`
       named after the type of the bridge
 - [x] Use `MOI.Bridges.runtests` to test various inputs and outputs of the
       bridge
 - [x] If, after opening the pull request to add the bridge, some lines are not
       covered by the tests, add additional bridge-specific tests to cover the
       untested lines.

## Documentation

 - [x] Add a docstring which uses the same template as existing bridges.

## Final touch

If the bridge depends on run-time values of other variables and constraints in
the model:

 - [x] Implement `MOI.Utilities.needs_final_touch(::Bridge)`
 - [x] Implement `MOI.Utilities.final_touch(::Bridge, ::MOI.ModelLike)`
 - [x] Ensure that `final_touch` can be called multiple times in a row