### PR TITLE
Don't copy ScalarNonlinearFunction in VectorOfConstraints

### DIFF
--- a/src/Utilities/vector_of_constraints.jl
+++ b/src/Utilities/vector_of_constraints.jl
@@ -103,7 +103,14 @@ function MOI.get(
 ) where {F,S}
     MOI.throw_if_not_valid(v, ci)
     f, _ = v.constraints[ci]::Tuple{F,S}
-    return copy(f)
+    # Since `MA.mutability(MOI.ScalarNonlinearFunction)` is `MA.IsNotMutable`,
+    # this does not copy `MOI.ScalarNonlinearFunction`. This is important if the
+    # function share aliases of the same subexpression at different parts of
+    # it's expression graph or the expression graph of other functions of the
+    # model. If we `copy`, they won't be aliases of the same subexpression
+    # anymore hence `MOI.Nonlinear.ReverseAD` won't detect them as common
+    # subexpressions.
+    return MA.copy_if_mutable(f)
 end
 
 function MOI.get(


### PR DESCRIPTION
Extracted from https://github.com/jump-dev/MathOptInterface.jl/pull/2788

I'm not too convinced by the current approach.

For the `copy` in `ConstraintFunction`, I think we add it mostly to be extra-sure the user does not alter the function but we don't really need it in the context of `MOI.copy_to` since `add_constraint` specifies that the model should have its own copy. Maybe we should also have `UnsafeConstraintFunction` that is used inside `MOI.copy_to`, it should also safe wasteful copies for `ScalarAffineFunction` and `ScalarQuadraticFunction`. So if we have tests that checks that solvers have their own copies in `add_constraint` then it should be safe.