### PR TITLE
[FileFormats.LP] add explicit tests for the ParseError messages

### DIFF
--- a/test/FileFormats/LP/models/invalid_bound_2.lp
+++ b/test/FileFormats/LP/models/invalid_bound_2.lp
@@ -1,7 +1,7 @@
-maximize 
+maximize
 obj: x1
-subject to 
+subject to
 c1: x <= 11
-bounds 
- x1 != 10 
-end 
+bounds
+ x1 != 10
+end

--- a/test/FileFormats/LP/models/invalid_constraint.lp
+++ b/test/FileFormats/LP/models/invalid_constraint.lp
@@ -1,13 +1,13 @@
-\ File: lo1.lp 
-maximize 
-obj: 3 x1 + x2 + 5 x3 + x4 
-subject to 
-c1:  3 x1 + x2 + 2 x3 = 30 
-c2:  2 x1 + x2 + c2: + 3 x3 + x4 >= 15 
-c3:  2 x2 + 3 x4 <= 25 
-bounds 
- 0 <= x1 <= +infinity 
- 0 <= x2 <= 10 
- 0 <= x3 <= +infinity 
- 0 <= x4 <= +infinity 
-end 
+\ File: lo1.lp
+maximize
+obj: 3 x1 + x2 + 5 x3 + x4
+subject to
+c1:  3 x1 + x2 + 2 x3 = 30
+c2:  2 x1 + x2 + c2: + 3 x3 + x4 >= 15
+c3:  2 x2 + 3 x4 <= 25
+bounds
+ 0 <= x1 <= +infinity
+ 0 <= x2 <= 10
+ 0 <= x3 <= +infinity
+ 0 <= x4 <= +infinity
+end

--- a/test/FileFormats/LP/models/invalid_variable_name.lp
+++ b/test/FileFormats/LP/models/invalid_variable_name.lp
@@ -1,13 +1,13 @@
-\ File: lo1.lp 
-maximize 
-obj: 3 1x1 + x2 + 5 x3 + x4 
-subject to 
-c1:  3 x1 + x2 + 2 x3 = 30 
-c2:  2 x1 + x2 + 3 x3 + x4 >= 15 
-c3:  2 x2 + 3 x4 <= 25 
-bounds 
- 0 <= x1 <= +infinity 
- 0 <= x2 <= 10 
- 0 <= x3 <= +infinity 
- 0 <= x4 <= +infinity 
-end 
+\ File: lo1.lp
+maximize
+obj: 3 1x1 + x2 + 5 x3 + x4
+subject to
+c1:  3 x1 + x2 + 2 x3 = 30
+c2:  2 x1 + x2 + 3 x3 + x4 >= 15
+c3:  2 x2 + 3 x4 <= 25
+bounds
+ 0 <= x1 <= +infinity
+ 0 <= x2 <= 10
+ 0 <= x3 <= +infinity
+ 0 <= x4 <= +infinity
+end


### PR DESCRIPTION
Cleaned up some of the error messages, and fixed a bug when we tried to print an error with unicode in the string.