### PR TITLE
[Utilities] fix backwards compat of ConflictCount in MockOptimizer

### DIFF
--- a/src/Utilities/mockoptimizer.jl
+++ b/src/Utilities/mockoptimizer.jl
@@ -319,6 +319,12 @@ function MOI.set(
     ::MOI.ConflictStatus,
     value::MOI.ConflictStatusCode,
 )
+    if value == MOI.CONFLICT_FOUND && mock.conflict_count == 0
+        # A backwards compatible change for JuMP, which set MOI.ConflictStatus
+        # in its tests without setting MOI.ConflictCount (because the test was
+        # writte prior to the introduction of MOI.ConflictCount).
+        mock.conflict_count = 1
+    end
     mock.conflict_status = value
     return
 end


### PR DESCRIPTION
JuMP was failing solver-tests: https://github.com/jump-dev/MathOptInterface.jl/pull/2799

We could have fixed this in the JuMP tests, but I'd rather do it here.

https://github.com/jump-dev/MathOptInterface.jl/actions/runs/16738147486