### PR TITLE
Clearer error message with constrained variables in VectorOfVariables

### DIFF
--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -468,6 +468,29 @@ end
 
 function substitute_variables(
     variable_map::F,
+    f::MOI.VectorOfVariables,
+) where {F<:Function}
+    variables = MOI.VariableIndex[]
+    for variable in f.variables
+        mapped_variable = variable_map(variable)
+        try
+            push!(variables, convert(MOI.VariableIndex, mapped_variable))
+        catch err
+            @assert err isa InexactError
+            error(
+                "Cannot substitute `VectorOfVariables`: variable `$variable` is mapped " *
+                "to `$mapped_variable`, not directly to another variable. Variables " *
+                "constrained on creation can be used in a `VectorOfVariables` function " *
+                "only when their bridge maps each one directly to another variable, " *
+                "without a transformation.",
+            )
+        end
+    end
+    return MOI.VectorOfVariables(variables)
+end
+
+function substitute_variables(
+    variable_map::F,
     term::MOI.ScalarAffineTerm{T},
 ) where {T,F<:Function}
     # We could have `T = Complex{Float64}` and `variable_map(term.variable)`

--- a/src/Utilities/functions.jl
+++ b/src/Utilities/functions.jl
@@ -468,29 +468,6 @@ end
 
 function substitute_variables(
     variable_map::F,
-    f::MOI.VectorOfVariables,
-) where {F<:Function}
-    variables = MOI.VariableIndex[]
-    for variable in f.variables
-        mapped_variable = variable_map(variable)
-        try
-            push!(variables, convert(MOI.VariableIndex, mapped_variable))
-        catch err
-            @assert err isa InexactError
-            error(
-                "Cannot substitute `VectorOfVariables`: variable `$variable` is mapped " *
-                "to `$mapped_variable`, not directly to another variable. Variables " *
-                "constrained on creation can be used in a `VectorOfVariables` function " *
-                "only when their bridge maps each one directly to another variable, " *
-                "without a transformation.",
-            )
-        end
-    end
-    return MOI.VectorOfVariables(variables)
-end
-
-function substitute_variables(
-    variable_map::F,
     term::MOI.ScalarAffineTerm{T},
 ) where {T,F<:Function}
     # We could have `T = Complex{Float64}` and `variable_map(term.variable)`
@@ -564,6 +541,36 @@ function substitute_variables(
         end
     end
     return MOI.ScalarNonlinearFunction(f.head, new_args)
+end
+
+function substitute_variables(
+    variable_map::F,
+    f::MOI.VectorOfVariables,
+) where {F<:Function}
+    variables = MOI.VariableIndex[]
+    for (i, x) in enumerate(f.variables)
+        y = variable_map(x)
+        try
+            push!(variables, convert(MOI.VariableIndex, y))
+        catch err
+            @assert err isa InexactError
+            error(
+                """
+                Cannot substitute variables in the `VectorOfVariables` \
+                function because the result is not representable as a \
+                `VectorOfVariables` function.
+
+                The variable `$x` in index `$i` is mapped to the expression \
+                `$y`, not directly to another `VariableIndex`.
+
+                Note that variables constrained on creation can be used in a \
+                `VectorOfVariables` function only when their bridge maps each \
+                one directly to another variable, without a transformation.
+                """,
+            )
+        end
+    end
+    return MOI.VectorOfVariables(variables)
 end
 
 function substitute_variables(

--- a/test/Utilities/test_functions.jl
+++ b/test/Utilities/test_functions.jl
@@ -329,19 +329,32 @@ function test_substitute_variables()
     int_quad = 3 * y * x
     @test MOI.Utilities.substitute_variables(vi -> true * y, int_quad) ≈
           3 * y * y
+    return
+end
 
-    vector_of_variables = MOI.VectorOfVariables([w, x])
-    @test MOI.Utilities.substitute_variables(
-        vi -> Dict(w => y, x => z)[vi],
-        vector_of_variables,
-    ) == MOI.VectorOfVariables([y, z])
-    err = try
-        MOI.Utilities.substitute_variables(vi -> 2.0 * vi, vector_of_variables)
-    catch err
-        err
-    end
-    @test err isa ErrorException
-    @test occursin("Variables constrained on creation", sprint(showerror, err))
+function test_substitute_variables_vector_of_variables()
+    w, x, y, z = MOI.VariableIndex.(1:4)
+    f1 = MOI.VectorOfVariables([w, x])
+    f2 = MOI.VectorOfVariables([y, z])
+    v_map = Dict(w => y, x => z)
+    @test MOI.Utilities.substitute_variables(v -> v_map[v], f1) == f2
+    @test_throws(
+        ErrorException(
+            """
+            Cannot substitute variables in the `VectorOfVariables` function \
+            because the result is not representable as a `VectorOfVariables` \
+            function.
+
+            The variable `$w` in index `1` is mapped to the expression \
+            `$(2.0 * w)`, not directly to another `VariableIndex`.
+
+            Note that variables constrained on creation can be used in a \
+            `VectorOfVariables` function only when their bridge maps each \
+            one directly to another variable, without a transformation.
+            """,
+        ),
+        MOI.Utilities.substitute_variables(vi -> 2.0 * vi, f1),
+    )
     return
 end
 

--- a/test/Utilities/test_functions.jl
+++ b/test/Utilities/test_functions.jl
@@ -329,6 +329,19 @@ function test_substitute_variables()
     int_quad = 3 * y * x
     @test MOI.Utilities.substitute_variables(vi -> true * y, int_quad) ≈
           3 * y * y
+
+    vector_of_variables = MOI.VectorOfVariables([w, x])
+    @test MOI.Utilities.substitute_variables(
+        vi -> Dict(w => y, x => z)[vi],
+        vector_of_variables,
+    ) == MOI.VectorOfVariables([y, z])
+    err = try
+        MOI.Utilities.substitute_variables(vi -> 2.0 * vi, vector_of_variables)
+    catch err
+        err
+    end
+    @test err isa ErrorException
+    @test occursin("Variables constrained on creation", sprint(showerror, err))
     return
 end
 


### PR DESCRIPTION
When there was a variable constrained at creation in a `VectorOfVariables` constraint, it was just throwing a `MethodError`. Now we have a clearer error.
The reason we error is that we want to keep the `VectorOfVariables` type. If a variable is mapped to a variable, we can actually make it work. It is useful for https://github.com/NexOR-Optimization/MathOptVRP.jl/blob/0fc70cc2176767472aad8643c2e2c8f66e5cd00e/src/Bridges/PermutationToPartitionBridge.jl#L17 which mapped variables to other variables without transformation.
Also for https://github.com/jump-dev/MathOptInterface.jl/blob/9bddcb7e7bfe9c8e7c68e25a464355d130fee899/src/Bridges/Variable/bridges/VectorizeBridge.jl#L37 if the constant is zero.