### PR TITLE
[FileFormats.NL] fix try_scalar_affine_function

### DIFF
--- a/src/FileFormats/NL/read.jl
+++ b/src/FileFormats/NL/read.jl
@@ -271,11 +271,15 @@ _try_scalar_affine_function(x::MOI.VariableIndex) = x
 function _try_scalar_affine_function(expr::Expr)
     if expr.args[1] == :+
         args = _try_scalar_affine_function.(expr.args[2:end])
-        if !any(isnothing, args)
-            return MOI.Utilities.operate(+, Float64, args...)
+        if any(isnothing, args)
+            return nothing
         end
+        return MOI.Utilities.operate(+, Float64, args...)
     elseif expr.args[1] == :*
         args = _try_scalar_affine_function.(expr.args[2:end])
+        if any(isnothing, args)
+            return nothing
+        end
         n_affine_terms = 0
         for arg in args
             n_affine_terms += arg isa MOI.VariableIndex

--- a/test/FileFormats/NL/read.jl
+++ b/test/FileFormats/NL/read.jl
@@ -1066,6 +1066,29 @@ function test_binary_parse_S_Float64()
     return
 end
 
+function test_try_scalar_affine_function()
+    compare(::Nothing, ::Nothing) = true
+    compare(x::T, y::T) where {T} = isapprox(x, y)
+    compare(x, y) = (@show(x, y, typeof(x), typeof(y)); false)
+    x = MOI.VariableIndex(1)
+    for (expr, ret) in Any[
+        :(2.0)=>2.0,
+        :($x)=>x,
+        :(2.0*$x)=>2.0*x,
+        :($x*2.0)=>2.0*x,
+        :(($x+$x))=>2.0*x,
+        :(2.0*($x+$x))=>4.0*x,
+        :(($x+$x)*2.0)=>4.0*x,
+        :(($x+x)+2.0)=>2.0*x+2.0,
+        :(sin($x)*($x+$x))=>nothing,
+        :(($x+$x)*sin($x))=>nothing,
+        :($x*$x)=>nothing,
+    ]
+        @test compare(MOI.FileFormats.NL._try_scalar_affine_function(expr), ret)
+    end
+    return
+end
+
 end
 
 TestNonlinearRead.runtests()

--- a/test/FileFormats/NL/read.jl
+++ b/test/FileFormats/NL/read.jl
@@ -1079,7 +1079,7 @@ function test_try_scalar_affine_function()
         :(($x+$x))=>2.0*x,
         :(2.0*($x+$x))=>4.0*x,
         :(($x+$x)*2.0)=>4.0*x,
-        :(($x+x)+2.0)=>2.0*x+2.0,
+        :(($x+$x)+2.0)=>2.0*x+2.0,
         :(sin($x)*($x+$x))=>nothing,
         :(($x+$x)*sin($x))=>nothing,
         :($x*$x)=>nothing,


### PR DESCRIPTION
x-ref https://discourse.julialang.org/t/convert-a-nonlinear-model-defined-by-jumps-legacy-version-to-latest-version/129542