### PR TITLE
Install Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I noticed you're using an old version of `julia-actions/cache` (which I don't think caches very well), but I also noticed you don't have Dependabot installed at all, so I figured I'd let it do all the upgrades