### PR TITLE
Fix Cholesky decompoosition error when given different element type

### DIFF
--- a/src/Bridges/Constraint/bridges/QuadtoSOCBridge.jl
+++ b/src/Bridges/Constraint/bridges/QuadtoSOCBridge.jl
@@ -80,7 +80,12 @@ function compute_sparse_sqrt_fallback(Q, ::F, ::S) where {F,S}
 end
 
 function compute_sparse_sqrt(Q, func, set)
-    factor = LinearAlgebra.cholesky(Q; check = false)
+    factor = try
+        LinearAlgebra.cholesky(Q; check = false)
+    catch
+        msg = "There was an error computing a Cholesky decomposition"
+        throw(MOI.UnsupportedConstraint{typeof(func),typeof(set)}(msg))
+    end
     if !LinearAlgebra.issuccess(factor)
         return compute_sparse_sqrt_fallback(Q, func, set)
     end

--- a/test/Bridges/Constraint/test_QuadtoSOCBridge.jl
+++ b/test/Bridges/Constraint/test_QuadtoSOCBridge.jl
@@ -356,9 +356,7 @@ function test_semidefinite_cholesky_fail()
 end
 
 function test_compute_sparse_sqrt_edge_cases()
-    f = zero(MOI.ScalarQuadraticFunction{Float64})
-    s = MOI.GreaterThan(0.0)
-    for A in [
+    for A in Any[
         # Trivial Cholesky
         [1.0 0.0; 0.0 2.0],
         # Cholesky works, with pivoting
@@ -371,20 +369,29 @@ function test_compute_sparse_sqrt_edge_cases()
         [2.0 0.0; 0.0 0.0],
     ]
         B = SparseArrays.sparse(A)
+        f = zero(MOI.ScalarQuadraticFunction{eltype(A)})
+        s = MOI.GreaterThan(zero(eltype(A)))
         I, J, V = MOI.Bridges.Constraint.compute_sparse_sqrt(B, f, s)
-        U = zeros(size(A))
+        U = zeros(eltype(A), size(A))
         for (i, j, v) in zip(I, J, V)
             U[i, j] += v
         end
         @test isapprox(A, U' * U; atol = 1e-10)
     end
     # Test failures
-    for A in [
+    for A in Any[
         [-1.0 0.0; 0.0 1.0],
         # Found from test_quadratic_nonconvex_constraint_basic
         [0.0 -1.0; -1.0 0.0],
+        # Different element type. We could potentially make this work in future,
+        # but it first requires https://github.com/JuliaSmoothOptimizers/LDLFactorizations.jl/pull/142
+        BigFloat[-1.0 0.0; 0.0 1.0],
+        BigFloat[1.0 0.0; 0.0 2.0],
+        BigFloat[1.0 1.0; 1.0 1.0],
     ]
         B = SparseArrays.sparse(A)
+        f = zero(MOI.ScalarQuadraticFunction{eltype(A)})
+        s = MOI.GreaterThan(zero(eltype(A)))
         @test_throws(
             MOI.UnsupportedConstraint{typeof(f),typeof(s)},
             MOI.Bridges.Constraint.compute_sparse_sqrt(B, f, s),


### PR DESCRIPTION
Found by testing Hypatia for #2955 (I'd overlooked the error because of the other ones)

The issue is that Julia's cholesky is missing `BigFloat` support. We could potentially use LDLFactorization, but that needs the `factorized` fix.