### PR TITLE
[FileFormats.LP] fix type stability of LP reader

### DIFF
--- a/src/FileFormats/LP/read.jl
+++ b/src/FileFormats/LP/read.jl
@@ -242,8 +242,8 @@ struct _Token
 end
 
 """
-    mutable struct _LexerState
-        io::IO
+    mutable struct _LexerState{O<:IO}
+        io::O
         line::Int
         peek_char::Union{Nothing,Char}
         peek_tokens::Vector{_Token}
@@ -257,12 +257,12 @@ A struct that is used to manage state when lexing. It stores:
  * `peek_char`: the next `Char` in the `io`
  * `peek_tokens`: the list of upcoming tokens that we have already peeked
 """
-mutable struct _LexerState
-    io::IO
+mutable struct _LexerState{O<:IO}
+    io::O
     line::Int
     peek_char::Union{Nothing,Char}
     peek_tokens::Vector{_Token}
-    _LexerState(io::IO) = new(io, 1, nothing, _Token[])
+    _LexerState(io::IO) = new{typeof(io)}(io, 1, nothing, _Token[])
 end
 
 """


### PR DESCRIPTION
Another follow-up to #2840 

Now reading into an MOI model is only 4x slower than just counting the new lines char-by-char:
```julia
julia> import MathOptInterface as MOI

julia> function main()
           model = MOI.FileFormats.LP.Model{Float64}()
           MOI.read_from_file(model, "/Users/odow/Downloads/QPLIB_10005.lp")
           return model
       end
main (generic function with 1 method)

julia> @time main();
  1.065072 seconds (43.71 M allocations: 1.511 GiB, 22.66% gc time)

julia> function count_newlines(io::IO)
           i = 0
           while !eof(io)
               if read(io, Char) == '\n'
                   i += 1
               end
           end
           return i
       end
count_newlines (generic function with 1 method)

julia> @time open(count_newlines, "/Users/odow/Downloads/QPLIB_10005.lp", "r")
  0.274165 seconds (14 allocations: 792 bytes)
201553
```