### PR TITLE
Prep for v1.45.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.44.0"
+version = "1.45.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,28 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.45.0 (September 18, 2025)
+
+### Added
+
+ - Added [`Bridges.ObjectiveToScalarNonlinearBridge`](@ref) (#2834), (#2835)
+ - Added support support for querying [`ConstraintConflictStatus`](@ref) when
+   the constraint was bridged (#2839)
+
+### Fixed
+
+ - Fixed a type instability in [`Utilities.set_dot`](@ref) (#2831)
+ - Rewrote `Base.read!(::IO, ::FileFormats.LP.Model)` to use a proper recursive
+   descent parser. This fixed numerous performance issues, and the resulting
+   parser is simpler to maintain and extend. (#2840), (#2841), (#2842), (#2843),
+   (#2844), (#2846), (#2847), (#2848)
+ - Rewrote the error handling in `read!(::IO, ::FileFormats.MPS.Model)` to throw
+   a `FileFormats.MPS.ParseError` (#2845), (#2849)
+
+### Other
+
+- Temporarily pinned `OpenSSL_jll` to work around an upstream bug (#2850)
+
 ## v1.44.0 (September 4, 2025)
 
 ### Added


### PR DESCRIPTION
## TODO

We should probably wait for https://github.com/JuliaRegistries/General/pull/138737 to be merged and then revert #2850 before tagging a release.

## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [ ] The `solver-tests.yml` GitHub action does not have unexpected failures.
       To run the action, go to:
       https://github.com/jump-dev/MathOptInterface.jl/actions/workflows/solver-tests.yml
       and click "Run workflow"
 - [x] If new tests were added, ensure that `MOI.Test.version_added` is implemented.