### PR TITLE
[FileFormats.SDPA] add coefficient_type kwarg and improve tests

### DIFF
--- a/src/FileFormats/SDPA/SDPA.jl
+++ b/src/FileFormats/SDPA/SDPA.jl
@@ -55,9 +55,9 @@ struct Options end
 get_options(m::Model) = get(m.ext, :SDPA_OPTIONS, Options())
 
 """
-    Model(; number_type::Type = Float64)
+    Model(; coefficient_type::Type{T} = Float64) where {T}
 
-Create an empty instance of `FileFormats.SDPA.Model{number_type}`.
+Create an empty instance of `FileFormats.SDPA.Model{T}`.
 
 It is important to be aware that the SDPA file format is interpreted in
 *geometric* form and not *standard conic* form.
@@ -122,8 +122,11 @@ and affine constraints will be bridged into equality constraints
 by creating a slack variable by the
 [`MOI.Bridges.Constraint.VectorSlackBridge`](@ref).
 """
-function Model(; number_type::Type = Float64)
-    model = Model{number_type}()
+function Model(;
+    number_type::Type{T} = Float64,
+    coefficient_type::Type{S} = number_type,
+) where {T,S}
+    model = Model{S}()
     model.ext[:SDPA_OPTIONS] = Options()
     return model
 end

--- a/test/FileFormats/SDPA/models/example_A_int.dat-s
+++ b/test/FileFormats/SDPA/models/example_A_int.dat-s
@@ -1,0 +1,16 @@
+"Example from http://plato.asu.edu/ftp/sdpa_format.txt
+"A sample problem.
+2 =mdim
+2 =nblocks
+2 2
+10 20
+0 1 1 1 1
+0 1 2 2 2
+0 2 1 1 3
+0 2 2 2 4
+1 1 1 1 1
+1 1 2 2 1
+2 1 2 2 1
+2 2 1 1 5
+2 2 1 2 2
+2 2 2 2 6


### PR DESCRIPTION
#2768, #2769, and #2770 added this for LP, MPS, and MOF respectively. SDPA already had some support, but it used `number_type` as the kwarg. This change unifies the kwarg to `coefficient_type` and adds a proper test.

Part of #2765 