### PR TITLE
[docs] Fix LaTeX alignement in example of `VectorNonlinearOracle` docstring

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -2744,7 +2744,7 @@ To model the set:
 \\begin{aligned}
 0 &\\le x^2                    & \\le 1 \\\\
 0 &\\le y^2 + x \\cdot z^3 - w & \\le 0
-\end{aligned}
+\\end{aligned}
 ```
 do
 ```jldoctest


### PR DESCRIPTION
It was not displayed correctly in the generated HTML doc.