### PR TITLE
Implement extract_function for transpose matrix

### DIFF
--- a/perf/matrix_of_constraints.jl
+++ b/perf/matrix_of_constraints.jl
@@ -1,13 +1,16 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
 import SparseArrays
 using BenchmarkTools
 
 import MathOptInterface as MOI
 
 # Inspired from MatrixOfConstraints
-MOI.Utilities.@product_of_sets(
-    _EqualTos,
-    MOI.EqualTo{T},
-)
+MOI.Utilities.@product_of_sets(_EqualTos, MOI.EqualTo{T},)
 
 a = 1
 
@@ -54,7 +57,9 @@ end
 function bench(m, args...; kws...)
     T = Float64
     model = lp_standard_form(m, args...; kws...)
-    ci = MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}(rand(1:m))
+    ci = MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}(
+        rand(1:m),
+    )
     return @benchmark MOI.get($model, MOI.ConstraintFunction(), $ci)
 end
 
@@ -65,7 +70,9 @@ function prof(m, args...)
     T = Float64
     model = lp_standard_form(m, args...)
     return @profview for i in 1:m
-        ci = MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}(rand(1:m))
+        ci = MOI.ConstraintIndex{MOI.ScalarAffineFunction{T},MOI.EqualTo{T}}(
+            rand(1:m),
+        )
         MOI.get(model, MOI.ConstraintFunction(), ci)
     end
 end

--- a/src/Utilities/sparse_matrix.jl
+++ b/src/Utilities/sparse_matrix.jl
@@ -221,25 +221,25 @@ function extract_function(
 end
 
 function extract_function(A::LinearAlgebra.Transpose, row::Integer, constant)
-    return extract_column_as_function(parent(A), row, constant, identity)
+    return _extract_column_as_function(parent(A), row, constant, identity)
 end
 
 function extract_function(A::LinearAlgebra.Adjoint, row::Integer, constant)
-    return extract_column_as_function(parent(A), row, constant, conj)
+    return _extract_column_as_function(parent(A), row, constant, conj)
 end
 
-function extract_column_as_function(
+function _extract_column_as_function(
     A::Union{MutableSparseMatrixCSC{T},SparseArrays.SparseMatrixCSC{T}},
     col::Integer,
     constant::T,
-    value_map::F
+    value_map::F,
 ) where {T,F<:Function}
     func = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm{T}[], constant)
-    for idx in SparseArrays.nzrange(A, col)
-        row = _shift(A.rowval[idx], _indexing(A), OneBasedIndexing())
+    for i in SparseArrays.nzrange(A, col)
+        row = _shift(A.rowval[i], _indexing(A), OneBasedIndexing())
         push!(
             func.terms,
-            MOI.ScalarAffineTerm(value_map(A.nzval[idx]), MOI.VariableIndex(row)),
+            MOI.ScalarAffineTerm(value_map(A.nzval[i]), MOI.VariableIndex(row)),
         )
     end
     return func

--- a/test/Utilities/matrix_of_constraints.jl
+++ b/test/Utilities/matrix_of_constraints.jl
@@ -751,7 +751,11 @@ function test_lp_standard_form()
     con_names = ["c1", "c2"]
     A = SparseArrays.sparse([1.0 - 3im 0.0; 3.0 + 2im 4.0])
     b = [5.0 - im, 6.0 + im]
-    for _A in [A, LinearAlgebra.transpose(copy(LinearAlgebra.transpose(A))), (copy(A'))']
+    for _A in [
+        A,
+        LinearAlgebra.transpose(copy(LinearAlgebra.transpose(A))),
+        (copy(A'))',
+    ]
         form = MOI.Utilities.GenericModel{Float64}(
             expected.model.objective,
             expected.model.variables,


### PR DESCRIPTION
```
BenchmarkTools.Trial: 5550 samples with 1 evaluation per sample.
 Range (min … max):  844.629 μs …   6.681 ms  ┊ GC (min … max): 0.00% … 84.35%
 Time  (median):     872.664 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   899.857 μs ± 170.774 μs  ┊ GC (mean ± σ):  1.34% ±  5.28%

      ▁▅█▇▆▄▃                                                    
  ▂▂▄▆█████████▇▅▄▄▃▃▃▃▂▂▂▂▂▂▁▁▂▂▂▂▂▃▃▃▃▄▄▄▄▃▃▃▃▃▂▂▂▃▂▂▂▂▂▁▂▂▂▂ ▃
  845 μs           Histogram: frequency by time         1.03 ms <

 Memory estimate: 393.92 KiB, allocs estimate: 17.
```
With transpose:
```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  22.285 μs …   5.641 ms  ┊ GC (min … max):  0.00% … 99.26%
 Time  (median):     26.119 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   44.105 μs ± 122.671 μs  ┊ GC (mean ± σ):  13.06% ±  5.26%

  ▄█▆▄▂▁▁▂▃▃▃▂                                        ▁▂▃▂▂▁   ▂
  █████████████▇▆▅▄▄▅▅▅▃▄▁▃▁▁▃▁▃▃▁▁▁▁▁▃▃▁▃▁▁▄▁▁▃▁▁▁▁▄▆███████▇ █
  22.3 μs       Histogram: log(frequency) by time       142 μs <

 Memory estimate: 393.92 KiB, allocs estimate: 17.
```