### PR TITLE
Fix dimension of VectorNonlinearOracle in test and docstring

### DIFF
--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -177,7 +177,7 @@ end
 
 function _set(::Type{T}, ::Type{MOI.VectorNonlinearOracle}) where {T}
     set = MOI.VectorNonlinearOracle(;
-        dimension = 3,
+        dimension = 4,
         l = T[0, 0],
         u = T[1, 0],
         eval_f = (ret, x) -> begin
@@ -194,7 +194,8 @@ function _set(::Type{T}, ::Type{MOI.VectorNonlinearOracle}) where {T}
             return
         end,
     )
-    x, ret_f, ret_J = T[1, 2, 3, 4, 5], T[0, 0], T[0, 0, 0, 0]
+    @assert MOI.dimension(set) == 4
+    x, ret_f, ret_J = T[1, 2, 3, 4], T[0, 0], T[0, 0, 0, 0]
     set.eval_f(ret_f, x)
     set.eval_jacobian(ret_J, x)
     return set

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -2739,7 +2739,7 @@ do
 julia> import MathOptInterface as MOI
 
 julia> set = MOI.VectorNonlinearOracle(;
-           dimension = 3,
+           dimension = 4,
            l = [0.0, 0.0],
            u = [1.0, 0.0],
            eval_f = (ret, x) -> begin
@@ -2766,7 +2766,7 @@ julia> set = MOI.VectorNonlinearOracle(;
 
 julia> set
 VectorNonlinearOracle{Float64}(;
-    dimension = 3,
+    dimension = 4,
     l = [0.0, 0.0],
     u = [1.0, 0.0],
     ...,


### PR DESCRIPTION
As found by https://github.com/jump-dev/KNITRO.jl/pull/351, it's very clearly not 3...