### PR TITLE
Remove Julia 1-ubuntu-latest-x64 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,6 @@ jobs:
             arch: x64
             downgrade: false
           - version: '1'
-            os: ubuntu-latest
-            arch: x64
-            downgrade: false
-          - version: '1'
             os: windows-latest
             arch: x64
             downgrade: false


### PR DESCRIPTION
Related to #2932, we just have a lot of CI jobs running that overlap. I'm not sure we need this one, when we test on Ubuntu and Julia 1.10, as well as Ubuntu on Julia 1 and x86. For this job to matter, there'd need to be a failure that happened on x64 but not x86 and Julia 1 but not Julia 1.10 and on Ubuntu but not on Windows. Seems pretty unlikely to me.