### PR TITLE
Add VectorNonlinearOracle set

### DIFF
--- a/docs/src/manual/standard_form.md
+++ b/docs/src/manual/standard_form.md
@@ -82,6 +82,7 @@ The vector-valued set types implemented in MathOptInterface.jl are:
 | [`RelativeEntropyCone(d)`](@ref MathOptInterface.RelativeEntropyCone) | ``\{ (u, v, w) \in \mathbb{R}^{d} : u \ge \sum_i w_i \log (\frac{w_i}{v_i}), v_i \ge 0, w_i \ge 0 \}`` |
 | [`HyperRectangle(l, u)`](@ref MathOptInterface.HyperRectangle)        | ``\{x \in \bar{\mathbb{R}}^d: x_i \in [l_i, u_i] \forall i=1,\ldots,d\}`` |
 | [`NormCone(p, d)`](@ref MathOptInterface.NormCone)       | ``\{ (t,x) \in \mathbb{R}^{d} : t \ge \left(\sum\limits_i \lvert x_i \rvert^p\right)^{\frac{1}{p}} \}`` |
+| [`VectorNonlinearOracle`](@ref MathOptInterface.VectorNonlinearOracle)| ``\{x \in \mathbb{R}^{dimension}: l \le f(x) \le u \}`` |
 
 ## Matrix cones
 

--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -104,6 +104,7 @@ ACTIVATE_ON_ONE
 Complements
 HyperRectangle
 Scaled
+VectorNonlinearOracle
 ```
 
 ## Constraint programming sets

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -175,6 +175,27 @@ function _set(::Type{T}, ::Type{MOI.HyperRectangle}) where {T}
     return MOI.HyperRectangle(zeros(T, 3), ones(T, 3))
 end
 
+function _set(::Type{T}, ::Type{MOI.VectorNonlinearOracle}) where {T}
+    return MOI.VectorNonlinearOracle(;
+        dimension = 3,
+        l = [0.0, 0.0],
+        u = [1.0, 0.0],
+        eval_f = (ret, x) -> begin
+            ret[1] = x[2]^2
+            ret[2] = x[3]^2 + x[4]^3 - x[1]
+            return
+        end,
+        jacobian_structure = [(1, 2), (2, 1), (2, 3), (2, 4)],
+        eval_jacobian = (ret, x) -> begin
+            ret[1] = 2.0 * x[2]
+            ret[2] = -1.0
+            ret[3] = 2.0 * x[3]
+            ret[4] = 3.0 * x[4]^2
+            return
+        end,
+    )
+end
+
 function _test_function_modification(
     model::MOI.ModelLike,
     config::Config{T},

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -843,6 +843,7 @@ const EqualToIndicatorZero{T} =
         MOI.Table,
         MOI.BinPacking,
         MOI.HyperRectangle,
+        MOI.VectorNonlinearOracle,
     ),
     (MOI.ScalarNonlinearFunction,),
     (MOI.ScalarAffineFunction, MOI.ScalarQuadraticFunction),

--- a/test/General/sets.jl
+++ b/test/General/sets.jl
@@ -419,6 +419,21 @@ function test_update_dimension()
     return
 end
 
+function test_VectorNonlinearOracle()
+    @test_throws(
+        DimenionMismatch,
+        MOI.VectorNonlinearOracle(;
+            dimension = 3,
+            l = [0.0, 0.0, 1.0],
+            u = [1.0, 0.0],
+            eval_f = (ret, x) -> nothing,
+            jacobian_structure = Tuple{Int,Int}[],
+            eval_jacobian = (ret, x) -> nothing,
+        ),
+    )
+    return
+end
+
 end  # module
 
 TestSets.runtests()


### PR DESCRIPTION
 - [ ] Still need to test a few things, and check that it's okay once I update Ipopt

## Basic

 - [x] Add a new `AbstractScalarSet` or `AbstractVectorSet` to `src/sets.jl`
 - [x] If `isbitstype(S) == false`, implement `Base.copy(set::S)`
 - [x] <s>If `isbitstype(S) == false`, implement `Base.:(==)(x::S, y::S)`</s>
 - [x] If an `AbstractVectorSet`, implement `dimension(set::S)`, unless the
       dimension is given by `set.dimension`.

## Utilities

 - [ ] If an `AbstractVectorSet`, implement `Utilities.set_dot`,
       unless the dot product between two vectors in the set is equivalent to
       `LinearAlgebra.dot`
 - [ ] If an `AbstractVectorSet`, implement `Utilities.set_with_dimension` in
       `src/Utilities/matrix_of_constraints.jl`
 - [x] Add the set to the `@model` macro at the bottom of `src/Utilities.model.jl`

## Documentation

 - [x] Add a docstring, which gives the mathematical definition of the set,
       along with an `## Example` block containing a `jldoctest`
 - [x] Add the docstring to `docs/src/reference/standard_form.md`
 - [x] Add the set to the relevant table in `docs/src/manual/standard_form.md`

## Tests

 - [x] Define a new `_set(::Type{S})` method in `src/Test/test_basic_constraint.jl`
       and add the name of the set to the list at the bottom of that files
 - [x] If the set has any checks in its constructor, add tests to `test/sets.jl`

## MathOptFormat

 - [x] <s>Open an issue at `https://github.com/jump-dev/MathOptFormat` to add
       support for the new set {{ replace with link to the issue }}</s>

## Optional

 - [x] <s>Implement `dual_set(::S)` and `dual_set_type(::Type{S})`</s>
 - [x] Add new tests to the `Test` submodule exercising your new set
 - [x] <s>Add new bridges to convert your set into more commonly used sets</s>