### PR TITLE
[FileFormats.MPS] test that duplicate entries are summed

### DIFF
--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -1661,6 +1661,20 @@ function test_obj_constant_max_to_max()
     return
 end
 
+function test_duplicate_coefficient()
+    model = MPS.Model()
+    MOI.read_from_file(model, joinpath(@__DIR__, "duplicate_coefficient.mps"))
+    dest = MOI.Utilities.Model{Float64}()
+    MOI.copy_to(dest, model)
+    F, S = MOI.ScalarAffineFunction{Float64}, MOI.EqualTo{Float64}
+    x = only(MOI.get(dest, MOI.ListOfVariableIndices()))
+    c = only(MOI.get(dest, MOI.ListOfConstraintIndices{F,S}()))
+    f = MOI.get(dest, MOI.ConstraintFunction(), c)
+    @test isapprox(f, 2.0 * x)
+    @test MOI.get(dest, MOI.ConstraintSet(), c) == MOI.EqualTo(1.0)
+    return
+end
+
 end  # TestMPS
 
 TestMPS.runtests()

--- a/test/FileFormats/MPS/duplicate_coefficient.mps
+++ b/test/FileFormats/MPS/duplicate_coefficient.mps
@@ -1,0 +1,13 @@
+NAME          DUPLICATE_COEFFICIENT
+ROWS
+ N  obj
+ E  c
+COLUMNS
+    x         obj       1
+    x         c         1
+    x         c         1
+RHS
+    rhs       c        1
+BOUNDS
+ FR bounds    x
+ENDATA


### PR DESCRIPTION
Closes #2786

It's not obvious what the right thing to do here is.

Gurobi ignores the repeated coefficients:
```
(base) oscar@Oscars-MacBook-Pro MathOptInterface % gurobi_cl test/FileFormats/MPS/duplicate_coefficient.mps
Set parameter LicenseID to value 890341
Set parameter LogFile to value "gurobi.log"
Using license file /Users/oscar/gurobi.lic

Gurobi Optimizer version 11.0.1 build v11.0.1rc0 (mac64[x86] - Darwin 24.1.0 24B83)
Copyright (c) 2024, Gurobi Optimization, LLC

Warning: duplicate nonzeros for column x and row c.
Read MPS format model from file test/FileFormats/MPS/duplicate_coefficient.mps
Reading time = 0.00 seconds
DUPLICATE_COEFFICIENT: 1 rows, 1 columns, 1 nonzeros

CPU model: Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
Thread count: 4 physical cores, 8 logical processors, using up to 8 threads

Optimize a model with 1 rows, 1 columns and 1 nonzeros
Model fingerprint: 0x0866ac82
Coefficient statistics:
  Matrix range     [1e+00, 1e+00]
  Objective range  [1e+00, 1e+00]
  Bounds range     [0e+00, 0e+00]
  RHS range        [1e+00, 1e+00]
Presolve removed 1 rows and 1 columns
Presolve time: 0.01s
Presolve: All rows and columns removed
Iteration    Objective       Primal Inf.    Dual Inf.      Time
       0    1.0000000e+00   0.000000e+00   0.000000e+00      0s

Solved in 0 iterations and 0.01 seconds (0.00 work units)
Optimal objective  1.000000000e+00
```

Cbc says:
```
Coin:import test/FileFormats/MPS/duplicate_coefficient.mps
At line 1 NAME          DUPLICATE_COEFFICIENT
At line 2 ROWS
At line 5 COLUMNS
Duplicate row c at line 8 <     x         c         1 >
At line 9 RHS
At line 11 BOUNDS
At line 13 ENDATA
Problem DUPLICATE_COEFFICIENT has 1 rows, 1 columns and 1 elements
Coin0008I DUPLICATE_COEFFICIENT read with 1 errors
There were 1 errors on input
```

So should we keep the current behavior or change to an error? Gurobi throwing a warning but solving an arbitrary (which one did it ignore!!!) problem seems like a massively wrong choice. (cc @simonbowly)