### PR TITLE
[Utilities] fix bug converting MutableSparseMatrixCSC to SparseMatrixCSC

### DIFF
--- a/src/Utilities/sparse_matrix.jl
+++ b/src/Utilities/sparse_matrix.jl
@@ -35,9 +35,11 @@ _first_index(::Type{T}, ::ZeroBasedIndexing) where {T} = T(0)
 _first_index(::Type{T}, ::OneBasedIndexing) where {T} = T(1)
 
 _shift(x, ::T, ::T) where {T<:AbstractIndexing} = x
-_shift(x::Integer, ::ZeroBasedIndexing, ::OneBasedIndexing) = x + 1
-_shift(x::Integer, ::OneBasedIndexing, ::ZeroBasedIndexing) = x - 1
-_shift(x::Array{<:Integer}, ::ZeroBasedIndexing, ::OneBasedIndexing) = x .+ 1
+_shift(x::Integer, ::ZeroBasedIndexing, ::OneBasedIndexing) = x + one(typeof(x))
+_shift(x::Integer, ::OneBasedIndexing, ::ZeroBasedIndexing) = x - one(typeof(x))
+function _shift(x::Array{<:Integer}, ::ZeroBasedIndexing, ::OneBasedIndexing)
+    return x .+ one(eltype(x))
+end
 
 """
     mutable struct MutableSparseMatrixCSC{Tv,Ti<:Integer,I<:AbstractIndexing}

--- a/test/Utilities/sparse_matrix.jl
+++ b/test/Utilities/sparse_matrix.jl
@@ -235,6 +235,15 @@ function test_ScalarAffine_OneBased()
     return
 end
 
+function test_MutableSparseMatrixCSC_convert_to_Cint()
+    I = MOI.Utilities.ZeroBasedIndexing
+    A = MOI.Utilities.MutableSparseMatrixCSC{Float32,Int32,I}()
+    B = convert(SparseArrays.SparseMatrixCSC{Float32,Int32}, A)
+    @test B isa SparseArrays.SparseMatrixCSC{Float32,Int32}
+    @test isempty(B)
+    return
+end
+
 end
 
 TestSparseMatrix.runtests()


### PR DESCRIPTION
Found when I was trying to put together a small script for the cvxpy folks and found this method error.