### PR TITLE
Add canonical

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -1056,6 +1056,32 @@ function canonical(f::MOI.AbstractFunction)
     return g
 end
 
+# Workaround: both `is_canonical` and `canonicalize!` would be slow otherwise
+canonical(f::MOI.ScalarNonlinearFunction) = f
+
+# This is maybe the right fix, but commented out to be sure to isolate
+# JuMP-side of profiling in https://github.com/jump-dev/JuMP.jl/pull/4032
+# We still need to figure out what's the right fix here anyway
+#function canonical(f::MOI.ScalarNonlinearFunction)
+#    cache = Dict{MOI.AbstractScalarFunction,MOI.AbstractScalarFunction}()
+#    # Don't use recursion here. This gets called for all scalar nonlinear
+#    # constraints.
+#    stack = Any[arg for arg in f.args]
+#    while !isempty(stack)
+#        arg = pop!(stack)
+#        if arg isa MOI.ScalarNonlinearFunction
+#            for a in arg.args
+#                push!(stack, a)
+#            end
+#        else
+#            if !is_canonical(arg)
+#                return false
+#            end
+#        end
+#    end
+#    return true
+#end
+
 canonicalize!(f::Union{MOI.VectorOfVariables,MOI.VariableIndex}) = f
 
 """


### PR DESCRIPTION
Extracted from https://github.com/jump-dev/MathOptInterface.jl/pull/2803

I'm not too convinced by the current approach.

For `canonical`, I think we need to implement `canonical` with a cache that checks that it creates aliases when it sees a second time an alias to the same sub-expression.