### PR TITLE
Prep for v1.51.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MathOptInterface"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.50.1"
+version = "1.51.0"
 
 [deps]
 CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,42 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.51.0 (April 24, 2026)
+
+### Breaking
+
+- Move BenchmarkTools.jl to a package extension (#2982)
+
+  This is a breaking change because it requires the user to install and load
+  BenchmarkTools.jl.
+
+  We justify releasing it in a minor release of MathOptInterface because we
+  assess that there are very few users of it, and because it should be used
+  only during package development by advanced users.
+
+  We reserve the right to revert this commit in a future release of MOI if it
+  causes problems in the ecosystem, so please let us know if you were using
+  `MOI.Benchmarks` in some critical run-time system.
+
+### Added
+
+- Added an extension for CliqueTrees.jl (#2967)
+- Added support for `-` in `convert` (#2987)
+
+### Fixed
+
+- Fixed a bug to now throw `GetAttributeNotAllowed` in `AbstractBridge` getters
+  (#2988)
+- Fixed reading variable with a negative upper bound in LP files(#2994)
+
+### Other
+
+- Bumped `codecov/codecov-action` from 5 to 6 (#2984)
+- Added MosekTools setup to solver-tests workflow (#2990)
+- Replaced CompatHelper with dependabot (#2991)
+- Documented why `[]` are not allowed in identifiers in LP format (#2993)
+- Updated PrecompileTools compatibility version (#2995)
+
 ## v1.50.1 (March 27, 2026)
 
 ### Fixed

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Bumped `codecov/codecov-action` from 5 to 6 (#2984)
-- Added MosekTools setup to solver-tests workflow (#2990)
+- Added MosekTools setup to solver-tests workflow (#2990), (#2998)
 - Replaced CompatHelper with `dependabot.yml` (#2991)
 - Documented why `[]` are not allowed in identifiers in LP format (#2993)
 - Updated PrecompileTools compatibility version (#2995)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced CompatHelper with `dependabot.yml` (#2991)
 - Documented why `[]` are not allowed in identifiers in LP format (#2993)
 - Updated PrecompileTools compatibility version (#2995)
+- Fix a common typo: `avaiable -> available` (#2997)
 
 ## v1.50.1 (March 27, 2026)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Bumped `codecov/codecov-action` from 5 to 6 (#2984)
-- Added MosekTools setup to solver-tests workflow (#2990), (#2998)
+- Added MosekTools setup to solver-tests workflow (#2990), (#2998), (#3000)
 - Replaced CompatHelper with `dependabot.yml` (#2991)
 - Documented why `[]` are not allowed in identifiers in LP format (#2993)
 - Updated PrecompileTools compatibility version (#2995)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug to now throw `GetAttributeNotAllowed` in `AbstractBridge` getters
   (#2988)
-- Fixed reading variable with a negative upper bound in LP files(#2994)
+- Fixed reading variable with a negative upper bound in LP files (#2994)
 
 ### Other
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped `codecov/codecov-action` from 5 to 6 (#2984)
 - Added MosekTools setup to solver-tests workflow (#2990)
-- Replaced CompatHelper with dependabot (#2991)
+- Replaced CompatHelper with `dependabot.yml` (#2991)
 - Documented why `[]` are not allowed in identifiers in LP format (#2993)
 - Updated PrecompileTools compatibility version (#2995)
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,7 +7,7 @@ CurrentModule = MathOptInterface
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.51.0 (April 24, 2026)
+## v1.51.0 (April 27, 2026)
 
 ### Breaking
 


### PR DESCRIPTION
## Basic

 - [x] `version` field of `Project.toml` has been updated
       - If a breaking change, increment the MAJOR field and reset others to 0
       - If adding new features, increment the MINOR field and reset PATCH to 0
       - If adding bug fixes or documentation changes, increment the PATCH field

## Documentation

 - [x] Add a new entry to `docs/src/changelog.md`, following existing style

## Tests

 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/24864241664
 - [x] https://github.com/jump-dev/MathOptInterface.jl/actions/runs/24974886579
   - [x] Uno failure is because their `main` can depend on unreleased `Uno_jll` 
   - [x] EAGO is a known issue 
   - [x] Optim looks unrelated
   - [x] FrankWolfe looks unrelated
 - [x] If new tests were added, ensure that `MOI.Test.version_added` is implemented.