### PR TITLE
Add a check that bridge is used

### DIFF
--- a/test/Bridges/Constraint/IndicatorSOS1Bridge.jl
+++ b/test/Bridges/Constraint/IndicatorSOS1Bridge.jl
@@ -345,6 +345,7 @@ function test_runtests()
         [z, 2.0 * x * x] in Indicator{ACTIVATE_ON_ONE}(LessThan(2.0))
         z in ZeroOne()
         """,
+        no_bridge_used = true,
     )
     return
 end

--- a/test/Bridges/Constraint/NumberConversionBridge.jl
+++ b/test/Bridges/Constraint/NumberConversionBridge.jl
@@ -104,6 +104,7 @@ function test_runtests()
         variables: x
         ::Float64: [x, x] in Zeros(2)
         """,
+        no_bridge_used = true,
     )
     # VectorAffineFunction
     MOI.Bridges.runtests(


### PR DESCRIPTION
Most of the time when I debug a new bridge, it starts by not being used and I sometimes loose some time checking it. Having it explicitly checked would be helpful.