### PR TITLE
[FileFormats.LP] fix reading variable with negative upper bound

### DIFF
--- a/src/FileFormats/LP/read.jl
+++ b/src/FileFormats/LP/read.jl
@@ -981,9 +981,6 @@ function _add_bound(
 end
 
 function _add_bound(cache::_ReadCache, x::MOI.VariableIndex, set::MOI.LessThan)
-    if set.upper < 0
-        delete!(cache.variable_with_default_bound, x)
-    end
     if isfinite(set.upper)
         MOI.add_constraint(cache.model, x, set)
     end

--- a/test/FileFormats/LP/test_LP.jl
+++ b/test/FileFormats/LP/test_LP.jl
@@ -626,7 +626,7 @@ function test_read_model2()
     ci = MOI.ConstraintIndex{MOI.VariableIndex,MOI.Interval{Float64}}(2)
     @test !MOI.is_valid(model, ci)
     @test MOI.get(model, MOI.VariableName(), MOI.VariableIndex(8)) == "V8"
-    @test model.variables.lower[8] == -Inf
+    @test model.variables.lower[8] == 0.0
     @test model.variables.upper[8] == -3
     obj_type = MOI.get(model, MOI.ObjectiveFunctionType())
     obj_func = MOI.get(model, MOI.ObjectiveFunction{obj_type}())
@@ -895,17 +895,17 @@ function test_reading_bounds()
     # Test upper bound
     _test_round_trip("x <= 1", "Bounds\n0 <= x <= 1\nEnd")
     _test_round_trip("x <= 0", "Bounds\nx = 0\nEnd")
-    _test_round_trip("x <= -1", "Bounds\n-infinity <= x <= -1\nEnd")
+    _test_round_trip("x <= -1", "Bounds\n0 <= x <= -1\nEnd")
     _test_round_trip("x < 1", "Bounds\n0 <= x <= 1\nEnd")
     _test_round_trip("x < 0", "Bounds\nx = 0\nEnd")
-    _test_round_trip("x < -1", "Bounds\n-infinity <= x <= -1\nEnd")
+    _test_round_trip("x < -1", "Bounds\n0 <= x <= -1\nEnd")
     # Test reversed upper bound
     _test_round_trip("1 >= x", "Bounds\n0 <= x <= 1\nEnd")
     _test_round_trip("0 >= x", "Bounds\nx = 0\nEnd")
-    _test_round_trip("-1 >= x", "Bounds\n-infinity <= x <= -1\nEnd")
+    _test_round_trip("-1 >= x", "Bounds\n0 <= x <= -1\nEnd")
     _test_round_trip("1 > x", "Bounds\n0 <= x <= 1\nEnd")
     _test_round_trip("0 > x", "Bounds\nx = 0\nEnd")
-    _test_round_trip("-1 > x", "Bounds\n-infinity <= x <= -1\nEnd")
+    _test_round_trip("-1 > x", "Bounds\n0 <= x <= -1\nEnd")
     # Test equality
     _test_round_trip("x == 1", "Bounds\nx = 1\nEnd")
     _test_round_trip("x == 0", "Bounds\nx = 0\nEnd")


### PR DESCRIPTION
x-ref https://github.com/NVIDIA/cuopt/pull/1120/changes#r3127185613

I think this is a dumb rule, but indeed:
```
(base) odow@Mac /tmp % cat bug.lp 
maximize x
subject to
bounds
x <= -1.0
end
(base) odow@Mac /tmp % gurobi_cl bug.lp 
Set parameter WLSAccessID
Set parameter WLSSecret
Set parameter LicenseID to value 722777
Set parameter LogFile to value "gurobi.log"
Using license file /Users/odow/gurobi.lic
WLS license 722777 - registered to JuMP Development

Gurobi Optimizer version 12.0.3 build v12.0.3rc0 (mac64[arm] - Darwin 24.6.0 24G419)
Copyright (c) 2025, Gurobi Optimization, LLC

Read LP format model from file bug.lp
Reading time = 0.00 seconds
: 0 rows, 1 columns, 0 nonzeros

Using Gurobi shared library /Library/gurobi1203/macos_universal2/lib/libgurobi120.dylib

CPU model: Apple M4
Thread count: 10 physical cores, 10 logical processors, using up to 10 threads

WLS license 722777 - registered to JuMP Development
Optimize a model with 0 rows, 1 columns and 0 nonzeros
Model fingerprint: 0xd939e866
Coefficient statistics:
  Matrix range     [0e+00, 0e+00]
  Objective range  [1e+00, 1e+00]
  Bounds range     [1e+00, 1e+00]
  RHS range        [0e+00, 0e+00]
Presolve time: 0.00s

Solved in 0 iterations and 0.00 seconds (0.00 work units)
Infeasible model
```

Traced to https://github.com/jump-dev/MathOptInterface.jl/pull/1810. I guess I just assumed what the correct behaviour was instead of looking into it in more detail.