### PR TITLE
Fix MosekTools.jl setup in solver-tests.yml

### DIFF
--- a/.github/workflows/solver-tests.yml
+++ b/.github/workflows/solver-tests.yml
@@ -172,11 +172,10 @@ jobs:
         if: ${{ matrix.package == 'MosekTools' }}
         shell: bash
         run: |
-          {
-            echo "MOSEKLM_LICENSE_FILE<<EOF"
-            echo "${{ secrets.MOSEK_LICENSE }}"
-            echo "EOF"
-          } >> $GITHUB_ENV
+          mkdir ~/mosek
+          echo "${MOSEK_LICENSE}" > ~/mosek/mosek.lic
+        env:
+          MOSEK_LICENSE: ${{ secrets.MOSEK_LICENSE }}
       # Setup Xpress.jl
       - name: Setup Xpress
         if: ${{ matrix.package == 'Xpress' }}

--- a/.github/workflows/solver-tests.yml
+++ b/.github/workflows/solver-tests.yml
@@ -35,7 +35,7 @@ jobs:
           - package: 'Ipopt'
           - package: 'KNITRO'
           - package: 'MiniZinc'
-          # - package: 'MosekTools' I need to fix this
+          - package: 'MosekTools'
           - package: 'MathOptAnalyzer'
           - package: 'MathOptIIS'
           - package: 'MultiObjectiveAlgorithms'


### PR DESCRIPTION
I still don't understand how newlines are mangled from GitHub secrets, to an environment variable, to `GITHUB_ENV`. But this worked in https://github.com/jump-dev/MosekTools.jl/pull/219 so let's go with it.