### PR TITLE
[Utilities] allow penalty relaxation for ScalarNonlinear constraints

### DIFF
--- a/test/Utilities/penalty_relaxation.jl
+++ b/test/Utilities/penalty_relaxation.jl
@@ -110,7 +110,7 @@ function test_relax_scalar_nonlinear_objective()
         """,
         """
         variables: x, y, a
-        minobjective: ScalarNonlinearFunction(+(exp(x), *(1.0, a)))
+        minobjective: ScalarNonlinearFunction(+(exp(x), esc(1.0 * a)))
         c1: x + y + -1.0 * a <= 1.0
         a >= 0.0
         """,


### PR DESCRIPTION
I'd like to use `JuMP.relax_with_penalty!` on a model with nonlinear constraints. If this implementation looks reasonable, I can clean this up and add tests. Here's an example:
```julia
using JuMP
model = Model()
@variable(model, x[1:3] >= 0)
@objective(model, Min, sum(x .^ 2))
@constraint(model, eq1, x[1] * x[2]^1.5 == x[3])
@constraint(model, ineq1, x[1] + x[2] + x[3] >= 4)
@constraint(model, ineq2, x[1]*x[2]*x[3] >= 1)
@constraint(model, ineq3, x[1] * exp(x[2]) <= 20)
@constraint(model, ineq4, 0 <= log(x[2] * x[3]) <= 10)
relax_with_penalty!(model)
println(model)
```
```console
┌ Warning: Skipping PenaltyRelaxation for ConstraintIndex{MathOptInterface.VariableIndex,MathOptInterface.GreaterThan{Float64}}
└ @ MathOptInterface.Utilities ~/.julia/dev/MathOptInterface/src/Utilities/penalty_relaxation.jl:367
Min x[1]² + x[2]² + x[3]² + _[4] + _[5] + _[6] + _[7] + _[8] + _[9] + _[10]
Subject to
 eq1 : ((x[1] * (x[2] ^ 1.5)) - x[3]) + (_[4] - _[5]) = 0
 ineq2 : (((x[1]*x[2]) * x[3]) - 1.0) + _[6] ≥ 0
 ineq3 : ((x[1] * exp(x[2])) - 20.0) - _[7] ≤ 0
 ineq4 : log(x[2]*x[3]) + (_[8] - _[9]) ∈ [0, 10]
 ineq1 : x[1] + x[2] + x[3] + _[10] ≥ 4
 x[1] ≥ 0
 x[2] ≥ 0
 x[3] ≥ 0
 _[4] ≥ 0
 _[5] ≥ 0
 _[6] ≥ 0
 _[7] ≥ 0
 _[8] ≥ 0
 _[9] ≥ 0
 _[10] ≥ 0
```

### Limitations
- Doesn't support `ScalarNonlinearFunction` objectives. We get a confusing warning in this case.
- Doesn't support `VariableIndex` objectives. We probably get the same confusing warning here.

I think both of these can be supported without too much effort.