### PR TITLE
Fix ConstraintDual transformation for SplitHyperRectangleBridge

### DIFF
--- a/src/Bridges/Constraint/bridges/SplitHyperRectangleBridge.jl
+++ b/src/Bridges/Constraint/bridges/SplitHyperRectangleBridge.jl
@@ -229,7 +229,7 @@ function MOI.set(
     set = bridge.set
     new_values = vcat(
         T[max(T(0), v) for (v, l) in zip(values, set.lower) if isfinite(l)],
-        T[min(T(0), v) for (v, u) in zip(values, set.upper) if isfinite(u)],
+        T[max(T(0), -v) for (v, u) in zip(values, set.upper) if isfinite(u)],
     )
     MOI.set(model, attr, bridge.ci, new_values)
     return

--- a/src/Bridges/Constraint/bridges/SplitHyperRectangleBridge.jl
+++ b/src/Bridges/Constraint/bridges/SplitHyperRectangleBridge.jl
@@ -255,7 +255,7 @@ function MOI.get(
     for (i, u) in enumerate(bridge.set.upper)
         if isfinite(u)
             row += 1
-            ret[i] += values[row]
+            ret[i] -= values[row]
         end
     end
     return ret


### PR DESCRIPTION
Fix for the issues detected in the SolverTests run of https://github.com/jump-dev/MathOptInterface.jl/pull/2808
I did not add any test since the test is in https://github.com/jump-dev/MathOptInterface.jl/pull/2810
I did https://github.com/jump-dev/MathOptInterface.jl/pull/2810 in a separate PR not only to show in CI that it would have caught this one but also to avoid delaying this PR and hence https://github.com/jump-dev/MathOptInterface.jl/pull/2808 in case https://github.com/jump-dev/MathOptInterface.jl/pull/2810 requires some discussion