### PR TITLE
Optionally disable warn on `PenaltyRelaxation`

### DIFF
--- a/src/Utilities/penalty_relaxation.jl
+++ b/src/Utilities/penalty_relaxation.jl
@@ -189,7 +189,7 @@ cannot be modified in-place.
 To modify variable bounds, rewrite them as linear constraints.
 
 If a constraint type can not be modified, a warning is logged and the
-constraint is skipped. This can be disabled by setting `warn = false`.
+constraint is skipped. The warning can be disabled by setting `warn = false`.
 
 ## Example
 

--- a/src/Utilities/penalty_relaxation.jl
+++ b/src/Utilities/penalty_relaxation.jl
@@ -142,7 +142,7 @@ end
     PenaltyRelaxation(
         penalties = Dict{MOI.ConstraintIndex,Float64}();
         default::Union{Nothing,T} = 1.0,
-        no_warning_skip_constraint::Bool = false,
+        warn::Bool = true,
     )
 
 A problem modifier that, when passed to [`MOI.modify`](@ref), destructively
@@ -189,8 +189,7 @@ cannot be modified in-place.
 To modify variable bounds, rewrite them as linear constraints.
 
 If a constraint type can not be modified, a warning is logged and the
-constraint is skipped. This can be disabled by setting
-`no_warning_skip_constraint = true`.
+constraint is skipped. This can be disabled by setting `warn = false`.
 
 ## Example
 
@@ -247,14 +246,14 @@ true
 mutable struct PenaltyRelaxation{T}
     default::Union{Nothing,T}
     penalties::Dict{MOI.ConstraintIndex,T}
-    no_warning_skip_constraint::Bool
+    warn::Bool
 
     function PenaltyRelaxation(
         p::Dict{MOI.ConstraintIndex,T};
         default::Union{Nothing,T} = one(T),
-        no_warning_skip_constraint::Bool = false,
+        warn::Bool = true,
     ) where {T}
-        return new{T}(default, p, no_warning_skip_constraint)
+        return new{T}(default, p, warn)
     end
 end
 
@@ -293,7 +292,7 @@ function _modify_penalty_relaxation(
             map[ci] = MOI.modify(model, ci, ScalarPenaltyRelaxation(penalty))
         catch err
             if err isa MethodError && err.f == MOI.modify
-                if !relax.no_warning_skip_constraint
+                if relax.warn
                     @warn(
                         "Skipping PenaltyRelaxation for ConstraintIndex{$F,$S}"
                     )

--- a/src/Utilities/penalty_relaxation.jl
+++ b/src/Utilities/penalty_relaxation.jl
@@ -188,7 +188,7 @@ cannot be modified in-place.
 
 To modify variable bounds, rewrite them as linear constraints.
 
-If a constraint type can not be modified, a warning is logged and the
+If a constraint cannot be modified, a warning is logged and the
 constraint is skipped. The warning can be disabled by setting `warn = false`.
 
 ## Example

--- a/test/Utilities/penalty_relaxation.jl
+++ b/test/Utilities/penalty_relaxation.jl
@@ -66,15 +66,7 @@ function test_relax_bounds()
 end
 
 function test_relax_no_warn()
-    src_str = """
-    variables: x, y
-    minobjective: x + y
-    x >= 0.0
-    y <= 0.0
-    x in ZeroOne()
-    y in Integer()
-    """
-    relaxed_str = """
+    input = """
     variables: x, y
     minobjective: x + y
     x >= 0.0
@@ -83,12 +75,11 @@ function test_relax_no_warn()
     y in Integer()
     """
     model = MOI.Utilities.Model{Float64}()
-    MOI.Utilities.loadfromstring!(model, src_str)
-    @test_logs(
-        MOI.modify(model, MOI.Utilities.PenaltyRelaxation(; warn = false)),
-    )
+    MOI.Utilities.loadfromstring!(model, input)
+    relaxation = MOI.Utilities.PenaltyRelaxation(; warn = false)
+    @test_logs MOI.modify(model, relaxation)
     dest = MOI.Utilities.Model{Float64}()
-    MOI.Utilities.loadfromstring!(dest, relaxed_str)
+    MOI.Utilities.loadfromstring!(dest, input)
     MOI.Bridges._test_structural_identical(model, dest)
     return
 end

--- a/test/Utilities/penalty_relaxation.jl
+++ b/test/Utilities/penalty_relaxation.jl
@@ -85,10 +85,7 @@ function test_relax_no_warn()
     model = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(model, src_str)
     @test_logs(
-        MOI.modify(
-            model,
-            MOI.Utilities.PenaltyRelaxation(no_warning_skip_constraint = true),
-        ),
+        MOI.modify(model, MOI.Utilities.PenaltyRelaxation(; warn = false)),
     )
     dest = MOI.Utilities.Model{Float64}()
     MOI.Utilities.loadfromstring!(dest, relaxed_str)

--- a/test/Utilities/penalty_relaxation.jl
+++ b/test/Utilities/penalty_relaxation.jl
@@ -65,6 +65,37 @@ function test_relax_bounds()
     return
 end
 
+function test_relax_no_warn()
+    src_str = """
+    variables: x, y
+    minobjective: x + y
+    x >= 0.0
+    y <= 0.0
+    x in ZeroOne()
+    y in Integer()
+    """
+    relaxed_str = """
+    variables: x, y
+    minobjective: x + y
+    x >= 0.0
+    y <= 0.0
+    x in ZeroOne()
+    y in Integer()
+    """
+    model = MOI.Utilities.Model{Float64}()
+    MOI.Utilities.loadfromstring!(model, src_str)
+    @test_logs(
+        MOI.modify(
+            model,
+            MOI.Utilities.PenaltyRelaxation(no_warning_skip_constraint = true),
+        ),
+    )
+    dest = MOI.Utilities.Model{Float64}()
+    MOI.Utilities.loadfromstring!(dest, relaxed_str)
+    MOI.Bridges._test_structural_identical(model, dest)
+    return
+end
+
 function test_relax_affine_lessthan()
     _test_roundtrip(
         """


### PR DESCRIPTION
This is a massive pain in:
- https://github.com/jump-dev/ModelAnalyzer.jl
- https://github.com/jump-dev/MathOptConflictSolver.jl

As we keep skipping bounds and such.

The behaviour is opt-out, so users remain with the warning.