### PR TITLE
[Bridges] Fix computing Q=U'U in QuadtoSOCBridge when Q has 0 eigenvalue

### DIFF
--- a/src/Bridges/Constraint/bridges/QuadtoSOCBridge.jl
+++ b/src/Bridges/Constraint/bridges/QuadtoSOCBridge.jl
@@ -140,9 +140,10 @@ function _compute_sparse_U(Q::LinearAlgebra.Symmetric)
         # order.
         return I, p[J], V
     end
-    # Cholesky failed. Use instead an eigen value decomposition.
+    # Cholesky failed. Use instead an eigen value decomposition. This is not
+    # triangular, but nothing says that it has to be.
     E = LinearAlgebra.eigen(LinearAlgebra.Symmetric(Matrix(Q)))
-    if minimum(E.values) < 0
+    if !all(isreal, E.values) || minimum(E.values) < 0
         error("Matrix is not PSD")
     end
     D = LinearAlgebra.Diagonal(sqrt.(E.values)) * E.vectors

--- a/test/Bridges/Constraint/QuadtoSOCBridge.jl
+++ b/test/Bridges/Constraint/QuadtoSOCBridge.jl
@@ -375,6 +375,12 @@ function test_compute_sparse_U_edge_cases()
         end
         @test isapprox(A, U' * U; atol = 1e-10)
     end
+    A = [-1.0 0.0; 0.0 1.0]
+    B = SparseArrays.sparse(A)
+    @test_throws(
+        ErrorException("Matrix is not PSD"),
+        MOI.Bridges.Constraint._compute_sparse_U(B),
+    )
     return
 end
 


### PR DESCRIPTION
Closes #1971 

There aren't many good options here.

My trivial test case is `(x + y)^2 / 2`.

The permissive options all fail:
```julia
julia> using LDLFactorizations, LinearAlgebra, QDLDL, SparseArrays

julia> A = [1.0 1.0; 1.0 1.0]
2×2 Matrix{Float64}:
 1.0  1.0
 1.0  1.0

julia> Q = SparseArrays.sparse(A);
julia> LinearAlgebra.cholesky(Q)
ERROR: PosDefException: matrix is not positive definite; Factorization failed.
Stacktrace:

julia> LinearAlgebra.ldlt(Q)
ERROR: ZeroPivotException: factorization encountered one or more zero pivots. Consider switching to a pivoted LU factorization.
Stacktrace:

julia> QDLDL.qdldl(Q)
ERROR: Zero entry in D (matrix is not quasidefinite)
Stacktrace:
```

LDLFactorizations.jl works:
```Julia
julia> LDLFactorizations.ldl(Q)
LDLFactorizations.LDLFactorization{Float64, Int64, Int64, Int64}(true, false, false, 2, [2, -1], [1, 0], [2, 2], [1, 2], [1, 2], [1, 2, 2], Int64[], Int64[], [2], [1.0], [1.0, 0.0], [0.0, 0.0], [1, 1], 0.0, 0.0, 0.0, 2)
```
but it requires us to add a GPL dependency.

This PR implements an option I don't think we've previously considered: do something that isn't upper triangular...

Am I missing something obviously wrong?