### PR TITLE
[Nonlinear.SymbolicAD] simplify zero and one terms in simplify!

### DIFF
--- a/src/Nonlinear/SymbolicAD/SymbolicAD.jl
+++ b/src/Nonlinear/SymbolicAD/SymbolicAD.jl
@@ -167,6 +167,14 @@ _iszero(x::Any)::Bool = _isnum(x) && iszero(x)
 
 _isone(x::Any)::Bool = _isnum(x) && isone(x)
 
+_iszero(x::MOI.ScalarAffineFunction) = iszero(x)
+
+_isone(x::MOI.ScalarAffineFunction) = isone(x)
+
+_iszero(x::MOI.ScalarQuadraticFunction) = iszero(x)
+
+_isone(x::MOI.ScalarQuadraticFunction) = isone(x)
+
 """
     _isexpr(f::Any, head::Symbol[, n::Int])
 

--- a/test/Nonlinear/test_SymbolicAD.jl
+++ b/test/Nonlinear/test_SymbolicAD.jl
@@ -755,6 +755,36 @@ function test_simplify_if_quadratic()
     return
 end
 
+function test_simplify_drops_zeros()
+    x, y = MOI.VariableIndex.(1:2)
+    f = MOI.ScalarNonlinearFunction(:/, Any[1.0 * x * x, y])
+    for F in (
+        MOI.ScalarAffineFunction{Float64},
+        MOI.ScalarQuadraticFunction{Float64},
+    )
+        g = MOI.ScalarNonlinearFunction(:+, Any[zero(F), f])
+        @test isapprox(MOI.Nonlinear.SymbolicAD.simplify(g), f)
+        g = MOI.ScalarNonlinearFunction(:+, Any[f, zero(F)])
+        @test isapprox(MOI.Nonlinear.SymbolicAD.simplify(g), f)
+    end
+    return
+end
+
+function test_simplify_drops_zeros()
+    x, y = MOI.VariableIndex.(1:2)
+    f = MOI.ScalarNonlinearFunction(:/, Any[1.0 * x * x, y])
+    for F in (
+        MOI.ScalarAffineFunction{Float64},
+        MOI.ScalarQuadraticFunction{Float64},
+    )
+        g = MOI.ScalarNonlinearFunction(:*, Any[one(F), f])
+        @test isapprox(MOI.Nonlinear.SymbolicAD.simplify(g), f)
+        g = MOI.ScalarNonlinearFunction(:*, Any[f, one(F)])
+        @test isapprox(MOI.Nonlinear.SymbolicAD.simplify(g), f)
+    end
+    return
+end
+
 end  # module
 
 TestMathOptSymbolicAD.runtests()

--- a/test/Nonlinear/test_SymbolicAD.jl
+++ b/test/Nonlinear/test_SymbolicAD.jl
@@ -757,7 +757,7 @@ end
 
 function test_simplify_drops_zeros()
     x, y = MOI.VariableIndex.(1:2)
-    f = MOI.ScalarNonlinearFunction(:/, Any[1.0 * x * x, y])
+    f = MOI.ScalarNonlinearFunction(:/, Any[1.0*x*x, y])
     for F in (
         MOI.ScalarAffineFunction{Float64},
         MOI.ScalarQuadraticFunction{Float64},
@@ -770,9 +770,9 @@ function test_simplify_drops_zeros()
     return
 end
 
-function test_simplify_drops_zeros()
+function test_simplify_drops_ones()
     x, y = MOI.VariableIndex.(1:2)
-    f = MOI.ScalarNonlinearFunction(:/, Any[1.0 * x * x, y])
+    f = MOI.ScalarNonlinearFunction(:/, Any[1.0*x*x, y])
     for F in (
         MOI.ScalarAffineFunction{Float64},
         MOI.ScalarQuadraticFunction{Float64},


### PR DESCRIPTION
Found by https://github.com/infiniteopt/DisjunctiveProgramming.jl/pull/138

`simplify!` didn't simplify `+(0, f) -> f` if `0` was `zero(ScalarAffineFunction)`. Same goes for `*(1, f)` and `ScalarQuadraticFunction`.