### PR TITLE
Temporarily disable MosekTools package in solver tests

### DIFF
--- a/.github/workflows/solver-tests.yml
+++ b/.github/workflows/solver-tests.yml
@@ -35,7 +35,7 @@ jobs:
           - package: 'Ipopt'
           - package: 'KNITRO'
           - package: 'MiniZinc'
-          - package: 'MosekTools'
+          # - package: 'MosekTools' I need to fix this
           - package: 'MathOptAnalyzer'
           - package: 'MathOptIIS'
           - package: 'MultiObjectiveAlgorithms'


### PR DESCRIPTION
I need to fix this after changing the license. Don't know the issue at the moment.