### PR TITLE
increase cost of DualGeoMeanBridge and DualRelativeEntropyBridge

### DIFF
--- a/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
+++ b/src/Bridges/Constraint/bridges/DualGeoMeanBridge.jl
@@ -33,6 +33,9 @@ end
 const DualGeoMean{T,OT<:MOI.ModelLike} =
     SingleBridgeOptimizer{DualGeoMeanBridge{T},OT}
 
+#prevent bridge from being used instead of FunctionConversionBridge
+MOI.Bridges.bridging_cost(::Type{<:DualGeoMeanBridge}) = 2.0
+
 function bridge_constraint(
     ::Type{DualGeoMeanBridge{T,G,H}},
     model::MOI.ModelLike,

--- a/src/Bridges/Constraint/bridges/DualRelativeEntropyBridge.jl
+++ b/src/Bridges/Constraint/bridges/DualRelativeEntropyBridge.jl
@@ -32,6 +32,9 @@ end
 const DualRelativeEntropy{T,OT<:MOI.ModelLike} =
     SingleBridgeOptimizer{DualRelativeEntropyBridge{T},OT}
 
+#prevent bridge from being used instead of FunctionConversionBridge
+MOI.Bridges.bridging_cost(::Type{<:DualRelativeEntropyBridge}) = 2.0
+
 function bridge_constraint(
     ::Type{DualRelativeEntropyBridge{T,F,G}},
     model::MOI.ModelLike,


### PR DESCRIPTION
Otherwise Hypatia uses them instead of FunctionConversionBridge and the supported cones DualGeometricMeanCone and DualRelativeEntropyCones, which is much less efficient.

The reason is that they generate `VectorAffineFunction` constraints, which Hypatia supports directly.

In constrast, Hypatia doesn't use GeoMeanBridge and RelativeEntropyBridge because they introduce VectorOfVariables constraints, which would need a FunctionConversionBridge anyway.

Another possibility would be to reduce the cost of transforming `VectorOfVariables` into `VectorAffineFunction`, for example by doing
```julia
function conversion_cost(
    ::Type{<:MOI.ScalarAffineFunction},
    ::Type{MOI.VariableIndex},
)
    return 0.9
end
```
That works, but I don't know if it has undesirable consequences.