### PR TITLE
[docs] temporarily pin OpenSSL_jll to work around upstream bug

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,8 +3,10 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JSONSchema = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 
 [compat]
 Documenter = "1"
 JSON = "0.21"
 JSONSchema = "1"
+OpenSSL_jll = "=3.5.2"


### PR DESCRIPTION
x-ref https://github.com/JuliaPackaging/Yggdrasil/pull/12080

Unless this gets fixed upstream with a yank: https://github.com/JuliaRegistries/General/pull/138670