### PR TITLE
[FileFormats.MPS] allow any whitespace as a separator between fields

### DIFF
--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -1160,7 +1160,14 @@ function Headers(s::AbstractString)
 end
 
 function line_to_items(line)
-    items = split(line, " "; keepempty = false)
+    # Split on any whitespace characters. We can't split only on `' '` because
+    # at least one models in MIPLIB has `\t` as a separator.
+    #
+    # This decision assumes that we are parsing a free MPS file, where
+    # whitespace is disallowed in names. If this ever becomes a problem, we
+    # could change to the fixed MPS format, where the files are split at the
+    # usual offsets.
+    items = split(line, r"\s"; keepempty = false)
     return String.(items)
 end
 

--- a/test/FileFormats/MPS/MPS.jl
+++ b/test/FileFormats/MPS/MPS.jl
@@ -1703,6 +1703,16 @@ function test_issue_2792()
     return
 end
 
+function test_issue_2797_tab()
+    @test MPS.line_to_items("a b") == ["a", "b"]
+    @test MPS.line_to_items(" a b") == ["a", "b"]
+    @test MPS.line_to_items("a\tb") == ["a", "b"]
+    @test MPS.line_to_items("a\tb") == ["a", "b"]
+    @test MPS.line_to_items("a\t b") == ["a", "b"]
+    @test MPS.line_to_items(" a \t b      c ") == ["a", "b", "c"]
+    return
+end
+
 end  # TestMPS
 
 TestMPS.runtests()


### PR DESCRIPTION
Part of https://github.com/jump-dev/MathOptInterface.jl/issues/2797