### PR TITLE
Convert common sub-functions as common sub-expressions

### DIFF
--- a/src/Nonlinear/types.jl
+++ b/src/Nonlinear/types.jl
@@ -76,8 +76,9 @@ tree.
 struct Expression
     nodes::Vector{Node}
     values::Vector{Float64}
-    Expression() = new(Node[], Float64[])
 end
+
+Expression() = Expression(Node[], Float64[])
 
 function Base.:(==)(x::Expression, y::Expression)
     return x.nodes == y.nodes && x.values == y.values
@@ -165,6 +166,11 @@ mutable struct Model
     operators::OperatorRegistry
     # This is a private field, used only to increment the ConstraintIndex.
     last_constraint_index::Int64
+    # This is a private field, used to detect common subexpressions.
+    cache::Dict{
+        MOI.ScalarNonlinearFunction,
+        Union{ExpressionIndex,Tuple{Expression,Int}},
+    }
     function Model()
         return new(
             nothing,
@@ -173,6 +179,10 @@ mutable struct Model
             Float64[],
             OperatorRegistry(),
             0,
+            Dict{
+                MOI.ScalarNonlinearFunction,
+                Union{ExpressionIndex,Tuple{Expression,Int}},
+            }(),
         )
     end
 end


### PR DESCRIPTION
Follow up from https://github.com/jump-dev/JuMP.jl/pull/4032.
At the moment, you can have a small model in terms of memory footprint of the `MOI.ScalarNonlinearFunction`. However, when you add it to the MOI level, the AD tape can be exponentially bigger.
With this PR, the AD tape has the same memory footprint as the `MOI.ScalarNonlinearFunction` simply by interpreting the use of the same (in terms of the same pointer in memory, no expensive comparison is done) sub-functions as sub-expressions.

What's a little bit tricky to handle is that the first time to see an expression, you're just going to add it to the tape so the second time you see it, you need to replace it in the tape as a subexpression and update the indices of variables after the tape.
Since the sub-expression is contiguous in the tape, it's fortunately not too hard to do.

It also prevents the copy of `MOI.ScalarNonlinearFunction`s, what's the catch there ?

Closes https://github.com/jump-dev/MathOptInterface.jl/issues/3065