### PR TITLE
add DualGeometricMeanCone and bridge

### DIFF
--- a/docs/src/manual/standard_form.md
+++ b/docs/src/manual/standard_form.md
@@ -76,7 +76,7 @@ The vector-valued set types implemented in MathOptInterface.jl are:
 | [`ExponentialCone()`](@ref)         | ``\{ (x,y,z) \in \mathbb{R}^3 : y \exp (x/y) \le z, y > 0 \}``                                                                             |
 | [`DualExponentialCone()`](@ref)     | ``\{ (u,v,w) \in \mathbb{R}^3 : -u \exp (v/u) \le \exp(1) w, u < 0 \}``                                                                    |
 | [`GeometricMeanCone(d)`](@ref)      | ``\{ (t,x) \in \mathbb{R}^{1+n} : x \ge 0, t \le \sqrt[n]{x_1 x_2 \cdots x_n} \}`` where ``n`` is ``d - 1``                                |
-| [`DualGeometricMeanCone(d)`](@ref)  | ``\{ (u,v) \in \mathbb{R}^{1+n} : v \\ge 0, 0 \\ge u \\ge -n \\sqrt[n]{\\prod_i v_i} \\}``, where ``n`` is ``d - 1``                       |
+| [`DualGeometricMeanCone(d)`](@ref)  | ``\{ (u,v) \in \mathbb{R}^{1+n} : v \ge 0, 0 \ge u \ge -n \sqrt[n]{\prod_i v_i} \}``, where ``n`` is ``d - 1``                             |
 | [`PowerCone(α)`](@ref)              | ``\{ (x,y,z) \in \mathbb{R}^3 : x^{\alpha} y^{1-\alpha} \ge \|z\|, x \ge 0,y \ge 0 \}``                                                    |
 | [`DualPowerCone(α)`](@ref)          | ``\{ (u,v,w) \in \mathbb{R}^3 : \left(\frac{u}{\alpha}\right)^{\alpha}\left(\frac{v}{1-\alpha}\right)^{1-\alpha} \ge \|w\|, u,v \ge 0 \}`` |
 | [`NormOneCone(d)`](@ref)            | ``\{ (t,x) \in \mathbb{R}^{d} : t \ge \sum_i \lvert x_i \rvert \}``                                                                        |

--- a/docs/src/manual/standard_form.md
+++ b/docs/src/manual/standard_form.md
@@ -76,6 +76,7 @@ The vector-valued set types implemented in MathOptInterface.jl are:
 | [`ExponentialCone()`](@ref)         | ``\{ (x,y,z) \in \mathbb{R}^3 : y \exp (x/y) \le z, y > 0 \}``                                                                             |
 | [`DualExponentialCone()`](@ref)     | ``\{ (u,v,w) \in \mathbb{R}^3 : -u \exp (v/u) \le \exp(1) w, u < 0 \}``                                                                    |
 | [`GeometricMeanCone(d)`](@ref)      | ``\{ (t,x) \in \mathbb{R}^{1+n} : x \ge 0, t \le \sqrt[n]{x_1 x_2 \cdots x_n} \}`` where ``n`` is ``d - 1``                                |
+| [`DualGeometricMeanCone(d)`](@ref)  | ``\{ (u,v) \in \mathbb{R}^{1+n} : v \\ge 0, 0 \\ge u \\ge -n \\sqrt[n]{\\prod_i v_i} \\}``, where ``n`` is ``d - 1``                       |
 | [`PowerCone(α)`](@ref)              | ``\{ (x,y,z) \in \mathbb{R}^3 : x^{\alpha} y^{1-\alpha} \ge \|z\|, x \ge 0,y \ge 0 \}``                                                    |
 | [`DualPowerCone(α)`](@ref)          | ``\{ (u,v,w) \in \mathbb{R}^3 : \left(\frac{u}{\alpha}\right)^{\alpha}\left(\frac{v}{1-\alpha}\right)^{1-\alpha} \ge \|w\|, u,v \ge 0 \}`` |
 | [`NormOneCone(d)`](@ref)            | ``\{ (t,x) \in \mathbb{R}^{d} : t \ge \sum_i \lvert x_i \rvert \}``                                                                        |

--- a/docs/src/reference/standard_form.md
+++ b/docs/src/reference/standard_form.md
@@ -88,6 +88,7 @@ NormCone
 SecondOrderCone
 RotatedSecondOrderCone
 GeometricMeanCone
+DualGeometricMeanCone
 ExponentialCone
 DualExponentialCone
 PowerCone

--- a/src/Bridges/Constraint/Constraint.jl
+++ b/src/Bridges/Constraint/Constraint.jl
@@ -39,6 +39,7 @@ function add_all_bridges(model, ::Type{T}) where {T}
     MOI.Bridges.add_bridge(model, CountBelongsToMILPBridge{T})
     MOI.Bridges.add_bridge(model, CountDistinctToMILPBridge{T})
     MOI.Bridges.add_bridge(model, CountGreaterThanToMILPBridge{T})
+    MOI.Bridges.add_bridge(model, DualGeoMeanBridge{T})
     # * ExponentialConeToScalarNonlinearFunctionBridge{T}
     #      This bridge is not added by default because it starts with a convex
     #      conic constraint and adds a nonlinear constraint that local NLP

--- a/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
+++ b/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
@@ -40,23 +40,15 @@ function bridge_constraint(
     s::MOI.DualGeometricMeanCone,
 ) where {T,G,H}
     f_scalars = MOI.Utilities.eachscalar(f)
-    nn_index = MOI.add_constraint(
+    u_neg = MOI.Utilities.vectorize([MOI.Utilities.operate(-, T, f_scalars[1])])
+    nn_index = MOI.add_constraint(model, u_neg, MOI.Nonnegatives(1))
+    u_n = MOI.Utilities.operate(/, T, f_scalars[1], -T(MOI.dimension(s) - 1))
+    ci = MOI.add_constraint(
         model,
-        MOI.Utilities.vectorize([MOI.Utilities.operate(-, T, f_scalars[1])]),
-        MOI.Nonnegatives(1),
-    )
-    geomean_func = MOI.Utilities.operate(
-        vcat,
-        T,
-        MOI.Utilities.operate(/, T, f_scalars[1], -T(MOI.dimension(s) - 1)),
-        f_scalars[2:end],
-    )
-    geomean_index = MOI.add_constraint(
-        model,
-        geomean_func,
+        MOI.Utilities.operate(vcat, T, u_n, f_scalars[2:end]),
         MOI.GeometricMeanCone(MOI.dimension(s)),
     )
-    return DualGeoMeanBridge{T,G,H}(nn_index, geomean_index)
+    return DualGeoMeanBridge{T,G,H}(nn_index, ci)
 end
 
 function MOI.supports_constraint(
@@ -76,22 +68,17 @@ end
 function MOI.Bridges.added_constraint_types(
     ::Type{<:DualGeoMeanBridge{T,G}},
 ) where {T,G}
-    return Tuple{Type,Type,Type}[(G, MOI.Nonnegatives, MOI.GeometricMeanCone)]
+    return Tuple{Type,Type}[(G, MOI.Nonnegatives), (G, MOI.GeometricMeanCone)]
 end
 
 function concrete_bridge_type(
     ::Type{<:DualGeoMeanBridge{T}},
-    H::Type{<:MOI.AbstractVectorFunction},
+    ::Type{H},
     ::Type{MOI.DualGeometricMeanCone},
-) where {T}
+) where {T,H<:MOI.AbstractVectorFunction}
     S = MOI.Utilities.scalar_type(H)
-    G = MOI.Utilities.promote_operation(
-        vcat,
-        T,
-        T,
-        S,
-        MOI.Utilities.promote_operation(+, T, S, MOI.VariableIndex),
-    )
+    TS = MOI.Utilities.promote_operation(+, T, S, MOI.VariableIndex)
+    G = MOI.Utilities.promote_operation(vcat, T, T, S, TS)
     return DualGeoMeanBridge{T,G,H}
 end
 
@@ -103,17 +90,18 @@ function MOI.get(
 end
 
 function MOI.get(
-    ::DualGeoMeanBridge{T,G},
-    ::MOI.NumberOfConstraints{G,MOI.GeometricMeanCone},
-)::Int64 where {T,G}
-    return 1
-end
-
-function MOI.get(
     bridge::DualGeoMeanBridge{T,G},
     ::MOI.ListOfConstraintIndices{G,MOI.Nonnegatives},
 ) where {T,G}
     return [bridge.nn_index]
+end
+
+
+function MOI.get(
+    ::DualGeoMeanBridge{T,G},
+    ::MOI.NumberOfConstraints{G,MOI.GeometricMeanCone},
+)::Int64 where {T,G}
+    return 1
 end
 
 function MOI.get(
@@ -134,15 +122,12 @@ function MOI.get(
     ::MOI.ConstraintFunction,
     bridge::DualGeoMeanBridge{T,G,H},
 ) where {T,G,H}
-    geomean_func = MOI.Utilities.eachscalar(
-        MOI.get(model, MOI.ConstraintFunction(), bridge.geomean_index),
-    )
-    d = length(geomean_func) - 1
-    u = MOI.Utilities.operate(*, T, geomean_func[1], T(-d))
-    return MOI.Utilities.convert_approx(
-        H,
-        MOI.Utilities.operate(vcat, T, u, geomean_func[2:end]),
-    )
+    g = MOI.get(model, MOI.ConstraintFunction(), bridge.geomean_index)
+    scalars = MOI.Utilities.eachscalar(g)
+    d = length(geomean_scalarsfunc) - 1
+    u = MOI.Utilities.operate(*, T, scalars[1], T(-d))
+    f = MOI.Utilities.operate(vcat, T, u, scalars[2:end])
+    return MOI.Utilities.convert_approx(H, f)
 end
 
 function MOI.get(
@@ -150,11 +135,8 @@ function MOI.get(
     ::MOI.ConstraintSet,
     bridge::DualGeoMeanBridge,
 )
-    return MOI.DualGeometricMeanCone(
-        MOI.dimension(
-            MOI.get(model, MOI.ConstraintSet(), bridge.geomean_index),
-        ),
-    )
+    set = MOI.get(model, MOI.ConstraintSet(), bridge.geomean_index)
+    return MOI.DualGeometricMeanCone(MOI.dimension(set))
 end
 
 function MOI.get(
@@ -162,9 +144,9 @@ function MOI.get(
     attr::MOI.ConstraintPrimal,
     bridge::DualGeoMeanBridge,
 )
-    geomean_primal = MOI.get(model, attr, bridge.geomean_index)
-    d = length(geomean_primal) - 1
-    return [-geomean_primal[1] * d; geomean_primal[2:end]]
+    primal = MOI.get(model, attr, bridge.geomean_index)
+    primal[1] *= -(length(primal) - 1)
+    return primal
 end
 
 function MOI.get(
@@ -172,7 +154,7 @@ function MOI.get(
     attr::MOI.ConstraintDual,
     bridge::DualGeoMeanBridge,
 )
-    geomean_dual = MOI.get(model, attr, bridge.geomean_index)
-    d = length(geomean_dual) - 1
-    return [-geomean_dual[1] / d; geomean_dual[2:end]]
+    dual = MOI.get(model, attr, bridge.geomean_index)
+    dual[1] ./= -(length(dual) - 1)
+    return dual
 end

--- a/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
+++ b/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
@@ -153,8 +153,8 @@ function MOI.get(
     bridge::DualGeoMeanBridge,
 )
     return MOI.DualGeometricMeanCone(
-            MOI.dimension(
-                MOI.get(model, MOI.ConstraintSet(), bridge.geomean_index)
-        )
+        MOI.dimension(
+            MOI.get(model, MOI.ConstraintSet(), bridge.geomean_index),
+        ),
     )
 end

--- a/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
+++ b/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
@@ -95,8 +95,6 @@ function concrete_bridge_type(
     return DualGeoMeanBridge{T,G,H}
 end
 
-MOI.get(::DualGeoMeanBridge, ::MOI.NumberOfVariables)::Int64 = 0
-
 function MOI.get(
     ::DualGeoMeanBridge{T,G},
     ::MOI.NumberOfConstraints{G,MOI.Nonnegatives},
@@ -157,4 +155,24 @@ function MOI.get(
             MOI.get(model, MOI.ConstraintSet(), bridge.geomean_index),
         ),
     )
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintPrimal,
+    bridge::DualGeoMeanBridge,
+)
+    geomean_primal = MOI.get(model, attr, bridge.geomean_index)
+    d = length(geomean_primal) - 1
+    return [-geomean_primal[1] * d; geomean_primal[2:end]]
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    attr::MOI.ConstraintDual,
+    bridge::DualGeoMeanBridge,
+)
+    geomean_dual = MOI.get(model, attr, bridge.geomean_index)
+    d = length(geomean_dual) - 1
+    return [-geomean_dual[1] / d; geomean_dual[2:end]]
 end

--- a/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
+++ b/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
@@ -124,8 +124,8 @@ function MOI.get(
 ) where {T,G,H}
     g = MOI.get(model, MOI.ConstraintFunction(), bridge.geomean_index)
     scalars = MOI.Utilities.eachscalar(g)
-    d = length(geomean_scalarsfunc) - 1
-    u = MOI.Utilities.operate(*, T, scalars[1], T(-d))
+    n = -T(length(scalars) - 1)
+    u = MOI.Utilities.operate(*, T, scalars[1], n)
     f = MOI.Utilities.operate(vcat, T, u, scalars[2:end])
     return MOI.Utilities.convert_approx(H, f)
 end

--- a/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
+++ b/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
@@ -96,7 +96,6 @@ function MOI.get(
     return [bridge.nn_index]
 end
 
-
 function MOI.get(
     ::DualGeoMeanBridge{T,G},
     ::MOI.NumberOfConstraints{G,MOI.GeometricMeanCone},
@@ -155,6 +154,6 @@ function MOI.get(
     bridge::DualGeoMeanBridge,
 )
     dual = MOI.get(model, attr, bridge.geomean_index)
-    dual[1] ./= -(length(dual) - 1)
+    dual[1] /= -(length(dual) - 1)
     return dual
 end

--- a/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
+++ b/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
@@ -1,0 +1,160 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+"""
+    DualGeoMeanBridge{T,G,H} <: Bridges.Constraint.AbstractBridge
+
+`DualGeoMeanBridge` implements the following reformulation:
+
+  * ``(u, v) \\in DualGeometricMeanCone`` into
+    ``(-u/length(v), v) \\in GeometricMeanCone`` and ``u \\le 0``
+
+## Source node
+
+`DualGeoMeanBridge` supports:
+
+  * `H` in [`MOI.DualGeometricMeanCone`](@ref)
+
+## Target nodes
+
+`DualGeoMeanBridge` creates:
+
+  * `G` in [`MOI.GeometricMeanCone`](@ref)
+  * `G` in [`MOI.Nonnegatives`](@ref)
+"""
+struct DualGeoMeanBridge{T,G,H} <: AbstractBridge
+    nn_index::MOI.ConstraintIndex{G,MOI.Nonnegatives}
+    geomean_index::MOI.ConstraintIndex{G,MOI.GeometricMeanCone}
+end
+
+const DualGeoMean{T,OT<:MOI.ModelLike} =
+    SingleBridgeOptimizer{DualGeoMeanBridge{T},OT}
+
+function bridge_constraint(
+    ::Type{DualGeoMeanBridge{T,G,H}},
+    model::MOI.ModelLike,
+    f::H,
+    s::MOI.DualGeometricMeanCone,
+) where {T,G,H}
+    f_scalars = MOI.Utilities.eachscalar(f)
+    nn_index = MOI.add_constraint(
+        model,
+        MOI.Utilities.vectorize([MOI.Utilities.operate(-, T, f_scalars[1])]),
+        MOI.Nonnegatives(1),
+    )
+    geomean_func = MOI.Utilities.operate(
+        vcat,
+        T,
+        MOI.Utilities.operate(/, T, f_scalars[1], -T(MOI.dimension(s) - 1)),
+        f_scalars[2:end],
+    )
+    geomean_index = MOI.add_constraint(
+        model,
+        geomean_func,
+        MOI.GeometricMeanCone(MOI.dimension(s)),
+    )
+    return DualGeoMeanBridge{T,G,H}(nn_index, geomean_index)
+end
+
+function MOI.supports_constraint(
+    ::Type{<:DualGeoMeanBridge{T}},
+    ::Type{<:MOI.AbstractVectorFunction},
+    ::Type{MOI.DualGeometricMeanCone},
+) where {T}
+    return true
+end
+
+function MOI.Bridges.added_constrained_variable_types(
+    ::Type{<:DualGeoMeanBridge},
+)
+    return Tuple{Type}[]
+end
+
+function MOI.Bridges.added_constraint_types(
+    ::Type{<:DualGeoMeanBridge{T,G}},
+) where {T,G}
+    return Tuple{Type,Type,Type}[(G, MOI.Nonnegatives, MOI.GeometricMeanCone)]
+end
+
+function concrete_bridge_type(
+    ::Type{<:DualGeoMeanBridge{T}},
+    H::Type{<:MOI.AbstractVectorFunction},
+    ::Type{MOI.DualGeometricMeanCone},
+) where {T}
+    S = MOI.Utilities.scalar_type(H)
+    G = MOI.Utilities.promote_operation(
+        vcat,
+        T,
+        T,
+        S,
+        MOI.Utilities.promote_operation(+, T, S, MOI.VariableIndex),
+    )
+    return DualGeoMeanBridge{T,G,H}
+end
+
+MOI.get(::DualGeoMeanBridge, ::MOI.NumberOfVariables)::Int64 = 0
+
+function MOI.get(
+    ::DualGeoMeanBridge{T,G},
+    ::MOI.NumberOfConstraints{G,MOI.Nonnegatives},
+)::Int64 where {T,G}
+    return 1
+end
+
+function MOI.get(
+    ::DualGeoMeanBridge{T,G},
+    ::MOI.NumberOfConstraints{G,MOI.GeometricMeanCone},
+)::Int64 where {T,G}
+    return 1
+end
+
+function MOI.get(
+    bridge::DualGeoMeanBridge{T,G},
+    ::MOI.ListOfConstraintIndices{G,MOI.Nonnegatives},
+) where {T,G}
+    return [bridge.nn_index]
+end
+
+function MOI.get(
+    bridge::DualGeoMeanBridge{T,G},
+    ::MOI.ListOfConstraintIndices{G,MOI.GeometricMeanCone},
+) where {T,G}
+    return [bridge.geomean_index]
+end
+
+function MOI.delete(model::MOI.ModelLike, bridge::DualGeoMeanBridge)
+    MOI.delete(model, bridge.geomean_index)
+    MOI.delete(model, bridge.nn_index)
+    return
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    ::MOI.ConstraintFunction,
+    bridge::DualGeoMeanBridge{T,G,H},
+) where {T,G,H}
+    geomean_func = MOI.Utilities.eachscalar(
+        MOI.get(model, MOI.ConstraintFunction(), bridge.geomean_index),
+    )
+    d = length(geomean_func) - 1
+    u = MOI.Utilities.operate(*, T, geomean_func[1], T(-d))
+    return MOI.Utilities.convert_approx(
+        H,
+        MOI.Utilities.operate(vcat, T, u, geomean_func[2:end]),
+    )
+end
+
+function MOI.get(
+    model::MOI.ModelLike,
+    ::MOI.ConstraintSet,
+    bridge::DualGeoMeanBridge,
+)
+    return MOI.DualGeometricMeanCone(
+            MOI.dimension(
+                MOI.get(model, MOI.ConstraintSet(), bridge.geomean_index)
+        )
+    )
+end

--- a/src/Test/test_basic_constraint.jl
+++ b/src/Test/test_basic_constraint.jl
@@ -115,6 +115,7 @@ _set(::Type{MOI.NormCone}) = MOI.NormCone(4.0, 3)
 _set(::Type{MOI.SecondOrderCone}) = MOI.SecondOrderCone(3)
 _set(::Type{MOI.RotatedSecondOrderCone}) = MOI.RotatedSecondOrderCone(3)
 _set(::Type{MOI.GeometricMeanCone}) = MOI.GeometricMeanCone(3)
+_set(::Type{MOI.DualGeometricMeanCone}) = MOI.DualGeometricMeanCone(3)
 _set(::Type{MOI.ExponentialCone}) = MOI.ExponentialCone()
 _set(::Type{MOI.DualExponentialCone}) = MOI.DualExponentialCone()
 _set(::Type{T}, ::Type{MOI.PowerCone}) where {T} = MOI.PowerCone(T(1//2))
@@ -403,6 +404,7 @@ for s in [
     :SecondOrderCone,
     :RotatedSecondOrderCone,
     :GeometricMeanCone,
+    :DualGeometricMeanCone,
     :ExponentialCone,
     :DualExponentialCone,
     :PowerCone,

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -3370,7 +3370,8 @@ function setup_test(
             mock,
             T[-3, 1, 1, 1]::Vector{T},
             (MOI.ScalarAffineFunction{T}, MOI.LessThan{T}) => [-T(1)],
-            (MOI.VectorAffineFunction{T}, MOI.DualGeometricMeanCone) => [ones(T, 4)],
+            (MOI.VectorAffineFunction{T}, MOI.DualGeometricMeanCone) =>
+                [ones(T, 4)],
         ),
     )
     return

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -2850,7 +2850,6 @@ function _test_conic_GeometricMeanCone_helper(
         )
         @test ≈(MOI.get(model, MOI.ConstraintPrimal(), c), n, config)
         if _supports(config, MOI.ConstraintDual)
-            display(MOI.get(model, MOI.ConstraintDual(), gmc))
             @test ≈(
                 MOI.get(model, MOI.ConstraintDual(), gmc),
                 vcat(T(-1), fill(inv(T(n)), n)),
@@ -3315,7 +3314,6 @@ function _test_conic_DualGeometricMeanCone_helper(
         )
         @test ≈(MOI.get(model, MOI.ConstraintPrimal(), c), n, config)
         if _supports(config, MOI.ConstraintDual)
-            display(MOI.get(model, MOI.ConstraintDual(), gmc))
             @test ≈(
                 MOI.get(model, MOI.ConstraintDual(), gmc),
                 ones(T, n + 1),

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -2850,6 +2850,7 @@ function _test_conic_GeometricMeanCone_helper(
         )
         @test ≈(MOI.get(model, MOI.ConstraintPrimal(), c), n, config)
         if _supports(config, MOI.ConstraintDual)
+            display(MOI.get(model, MOI.ConstraintDual(), gmc))
             @test ≈(
                 MOI.get(model, MOI.ConstraintDual(), gmc),
                 vcat(T(-1), fill(inv(T(n)), n)),
@@ -3211,6 +3212,165 @@ function setup_test(
             (MOI.ScalarAffineFunction{T}, MOI.LessThan{T}) => T[-2],
             (MOI.VectorAffineFunction{T}, MOI.GeometricMeanCone) =>
                 [T[-2, 2]],
+        ),
+    )
+    return
+end
+
+function _test_conic_DualGeometricMeanCone_helper(
+    model::MOI.ModelLike,
+    config::Config{T},
+    use_VectorOfVariables,
+    n = 3,
+) where {T<:Real}
+    # Problem DualGeoMean1
+    # min -3(xyz)^(1/3)
+    # s.t.
+    #      x + y + z ≤ 3
+    # in conic form:
+    # max t
+    # s.t.
+    #   (t,x,y,z) ∈ DualGeometricMeanCone(4)
+    #     x+y+z-3 ∈ LessThan(0.)
+    # By the arithmetic-geometric mean inequality,
+    # (xyz)^(1/3) ≤ (x+y+z)/3 = 1
+    # Therefore xyz ≤ 1
+    # This can be attained using x = y = z = 1 so it is optimal.
+    @requires MOI.supports_incremental_interface(model)
+    @requires MOI.supports(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
+    )
+    @requires MOI.supports(model, MOI.ObjectiveSense())
+    if use_VectorOfVariables
+        @requires MOI.supports_constraint(
+            model,
+            MOI.VectorOfVariables,
+            MOI.DualGeometricMeanCone,
+        )
+    else
+        @requires MOI.supports_constraint(
+            model,
+            MOI.VectorAffineFunction{T},
+            MOI.DualGeometricMeanCone,
+        )
+    end
+    @requires MOI.supports_constraint(
+        model,
+        MOI.ScalarAffineFunction{T},
+        MOI.LessThan{T},
+    )
+    t = MOI.add_variable(model)
+    x = MOI.add_variables(model, n)
+    vov = MOI.VectorOfVariables([t; x])
+    if use_VectorOfVariables
+        gmc = MOI.add_constraint(model, vov, MOI.DualGeometricMeanCone(n + 1))
+    else
+        gmc = MOI.add_constraint(
+            model,
+            MOI.VectorAffineFunction{T}(vov),
+            MOI.DualGeometricMeanCone(n + 1),
+        )
+    end
+    c = MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(T(1), x), T(0)),
+        MOI.LessThan(T(n)),
+    )
+    if _supports(config, MOI.NumberOfConstraints)
+        @test MOI.get(
+            model,
+            MOI.NumberOfConstraints{
+                use_VectorOfVariables ? MOI.VectorOfVariables :
+                MOI.VectorAffineFunction{T},
+                MOI.DualGeometricMeanCone,
+            }(),
+        ) == 1
+        @test MOI.get(
+            model,
+            MOI.NumberOfConstraints{
+                MOI.ScalarAffineFunction{T},
+                MOI.LessThan{T},
+            }(),
+        ) == 1
+    end
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
+        MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(T(1), t)], T(0)),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    if _supports(config, MOI.optimize!)
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+        MOI.optimize!(model)
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+        @test ≈(MOI.get(model, MOI.ObjectiveValue()), -3, config)
+        @test ≈(MOI.get(model, MOI.VariablePrimal(), t), -3, config)
+        @test ≈(MOI.get(model, MOI.VariablePrimal(), x), ones(T, n), config)
+        @test ≈(
+            MOI.get(model, MOI.ConstraintPrimal(), gmc),
+            T[-3, 1, 1, 1],
+            config,
+        )
+        @test ≈(MOI.get(model, MOI.ConstraintPrimal(), c), n, config)
+        if _supports(config, MOI.ConstraintDual)
+            display(MOI.get(model, MOI.ConstraintDual(), gmc))
+            @test ≈(
+                MOI.get(model, MOI.ConstraintDual(), gmc),
+                ones(T, n + 1),
+                config,
+            )
+            @test ≈(MOI.get(model, MOI.ConstraintDual(), c), -T(1), config)
+        end
+    end
+    return
+end
+
+function test_conic_DualGeometricMeanCone_VectorOfVariables(
+    model::MOI.ModelLike,
+    config::Config{T},
+) where {T<:Real}
+    _test_conic_DualGeometricMeanCone_helper(model, config, true)
+    return
+end
+
+function setup_test(
+    ::typeof(test_conic_DualGeometricMeanCone_VectorOfVariables),
+    model::MOIU.MockOptimizer,
+    ::Config{T},
+) where {T<:Real}
+    MOIU.set_mock_optimize!(
+        model,
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+            mock,
+            T[-3, 1, 1, 1]::Vector{T},
+            (MOI.ScalarAffineFunction{T}, MOI.LessThan{T}) => [-T(1)],
+        ),
+    )
+    return
+end
+
+function test_conic_DualGeometricMeanCone_VectorAffineFunction(
+    model::MOI.ModelLike,
+    config::Config{T},
+) where {T<:Real}
+    _test_conic_DualGeometricMeanCone_helper(model, config, false)
+    return
+end
+
+function setup_test(
+    ::typeof(test_conic_DualGeometricMeanCone_VectorAffineFunction),
+    model::MOIU.MockOptimizer,
+    ::Config{T},
+) where {T<:Real}
+    MOIU.set_mock_optimize!(
+        model,
+        (mock::MOIU.MockOptimizer) -> MOIU.mock_optimize!(
+            mock,
+            T[-3, 1, 1, 1]::Vector{T},
+            (MOI.ScalarAffineFunction{T}, MOI.LessThan{T}) => [-T(1)],
+            (MOI.VectorAffineFunction{T}, MOI.DualGeometricMeanCone) => [ones(T, 4)],
         ),
     )
     return

--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -3333,6 +3333,12 @@ function test_conic_DualGeometricMeanCone_VectorOfVariables(
     return
 end
 
+function version_added(
+    ::typeof(test_conic_DualGeometricMeanCone_VectorOfVariables),
+)
+    return v"1.53.0"
+end
+
 function setup_test(
     ::typeof(test_conic_DualGeometricMeanCone_VectorOfVariables),
     model::MOIU.MockOptimizer,
@@ -3355,6 +3361,12 @@ function test_conic_DualGeometricMeanCone_VectorAffineFunction(
 ) where {T<:Real}
     _test_conic_DualGeometricMeanCone_helper(model, config, false)
     return
+end
+
+function version_added(
+    ::typeof(test_conic_DualGeometricMeanCone_VectorAffineFunction),
+)
+    return v"1.53.0"
 end
 
 function setup_test(

--- a/src/Utilities/distance_to_set.jl
+++ b/src/Utilities/distance_to_set.jl
@@ -359,8 +359,8 @@ end
 """
     distance_to_set(::ProjectionUpperBoundDistance, x, ::MOI.GeometricMeanCone)
 
-Let `(t, y...) = x`. If all `y` are non-negative, return the epigraph distance
-`d` such that `(t + d, y...)` belongs to the set.
+Let `(t, y...) = x`. If all `y` are non-negative, return the hypograph distance
+`d` such that `(t - d, y...)` belongs to the set.
 
 If any `y` are strictly negative, return the 2-norm of the vector `d` that
 projects negative `y` elements to `0` and `t` to `ℝ₋`.
@@ -377,6 +377,36 @@ function distance_to_set(
         return LinearAlgebra.norm((min.(xs, zero(T)), max(t, zero(T))), 2)
     end
     return max(t - prod(xs)^inv(MOI.dimension(set) - 1), zero(T))
+end
+
+"""
+    distance_to_set(::ProjectionUpperBoundDistance, x, ::MOI.DualGeometricMeanCone)
+
+Let `(t, y...) = x`. If all `y` are non-negative, return the absolute value of
+`d` such that `(t + d, y...)` belongs to the set.
+
+If any `y` are strictly negative, return the 2-norm of the vector `d` that
+projects negative `y` elements to `0` and `t` to `0`.
+"""
+function distance_to_set(
+    ::ProjectionUpperBoundDistance,
+    x::AbstractVector{T},
+    set::MOI.DualGeometricMeanCone,
+) where {T<:Real}
+    Base.require_one_based_indexing(x)
+    _check_dimension(x, set)
+    t, xs = x[1], @view(x[2:end])
+    if any(<(zero(T)), xs)  # Project to x = 0
+        return LinearAlgebra.norm((min.(xs, zero(T)), abs(t)), 2)
+    else
+        n = T(MOI.dimension(set)) - 1
+        G = n * prod(xs)^inv(n)
+        if t < -G
+            return -G - t
+        else
+            return max(t, zero(T))
+        end
+    end
 end
 
 """

--- a/src/Utilities/model.jl
+++ b/src/Utilities/model.jl
@@ -813,6 +813,7 @@ const EqualToIndicatorZero{T} =
         MOI.SecondOrderCone,
         MOI.RotatedSecondOrderCone,
         MOI.GeometricMeanCone,
+        MOI.DualGeometricMeanCone,
         MOI.ExponentialCone,
         MOI.DualExponentialCone,
         MOI.RelativeEntropyCone,

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -825,7 +825,7 @@ julia> MOI.add_constraint(
            MOI.VectorOfVariables([t; x]),
            MOI.DualGeometricMeanCone(4),
        )
-MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInterface.DualGeometricMean/Cone}(1)
+MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInterface.DualGeometricMeanCone}(1)
 ```
 """
 struct DualGeometricMeanCone <: AbstractVectorSet

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -767,12 +767,6 @@ The geometric mean cone
 ``\\{ (t,x) \\in \\mathbb{R}^{n+1} : x \\ge 0, t \\le \\sqrt[n]{x_1 x_2 \\cdots x_n} \\}``,
 where `dimension = n + 1 >= 2`.
 
-## Duality note
-
-The dual of the geometric mean cone is
-``\\{ (u, v) \\in \\mathbb{R}^{n+1} : u \\le 0, v \\ge 0, -u \\le n \\sqrt[n]{\\prod_i v_i} \\}``,
-where `dimension = n + 1 >= 2`.
-
 ## Example
 
 ```jldoctest
@@ -805,6 +799,52 @@ struct GeometricMeanCone <: AbstractVectorSet
         return new(dimension)
     end
 end
+
+dual_set(s::GeometricMeanCone) = DualGeometricMeanCone(s.dimension)
+dual_set_type(::Type{GeometricMeanCone}) = DualGeometricMeanCone
+
+"""
+    DualGeometricMeanCone(dimension::Int)
+
+The dual geometric mean cone
+``\\{ (u, v) \\in \\mathbb{R}^{n+1} : v \\ge 0, 0 \\ge u \\ge -n \\sqrt[n]{\\prod_i v_i} \\}``,
+where `dimension = n + 1 >= 2`.
+
+## Example
+
+```jldoctest
+julia> model = MOI.Utilities.Model{Float64}();
+
+julia> t = MOI.add_variable(model)
+MOI.VariableIndex(1)
+
+julia> x = MOI.add_variables(model, 3);
+
+julia> MOI.add_constraint(
+           model,
+           MOI.VectorOfVariables([t; x]),
+           MOI.DualGeometricMeanCone(4),
+       )
+MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInterface.DualGeometricMean/Cone}(1)
+```
+"""
+struct DualGeometricMeanCone <: AbstractVectorSet
+    dimension::Int
+    function DualGeometricMeanCone(dimension::Base.Integer)
+        if !(dimension >= 2)
+            throw(
+                DimensionMismatch(
+                    "Dimension of DualGeometricMeanCone must be >= 2, not " *
+                    "$(dimension).",
+                ),
+            )
+        end
+        return new(dimension)
+    end
+end
+
+dual_set(s::DualGeometricMeanCone) = GeometricMeanCone(s.dimension)
+dual_set_type(::Type{DualGeometricMeanCone}) = GeometricMeanCone
 
 """
     ExponentialCone()

--- a/test/Bridges/Constraint/test_DualGeoMeanBridge.jl
+++ b/test/Bridges/Constraint/test_DualGeoMeanBridge.jl
@@ -1,0 +1,191 @@
+# Copyright (c) 2017: Miles Lubin and contributors
+# Copyright (c) 2017: Google Inc.
+#
+# Use of this source code is governed by an MIT-style license that can be found
+# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+
+module TestConstraintDualGeoMean
+
+using Test
+
+import MathOptInterface as MOI
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+include("../utilities.jl")
+
+function test_DualGeoMean()
+    mock = MOI.Utilities.MockOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+    )
+    config = MOI.Test.Config()
+    bridged_mock = MOI.Bridges.Constraint.DualGeoMean{Float64}(mock)
+    MOI.Test.test_basic_VectorOfVariables_DualGeometricMeanCone(
+        bridged_mock,
+        config,
+    )
+    MOI.empty!(bridged_mock)
+    MOI.Test.test_basic_VectorAffineFunction_DualGeometricMeanCone(
+        bridged_mock,
+        config,
+    )
+    MOI.empty!(bridged_mock)
+    MOI.Test.test_basic_VectorQuadraticFunction_DualGeometricMeanCone(
+        bridged_mock,
+        config,
+    )
+    return
+end
+
+function test_conic_DualGeometricMeanCone_VectorAffineFunction()
+    mock = MOI.Utilities.MockOptimizer(
+        MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+    )
+    config = MOI.Test.Config()
+    bridged_mock = MOI.Bridges.Constraint.DualGeoMean{Float64}(mock)
+    var_primal = [-3, 1, 1, 1]
+    geomean_dual = copy(var_primal)
+    mock.optimize! =
+        (mock::MOI.Utilities.MockOptimizer) -> MOI.Utilities.mock_optimize!(
+            mock,
+            var_primal,
+            (MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}) =>
+                [-1],
+            (MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives) => [[0]],
+            (MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone) =>
+                [geomean_dual],
+        )
+
+    MOI.Test.test_conic_DualGeometricMeanCone_VectorAffineFunction(
+        bridged_mock,
+        config,
+    )
+    var_names = ["t", "x", "y", "z"]
+    MOI.set(
+        bridged_mock,
+        MOI.VariableName(),
+        MOI.get(bridged_mock, MOI.ListOfVariableIndices()),
+        var_names,
+    )
+    nonneg = MOI.get(
+        mock,
+        MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}(),
+    )
+    geomean = MOI.get(
+        mock,
+        MOI.ListOfConstraintIndices{
+            MOI.VectorAffineFunction{Float64},
+            MOI.GeometricMeanCone,
+        }(),
+    )
+    @test length(nonneg) == 1
+    MOI.set(mock, MOI.ConstraintName(), nonneg[1], "nonneg")
+    @test length(geomean) == 1
+    MOI.set(mock, MOI.ConstraintName(), geomean[1], "geomean")
+    less = MOI.get(
+        mock,
+        MOI.ListOfConstraintIndices{
+            MOI.ScalarAffineFunction{Float64},
+            MOI.LessThan{Float64},
+        }(),
+    )
+    @test length(less) == 1
+    MOI.set(mock, MOI.ConstraintName(), less[1], "less")
+
+    s = """
+    variables: t, x, y, z
+    less: x + y + z in LessThan(3.0)
+    nonneg: [-1 * t] in Nonnegatives(1)
+    geomean: [-1/3 * t, x, y, z] in GeometricMeanCone(4)
+    minobjective: t
+    """
+    model = MOI.Utilities.Model{Float64}()
+    MOI.Utilities.loadfromstring!(model, s)
+    MOI.Test.util_test_models_equal(
+        mock,
+        model,
+        var_names,
+        ["less", "nonneg", "geomean"],
+    )
+    dualgeomean = MOI.get(
+        bridged_mock,
+        MOI.ListOfConstraintIndices{
+            MOI.VectorAffineFunction{Float64},
+            MOI.DualGeometricMeanCone,
+        }(),
+    )
+    @test length(dualgeomean) == 1
+    MOI.set(bridged_mock, MOI.ConstraintName(), dualgeomean[1], "dualgeomean")
+    less = MOI.get(
+        bridged_mock,
+        MOI.ListOfConstraintIndices{
+            MOI.ScalarAffineFunction{Float64},
+            MOI.LessThan{Float64},
+        }(),
+    )
+    @test length(less) == 1
+    MOI.set(bridged_mock, MOI.ConstraintName(), less[1], "less")
+
+    s = """
+    variables: t, x, y, z
+    less: x + y + z in LessThan(3.0)
+    dualgeomean: [1.0t, x, y, z] in DualGeometricMeanCone(4)
+    minobjective: t
+    """
+    model = MOI.Utilities.Model{Float64}()
+    MOI.Utilities.loadfromstring!(model, s)
+    MOI.Test.util_test_models_equal(
+        bridged_mock,
+        model,
+        var_names,
+        ["less", "dualgeomean"],
+    )
+    ci = first(
+        MOI.get(
+            bridged_mock,
+            MOI.ListOfConstraintIndices{
+                MOI.VectorAffineFunction{Float64},
+                MOI.DualGeometricMeanCone,
+            }(),
+        ),
+    )
+    _test_delete_bridge(
+        bridged_mock,
+        ci,
+        4,
+        (
+            (MOI.VectorAffineFunction{Float64}, MOI.Nonnegatives, 0),
+            (MOI.VectorAffineFunction{Float64}, MOI.GeometricMeanCone, 0),
+        ),
+    )
+    return
+end
+
+function test_runtests()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.DualGeoMeanBridge,
+        """
+        variables: u, w1, w2
+        [u, w1, w2] in DualGeometricMeanCone(3)
+        """,
+        """
+        variables: u, w1, w2
+        [-1/2 * u, w1, w2] in GeometricMeanCone(3)
+        [-1 * u] in Nonnegatives(1)
+        """,
+    )
+    return
+end
+
+end  # module
+
+TestConstraintDualGeoMean.runtests()

--- a/test/Bridges/Constraint/test_DualGeoMeanBridge.jl
+++ b/test/Bridges/Constraint/test_DualGeoMeanBridge.jl
@@ -78,7 +78,10 @@ function test_conic_DualGeometricMeanCone_VectorAffineFunction()
     )
     nonneg = MOI.get(
         mock,
-        MOI.ListOfConstraintIndices{MOI.VectorAffineFunction{Float64},MOI.Nonnegatives}(),
+        MOI.ListOfConstraintIndices{
+            MOI.VectorAffineFunction{Float64},
+            MOI.Nonnegatives,
+        }(),
     )
     geomean = MOI.get(
         mock,

--- a/test/General/test_sets.jl
+++ b/test/General/test_sets.jl
@@ -137,6 +137,7 @@ function test_sets_DimensionMismatch()
         (MOI.SecondOrderCone, 1),
         (MOI.RotatedSecondOrderCone, 2),
         (MOI.GeometricMeanCone, 2),
+        (MOI.DualGeometricMeanCone, 2),
         (MOI.Complements, 0),
         (MOI.RelativeEntropyCone, 1),
         (MOI.ScaledPositiveSemidefiniteConeTriangle, 0),
@@ -283,6 +284,16 @@ function test_sets_dual_psdtriangle()
         MOI.Scaled(MOI.HermitianPositiveSemidefiniteConeTriangle(2)),
         MOI.Scaled(MOI.HermitianPositiveSemidefiniteConeTriangle(3)),
     )
+    return
+end
+
+function test_sets_dual_geometric()
+    geo = MOI.GeometricMeanCone(4)
+    dual_geo = MOI.DualGeometricMeanCone(4)
+    _dual_set_test(geo, dual_geo)
+    @test MOI.dual_set(geo) != geo
+    _dual_set_test(dual_geo, geo)
+    @test MOI.dual_set(dual_geo) != dual_geo
     return
 end
 

--- a/test/Utilities/test_distance_to_set.jl
+++ b/test/Utilities/test_distance_to_set.jl
@@ -199,6 +199,19 @@ function test_geometricmeancone()
     return
 end
 
+function test_dualgeometricmeancone()
+    _test_set(
+        MOI.DualGeometricMeanCone(3),
+        [-2.0, 1.0, 1.0] => 0.0,
+        [3.0, 1.0, 2.0] => 3.0,
+        [-3.0, 1.0, 2.0] => 3.0 - 2sqrt(2),
+        [1.5, -1.0, 2.0] => sqrt(1 + 1.5^2),
+        [-1.5, -1.0, 2.0] => sqrt(1 + 1.5^2);
+        mismatch = [1.0],
+    )
+    return
+end
+
 function test_powercone()
     _test_set(
         MOI.PowerCone(0.5),


### PR DESCRIPTION
Part of #3037

I've added the set, related tests, and the bridge. Still missing are the bridge tests; I'm submitting the PR prematurely because it's already getting big and I'm getting nervous about losing stuff.

I also didn't add support in the file format, I don't know if that's desired.

## Basic

 - [x] Add a new `AbstractScalarSet` or `AbstractVectorSet` to `src/sets.jl`
 - [x] If `isbitstype(S) == false`, implement `Base.copy(set::S)`
 - [x] If `isbitstype(S) == false`, implement `Base.:(==)(x::S, y::S)`
 - [x] If an `AbstractVectorSet`, implement `dimension(set::S)`, unless the
       dimension is given by `set.dimension`.
 - [x] Ensure the set does not contain references to any variables or constraints

## Utilities

 - [x] If an `AbstractVectorSet`, implement `Utilities.set_dot`,
       unless the dot product between two vectors in the set is equivalent to
       `LinearAlgebra.dot`
 - [x] If an `AbstractVectorSet`, implement `Utilities.set_with_dimension` in
       `src/Utilities/matrix_of_constraints.jl`
 - [x] Add the set to the `@model` macro at the bottom of `src/Utilities.model.jl`

## Documentation

 - [x] Add a docstring, which gives the mathematical definition of the set,
       along with an `## Example` block containing a `jldoctest`
 - [x] Add the docstring to `docs/src/reference/standard_form.md`
 - [x] Add the set to the relevant table in `docs/src/manual/standard_form.md`

## Tests

 - [x] Define a new `_set(::Type{S})` method in `src/Test/test_basic_constraint.jl`
       and add the name of the set to the list at the bottom of that files
 - [x] If the set has any checks in its constructor, add tests to `test/sets.jl`

## MathOptFormat

 - [x] Open an issue at `https://github.com/jump-dev/MathOptFormat` to add
       support for the new set https://github.com/jump-dev/MathOptFormat/issues/37

## Optional

 - [x] Implement `dual_set(::S)` and `dual_set_type(::Type{S})`
 - [x] Add new tests to the `Test` submodule exercising your new set
 - [x] Add new bridges to convert your set into more commonly used sets