### PR TITLE
Fix compat bound of CliqueTrees.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ MathOptInterfaceCliqueTreesExt = "CliqueTrees"
 
 [compat]
 BenchmarkTools = "1"
-CliqueTrees = "1.17"
+CliqueTrees = "1.17.1"
 CodecBzip2 = "0.6, 0.7, 0.8"
 CodecZlib = "0.6, 0.7"
 ForwardDiff = "1"


### PR DESCRIPTION
Tests started failing in #3038.

Traced back to a change in the package versions that downgrade-ci was serving up (there can be multiple solutions; there's no single "oldest version").

Was a bug in v1.17.0 that was fixed in v1.17.1.