### PR TITLE
[FileFormats] throw a nicer error on unsupported keyword arguments

### DIFF
--- a/src/FileFormats/CBF/CBF.jl
+++ b/src/FileFormats/CBF/CBF.jl
@@ -63,7 +63,15 @@ end
 
 Create an empty instance of `FileFormats.CBF.Model`.
 """
-Model(; kwargs...) = Model{Float64}()
+function Model(; kwargs...)
+    if !isempty(kwargs)
+        error(
+            "The CBF file format does not support the keyword arguments: ",
+            kwargs...,
+        )
+    end
+    return Model{Float64}()
+end
 
 Base.summary(io::IO, ::Model) = print(io, "MOI.FileFormats.CBF.Model")
 

--- a/src/FileFormats/LP/LP.jl
+++ b/src/FileFormats/LP/LP.jl
@@ -100,7 +100,14 @@ function Model(;
     maximum_length::Int = 255,
     warn::Bool = false,
     coefficient_type::Type{T} = Float64,
+    kwargs...,
 ) where {T}
+    if !isempty(kwargs)
+        error(
+            "The LP file format does not support the keyword arguments: ",
+            kwargs...,
+        )
+    end
     model = Model{T}()
     options = Options(maximum_length, warn)
     model.ext[:LP_OPTIONS] = options

--- a/src/FileFormats/MOF/MOF.jl
+++ b/src/FileFormats/MOF/MOF.jl
@@ -159,7 +159,14 @@ function Model(;
     differentiation_backend::MOI.Nonlinear.AbstractAutomaticDifferentiation = MOI.Nonlinear.SparseReverseMode(),
     use_nlp_block::Union{Bool,Nothing} = nothing,
     coefficient_type::Type{T} = Float64,
+    kwargs...,
 ) where {T}
+    if !isempty(kwargs)
+        error(
+            "The MOF file format does not support the keyword arguments: ",
+            kwargs...,
+        )
+    end
     model = MOI.Utilities.UniversalFallback(InnerModel{T}())
     model.model.ext[:MOF_OPTIONS] =
         Options(print_compact, warn, differentiation_backend, use_nlp_block)

--- a/src/FileFormats/MPS/MPS.jl
+++ b/src/FileFormats/MPS/MPS.jl
@@ -154,7 +154,14 @@ function Model(;
     generic_names::Bool = false,
     quadratic_format::QuadraticFormat = kQuadraticFormatGurobi,
     coefficient_type::Type{T} = Float64,
+    kwargs...,
 ) where {T}
+    if !isempty(kwargs)
+        error(
+            "The MPS file format does not support the keyword arguments: ",
+            kwargs...,
+        )
+    end
     model = Model{T}()
     model.ext[:MPS_OPTIONS] =
         Options(warn, print_objsense, generic_names, quadratic_format)

--- a/src/FileFormats/NL/NL.jl
+++ b/src/FileFormats/NL/NL.jl
@@ -148,7 +148,13 @@ mutable struct Model <: MOI.ModelLike
     use_nlp_block::Bool
     complementarity_constraints::Vector{Vector{Int}}
 
-    function Model(; use_nlp_block::Bool = true)
+    function Model(; use_nlp_block::Bool = true, kwargs...)
+        if !isempty(kwargs)
+            error(
+                "The NL file format does not support the keyword arguments: ",
+                kwargs...,
+            )
+        end
         return new(
             "",
             _NLExpr(false, _NLTerm[], Dict{MOI.VariableIndex,Float64}(), 0.0),

--- a/src/FileFormats/SDPA/SDPA.jl
+++ b/src/FileFormats/SDPA/SDPA.jl
@@ -123,7 +123,14 @@ by creating a slack variable by the
 function Model(;
     number_type::Type{T} = Float64,
     coefficient_type::Type{S} = number_type,
+    kwargs...,
 ) where {T,S}
+    if !isempty(kwargs)
+        error(
+            "The SDPA file format does not support the keyword arguments: ",
+            kwargs...,
+        )
+    end
     model = Model{S}()
     model.ext[:SDPA_OPTIONS] = Options()
     return model

--- a/test/FileFormats/CBF/test_CBF.jl
+++ b/test/FileFormats/CBF/test_CBF.jl
@@ -726,6 +726,16 @@ function test_unsupported_variable_types()
     return
 end
 
+function test_unsupported_kwarg()
+    @test_throws(
+        ErrorException(
+            "The CBF file format does not support the keyword arguments: :foo => 1",
+        ),
+        CBF.Model(; foo = 1),
+    )
+    return
+end
+
 end  # module
 
 TestCBF.runtests()

--- a/test/FileFormats/LP/test_LP.jl
+++ b/test/FileFormats/LP/test_LP.jl
@@ -1812,6 +1812,16 @@ function test_get_line_about_pos()
     return
 end
 
+function test_unsupported_kwarg()
+    @test_throws(
+        ErrorException(
+            "The LP file format does not support the keyword arguments: :foo => 1",
+        ),
+        LP.Model(; foo = 1),
+    )
+    return
+end
+
 end  # module
 
 TestLP.runtests()

--- a/test/FileFormats/MOF/test_MOF.jl
+++ b/test/FileFormats/MOF/test_MOF.jl
@@ -1630,6 +1630,16 @@ function test_unsupported_objectives()
     return
 end
 
+function test_unsupported_kwarg()
+    @test_throws(
+        ErrorException(
+            "The MOF file format does not support the keyword arguments: :foo => 1",
+        ),
+        MOF.Model(; foo = 1),
+    )
+    return
+end
+
 end
 
 TestMOF.runtests()

--- a/test/FileFormats/MPS/test_MPS.jl
+++ b/test/FileFormats/MPS/test_MPS.jl
@@ -1830,6 +1830,16 @@ function test_issue_2941()
     return
 end
 
+function test_unsupported_kwarg()
+    @test_throws(
+        ErrorException(
+            "The MPS file format does not support the keyword arguments: :foo => 1",
+        ),
+        MPS.Model(; foo = 1),
+    )
+    return
+end
+
 end  # TestMPS
 
 TestMPS.runtests()

--- a/test/FileFormats/NL/test_NL.jl
+++ b/test/FileFormats/NL/test_NL.jl
@@ -1532,6 +1532,16 @@ function test_write_complements_VectorNonlinearFunction()
     return
 end
 
+function test_unsupported_kwarg()
+    @test_throws(
+        ErrorException(
+            "The NL file format does not support the keyword arguments: :foo => 1",
+        ),
+        NL.Model(; foo = 1),
+    )
+    return
+end
+
 end
 
 TestNLModel.runtests()

--- a/test/FileFormats/SDPA/test_SDPA.jl
+++ b/test/FileFormats/SDPA/test_SDPA.jl
@@ -419,6 +419,16 @@ function test_unsupported_objectives()
     return
 end
 
+function test_unsupported_kwarg()
+    @test_throws(
+        ErrorException(
+            "The SDPA file format does not support the keyword arguments: :foo => 1",
+        ),
+        SDPA.Model(; foo = 1),
+    )
+    return
+end
+
 end  # module
 
 TestSDPA.runtests()


### PR DESCRIPTION
The MethodError in https://github.com/jump-dev/MathOptAnalyzer.jl/issues/64#issuecomment-3926493266 was clearly not helpful to the user.