### PR TITLE
[Bridges] fix SquareBridge with differing constants in off-diagonal

### DIFF
--- a/src/Bridges/Constraint/bridges/SquareBridge.jl
+++ b/src/Bridges/Constraint/bridges/SquareBridge.jl
@@ -267,7 +267,7 @@ function MOI.get(
         f_ji = MOI.Utilities.operate(-, T, f[offset+i+(j-1)*dim], diff)
         # But we need to account for the constant moved into the set
         rhs = MOI.constant(MOI.get(model, MOI.ConstraintSet(), ci))
-        f_ji = MOI.Utilities.operate!(-, T, f_ji, rhs)
+        f_ji = MOI.Utilities.operate!(+, T, f_ji, rhs)
         f[offset+j+(i-1)*dim] = MOI.Utilities.convert_approx(eltype(f), f_ji)
     end
     return MOI.Utilities.vectorize(f)

--- a/src/Bridges/Constraint/bridges/SquareBridge.jl
+++ b/src/Bridges/Constraint/bridges/SquareBridge.jl
@@ -320,7 +320,7 @@ function MOI.get(
         primal[offset+i+(j-1)*dim] = primal[offset+j+(i-1)*dim] = value[k]
     end
     for ((i, j), ci) in bridge.sym
-        primal[offset+i+(j-1)*dim] += MOI.get(model, attr, ci)
+        primal[offset+j+(i-1)*dim] -= MOI.get(model, attr, ci)
     end
     return primal
 end
@@ -341,7 +341,7 @@ function MOI.set(
     k = offset
     for j in 1:dim, i in 1:j
         k += 1
-        primal[k] = value[offset+j+(i-1)*dim]
+        primal[k] = value[offset+i+(j-1)*dim]
     end
     MOI.set(model, attr, bridge.triangle, primal)
     for ((i, j), ci) in bridge.sym

--- a/test/Bridges/Constraint/test_SquareBridge.jl
+++ b/test/Bridges/Constraint/test_SquareBridge.jl
@@ -330,6 +330,24 @@ function test_square_bridge_with_constant()
     return
 end
 
+function test_constraint_primal_start()
+    inner = MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}())
+    model = MOI.Bridges.Constraint.Square{Float64}(inner)
+    x = MOI.add_variables(model, 4)
+    f = MOI.Utilities.vectorize(1.0 .* x .+ (1.0:4.0))
+    ci = MOI.add_constraint(model, f, MOI.PositiveSemidefiniteConeSquare(2))
+    bridge = MOI.Bridges.bridge(model, ci)
+    start = [11.0, 21.0, 12.0, 22.0]
+    MOI.set(model, MOI.ConstraintPrimalStart(), ci, start)
+    @test isapprox(
+        MOI.get(inner, MOI.ConstraintPrimalStart(), bridge.triangle),
+        [11.0, 12.0, 22.0]
+    )
+    @test ≈(MOI.get(inner, MOI.ConstraintPrimalStart(), bridge.sym[1][2]), -9.0)
+    @test ≈(MOI.get(model, MOI.ConstraintFunction(), ci), f)
+    return
+end
+
 end  # module
 
 TestConstraintSquare.runtests()

--- a/test/Bridges/Constraint/test_SquareBridge.jl
+++ b/test/Bridges/Constraint/test_SquareBridge.jl
@@ -341,7 +341,7 @@ function test_constraint_primal_start()
     MOI.set(model, MOI.ConstraintPrimalStart(), ci, start)
     @test isapprox(
         MOI.get(inner, MOI.ConstraintPrimalStart(), bridge.triangle),
-        [11.0, 12.0, 22.0]
+        [11.0, 12.0, 22.0],
     )
     @test ≈(MOI.get(inner, MOI.ConstraintPrimalStart(), bridge.sym[1][2]), -9.0)
     @test ≈(MOI.get(model, MOI.ConstraintFunction(), ci), f)

--- a/test/Bridges/Constraint/test_SquareBridge.jl
+++ b/test/Bridges/Constraint/test_SquareBridge.jl
@@ -314,6 +314,22 @@ function test_VectorNonlinearFunction_mixed_type()
     return
 end
 
+function test_square_bridge_with_constant()
+    MOI.Bridges.runtests(
+        MOI.Bridges.Constraint.SquareBridge,
+        """
+        variables: x11, x21, x12, x22
+        [x11 + 1.0, x21 + 2.0, x12 + 3.0, x22 + 4.0] in PositiveSemidefiniteConeSquare(2)
+        """,
+        """
+        variables: x11, x21, x12, x22
+        [x11 + 1.0, x12 + 3.0, x22 + 4.0] in PositiveSemidefiniteConeTriangle(2)
+        x12 + -1.0 * x21 == -1.0
+        """,
+    )
+    return
+end
+
 end  # module
 
 TestConstraintSquare.runtests()


### PR DESCRIPTION
# `SquareBridge` `ConstraintFunction` getter has a sign error when a symmetrization constraint has a nonzero constant

`src/Bridges/Constraint/bridges/SquareBridge.jl`, `MOI.get(::MOI.ModelLike, ::MOI.ConstraintFunction, ::SquareBridge)`, line 270.

When entries `(i, j)` and `(j, i)` of the square matrix differ by a nonzero
constant `c` (e.g. `f_ij = 3 + x`, `f_ji = 2 + x`), `bridge_constraint` adds a
constraint `(f_ij - f_ji) - c == -c` (the constant is moved into the set by
`normalize_and_add_constraint`). When reconstructing `f_ji` in the
`ConstraintFunction` getter, the code subtracts `rhs` a second time instead of
adding it back, so the recovered `f_ji` is off by `2c`.

Repro (`c = 1`):
```julia
inner = MOI.Utilities.Model{Float64}()
model = MOI.Bridges.Constraint.Square{Float64}(inner)
x = MOI.add_variable(model)
y = MOI.add_variable(model)
f = MOI.Utilities.operate(vcat, Float64, 1.0x .+ 1.0, 1.0x .+ 2.0, 1.0x .+ 3.0, 2.0y)
ci = MOI.add_constraint(model, f, MOI.PositiveSemidefiniteConeSquare(2))
MOI.get(model, MOI.ConstraintFunction(), ci)
# entry (2,1) comes back as `4 + x` instead of the original `2 + x`
```

This only shows up when the off-diagonal expressions differ by a nonzero
constant (e.g. `1 + x` vs `2 + x`); the common case of numerically-identical
or purely-linear-difference-with-zero-constant entries doesn't trigger it,
which is presumably why the existing test suite (`test/Bridges/Constraint/test_SquareBridge.jl`)
didn't catch it.

## Fix

Add `rhs` instead of subtracting it:

```julia
f_ji = MOI.Utilities.operate!(+, T, f_ji, rhs)
```

See `issue-001.patch`. Verified: the repro above returns the original
function exactly after the fix, and `test/Bridges/Constraint/test_SquareBridge.jl`
still passes in full (all testsets, 367 `@test`s total).

Note: `issue-003.patch` touches a different hunk of the same file
(`SquareBridge.jl`, the `ConstraintPrimal`/`ConstraintPrimalStart` getter and
setter rather than the `ConstraintFunction` getter); they're independent
fixes and both apply cleanly together.