### PR TITLE
 [Bridges] fix ConstraintPrimal for GeoMeanBridge

### DIFF
--- a/src/Bridges/Constraint/bridges/GeoMeanBridge.jl
+++ b/src/Bridges/Constraint/bridges/GeoMeanBridge.jl
@@ -374,7 +374,7 @@ function MOI.get(
             MOI.get(model, _variable_attribute(attr), bridge.xij[1]) / sqrt(N)
     end
     set = MOI.get(model, MOI.ConstraintSet(), bridge.t_upper_bound_constraint)
-    output[1] += MOI.constant(set)
+    output[1] -= MOI.constant(set)
     return output
 end
 
@@ -387,7 +387,7 @@ function MOI.set(
     set = MOI.get(model, MOI.ConstraintSet(), bridge.t_upper_bound_constraint)
     t_constant = MOI.constant(set)
     if bridge.d == 2
-        new_value = value[1] - value[2] - t_constant
+        new_value = value[1] - value[2] + t_constant
         MOI.set(model, attr, bridge.t_upper_bound_constraint, new_value)
         MOI.set(model, attr, bridge.x_nonnegative_constraint, [value[2]])
         return
@@ -404,7 +404,7 @@ function MOI.set(
         model,
         attr,
         bridge.t_upper_bound_constraint,
-        value[1] - sN * xl1 - t_constant,
+        value[1] - sN * xl1 + t_constant,
     )
     offset = length(bridge.rsoc_constraints)
     for i in l:-1:1

--- a/test/Bridges/Constraint/test_GeoMeanBridge.jl
+++ b/test/Bridges/Constraint/test_GeoMeanBridge.jl
@@ -631,6 +631,26 @@ function test_with_constant_d4()
     return
 end
 
+function test_constraint_primal()
+    inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    mock = MOI.Utilities.MockOptimizer(inner)
+    model = MOI.Bridges.Constraint.GeoMean{Float64}(mock)
+    x = MOI.add_variables(model, 4)
+    a = [0.1, 0.2, 0.3, 0.5]
+    f = MOI.Utilities.vectorize(x .+ a)
+    c = MOI.add_constraint(model, f, MOI.GeometricMeanCone(4))
+    start = [1.81, 1, 2, 3]
+    MOI.set(model, MOI.ConstraintPrimalStart(), c, start)
+    @test isapprox(MOI.get(model, MOI.ConstraintPrimalStart(), c), start)
+    F, S = MOI.ScalarAffineFunction{Float64}, MOI.LessThan{Float64}
+    c_mock = only(MOI.get(mock, MOI.ListOfConstraintIndices{F,S}()))
+    @test isapprox(
+        1.81 - (1 * 2 * 3)^(1/3) - 0.1,
+        MOI.get(mock, MOI.ConstraintPrimalStart(), c_mock),
+    )
+    return
+end
+
 end  # module
 
 TestConstraintGeomean.runtests()


### PR DESCRIPTION
Typically, I got #3056 back-to-front. My sign convention was wrong, but the round trip was correct. I thought I'd tested the original issue, but I guess I hadn't. Here's a test that would actually catch the bug.