### PR TITLE
Prep for v1.40.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.40.0"
+version = "1.40.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -154,12 +154,8 @@ Documenter.DocMeta.setdocmeta!(
     linkcheck_ignore = [
         # Ignore the PDF link, because it hasn't been built yet.
         "MathOptInterface.pdf",
-        # Ignore tags, because prepping for a new release will otherwise cause
-        # it to fail.
-        r"https://github.com/jump-dev/MathOptInterface.jl/releases/tag/v([0-9]).([0-9]+).([0-9]+)",
-        # Ignore issue and pull request links, because there are many of them,
-        # and they sometimes time-out the linkcheck.
-        r"https://github.com/jump-dev/MathOptInterface.jl/issues/([0-9]+)",
+        # Ignore the very many GitHub links
+        r"https://github.com/jump-dev/.+",
         "https://arxiv.org/abs/2002.03447",
     ],
     modules = [MathOptInterface],

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.40.1 (May 19, 2025)
+## v1.40.1 (May 20, 2025)
 
 ### Fixed
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,24 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.40.1 (May 19, 2025)
+
+### Fixed
+
+ - Fixed a missing [`dual_set`](@ref) for [`HermitianPositiveSemidefiniteConeTriangle`](@ref)
+   (#2749)
+ - Fixed [`Utilities.get_fallback`](@ref) of [`DualObjectiveValue`](@ref) with
+   [`HyperRectangle`](@ref) (#2755)
+ - Fixed reading SDPA files with `{}` punctuation (#2759)
+
+### Other
+
+ - Fixed a flakey doctest that depended on the runtime of a function (#2748)
+ - Changed to use `Base.only` when appropriate (#2751)
+ - Removed the experimental warning from Nonlinear module docstring (#2752)
+ - Changed to use `throw_if_scalar_and_constant_not_zero` when appropriate (#2753)
+ - Improved the text of `showerror` for `NotAllowedError` (#2757)
+
 ## v1.40.0 (May 4, 2025)
 
 ### Added


### PR DESCRIPTION
## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/15103076298
    - [x] PolyJuMP: known incompatibility
    - [x] SumOfSquares: known incompatibility
    - [x] BilevelJuMP: https://github.com/joaquimg/BilevelJuMP.jl/pull/221
    - [x] CATruustRegionMethod: looks like a flakey convergence issue
    - [x] Clarabel: https://github.com/oxfordcontrol/Clarabel.jl/pull/198
    - [x] Manopt: https://github.com/JuliaSmoothOptimizers/QuadraticModels.jl/issues/155
    - [x] Percival: https://github.com/JuliaSmoothOptimizers/QuadraticModels.jl/issues/155
 - [x] If new tests were added, ensure that `MOI.Test.version_added` is implemented.