### PR TITLE
Prep for v1.43.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.42.1"
+version = "1.43.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.43.0 (August 19, 2025)
+## v1.43.0 (August 21, 2025)
 
 ### Added
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,28 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.43.0 (August 12, 2025)
+
+### Added
+
+ - Added [`ConflictCount`](@ref) and `conflict_index` to
+   [`ConstraintConflictStatus`](@rref) (#2775), (#2800), (#2801)
+ - Added [`Bridges.Constraint.IntervalToHyperRectangleBridge`](@ref) (#2754),
+   (#2806)
+
+### Fixed
+
+ - Fixed the MPS reader to support any whitespace as a field separator (#2798)
+ - Fixed tests with duplicate names and added a CI test (#2804), (#2805)
+ - Fixed parsing `x * x` as `x^2` in `Nonlinear.Model` (#2799)
+ - Fixed a bug in [`Utilities.operate`](@ref) with quadratic outputs when a
+   `Integer` coefficient differs from the machine `Integer` (#2807)
+
+### Other
+
+ - Added an OPF benchmark (#2739)
+ - Updated to DataStructures@0.19 (#2796)
+
 ## v1.42.1 (August 1, 2025)
 
 ### Fixed

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.43.0 (August 12, 2025)
+## v1.43.0 (August 19, 2025)
 
 ### Added
 
@@ -24,7 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixed a bug in [`Utilities.operate`](@ref) with quadratic outputs when a
    `Integer` coefficient differs from the machine `Integer` (#2807)
  - Fixed `MOI.supports` of `MOI.ObjectiveFunction` in all file formats (#2814)
- - Fixed free rows in [`Bridges.Constraint.SplitHyperRectangleBridge`](@ref) (#2815)
+ - Fixed free rows in [`Bridges.Constraint.SplitHyperRectangleBridge`](@ref) (#2816)
+ - Fixed deleting a variable with constraint bridges (#2818)
+ - Fixed `Utilities.AbstractModel` with no constraints (#2819)
 
 ### Other
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
  - Added [`ConflictCount`](@ref) and `conflict_index` to
-   [`ConstraintConflictStatus`](@rref) (#2775), (#2800), (#2801)
+   [`ConstraintConflictStatus`](@ref) (#2775), (#2800), (#2801)
  - Added [`Bridges.Constraint.IntervalToHyperRectangleBridge`](@ref) (#2754),
-   (#2806)
+   (#2806), (#2809)
 
 ### Fixed
 
@@ -23,11 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Fixed parsing `x * x` as `x^2` in `Nonlinear.Model` (#2799)
  - Fixed a bug in [`Utilities.operate`](@ref) with quadratic outputs when a
    `Integer` coefficient differs from the machine `Integer` (#2807)
+ - Fixed `MOI.supports` of `MOI.ObjectiveFunction` in all file formats (#2814)
+ - Fixed free rows in [`Bridges.Constraint.SplitHyperRectangleBridge`](@ref) (#2815)
 
 ### Other
 
  - Added an OPF benchmark (#2739)
  - Updated to DataStructures@0.19 (#2796)
+ - Filter `identity_bridge.jl` out from `runtests` (#2812)
 
 ## v1.42.1 (August 1, 2025)
 


### PR DESCRIPTION
## Blocked by

- [x] https://github.com/jump-dev/MathOptInterface.jl/issues/2815
- [x] A decision on whether to change the bridge weights to avoid HyperRectangle

## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/16899022349
 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/16925784318
 - [x] If new tests were added, ensure that `MOI.Test.version_added` is implemented.