### PR TITLE
[Test] allow infeasible problems to also return INFEASIBLE_OR_UNBOUNDED

### DIFF
--- a/src/Test/test_conic.jl
+++ b/src/Test/test_conic.jl
@@ -904,8 +904,8 @@ function test_conic_NormInfinityCone_INFEASIBLE(
     if _supports(config, MOI.optimize!)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) ==
-              config.infeasible_status
+        @test MOI.get(model, MOI.TerminationStatus()) in
+              (config.infeasible_status, MOI.INFEASIBLE_OR_UNBOUNDED)
         @test MOI.get(model, MOI.PrimalStatus()) in
               (MOI.NO_SOLUTION, MOI.INFEASIBLE_POINT)
         # TODO test dual feasibility and objective sign
@@ -1331,8 +1331,8 @@ function test_conic_NormOneCone_INFEASIBLE(
     if _supports(config, MOI.optimize!)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) ==
-              config.infeasible_status
+        @test MOI.get(model, MOI.TerminationStatus()) in
+              (config.infeasible_status, MOI.INFEASIBLE_OR_UNBOUNDED)
         @test MOI.get(model, MOI.PrimalStatus()) in
               (MOI.NO_SOLUTION, MOI.INFEASIBLE_POINT)
         # TODO test dual feasibility and objective sign
@@ -1973,8 +1973,8 @@ function test_conic_SecondOrderCone_INFEASIBLE(
     if _supports(config, MOI.optimize!)
         @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
         MOI.optimize!(model)
-        @test MOI.get(model, MOI.TerminationStatus()) ==
-              config.infeasible_status
+        @test MOI.get(model, MOI.TerminationStatus()) in
+              (config.infeasible_status, MOI.INFEASIBLE_OR_UNBOUNDED)
         @test MOI.get(model, MOI.PrimalStatus()) in
               (MOI.NO_SOLUTION, MOI.INFEASIBLE_POINT)
         # TODO test dual feasibility and objective sign


### PR DESCRIPTION
Cbc returns INFEASIBLE_OR_UNBOUNDED here, which is reasonable: https://github.com/jump-dev/Cbc.jl/blob/43e5ecccdccee10a0ac2e5c8566330ce1910b2c7/test/MOI_wrapper.jl#L49-L51

There are already a bunch of other tests with a similar check:

https://github.com/jump-dev/MathOptInterface.jl/blob/9005adfdfa9c250bc18364590461bb892da1718b/src/Test/test_conic.jl#L503-L509