### PR TITLE
Test ConstraintDual for bridges

### DIFF
--- a/docs/src/submodules/Bridges/implementation.md
+++ b/docs/src/submodules/Bridges/implementation.md
@@ -79,7 +79,7 @@ julia> MOI.Bridges.runtests(
            """,
        )
 Test Summary:    | Pass  Total  Time
-Bridges.runtests |   29     29  0.0s
+Bridges.runtests |   30     30  0.0s
 ```
 
 There are a number of other useful keyword arguments.
@@ -123,5 +123,5 @@ Subject to:
 ScalarAffineFunction{Int64}-in-LessThan{Int64}
  (0) - (1) x <= (-1)
 Test Summary:    | Pass  Total  Time
-Bridges.runtests |   29     29  0.0s
+Bridges.runtests |   30     30  0.0s
 ```

--- a/src/Bridges/Constraint/bridges/SplitHyperRectangleBridge.jl
+++ b/src/Bridges/Constraint/bridges/SplitHyperRectangleBridge.jl
@@ -196,15 +196,28 @@ end
 
 function MOI.supports(
     model::MOI.ModelLike,
-    attr::Union{MOI.ConstraintPrimalStart,MOI.ConstraintDualStart},
+    attr::Union{
+        MOI.ConstraintPrimalStart,
+        MOI.ConstraintDualStart,
+        MOI.ConstraintDual,
+    },
     ::Type{<:SplitHyperRectangleBridge{T,G}},
 ) where {T,G}
     return MOI.supports(model, attr, MOI.ConstraintIndex{G,MOI.Nonnegatives})
 end
 
-_get_free_start(bridge, ::MOI.ConstraintDualStart) = bridge.free_dual_start
+function _get_free_start(
+    bridge,
+    ::Union{MOI.ConstraintDualStart,MOI.ConstraintDual},
+)
+    return bridge.free_dual_start
+end
 
-function _set_free_start(bridge, ::MOI.ConstraintDualStart, value)
+function _set_free_start(
+    bridge,
+    ::Union{MOI.ConstraintDualStart,MOI.ConstraintDual},
+    value,
+)
     bridge.free_dual_start = value
     return
 end
@@ -284,7 +297,7 @@ end
 
 function MOI.set(
     model::MOI.ModelLike,
-    attr::MOI.ConstraintDualStart,
+    attr::Union{MOI.ConstraintDualStart,MOI.ConstraintDual},
     bridge::SplitHyperRectangleBridge{T},
     values::AbstractVector{T},
 ) where {T}

--- a/test/Bridges/Constraint/ScalarFunctionizeBridge.jl
+++ b/test/Bridges/Constraint/ScalarFunctionizeBridge.jl
@@ -317,6 +317,7 @@ function test_FunctionConversionBridge()
         variables: x, y
         ScalarNonlinearFunction(1.0 * x * x + 2.0 * x * y + 3.0 * y + 4.0) >= 1.0
         """,
+        dual = nothing, # `get_fallback` ignores the constant `4.0` of the function
     )
     # VectorAffineFunction -> VectorQuadraticFunction
     MOI.Bridges.runtests(


### PR DESCRIPTION
I always thought it a bit silly to only define the setter for `ConstraintDualStart` and not with `ConstraintDual`. I sometimes want to test things mixing a `MockOptimizer` and a bridge and I can't because bridges don't define the setters for `ConstraintDual`.

I suggest the following non-breaking change: We should now encourage bridges to supports `ConstraintDual`. When they do, a new test will be enabled that will do an important consistency check. So the new test will not be run for existing bridge which is nice since it could be breaking but after the transition, it will be run for all bridges that don't disable it by doing `dual = nothing`.

This would have caught the bug in https://github.com/jump-dev/MathOptInterface.jl/pull/2809 as the CI should show