### PR TITLE
Enforce dimension > 0 for SOS1 and SOS2

### DIFF
--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1853,7 +1853,7 @@ MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInte
 struct SOS1{T<:Real} <: AbstractVectorSet
     weights::Vector{T}
 
-   function SOS1{T}(weights::Vector{T}) where {T<:Real}
+    function SOS1{T}(weights::Vector{T}) where {T<:Real}
         if isempty(weights)
             throw(DimensionMismatch("Dimension of SOS1 must be > 0."))
         end

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1852,7 +1852,18 @@ MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInte
 """
 struct SOS1{T<:Real} <: AbstractVectorSet
     weights::Vector{T}
+
+   function SOS1{T}(weights::Vector{T}) where {T<:Real}
+        if isempty(weights)
+            throw(DimensionMismatch("Dimension of SOS1 must be > 0."))
+        end
+        return new{T}(weights)
+    end
 end
+
+SOS1(w::AbstractVector{T}) where {T<:Real} = SOS1{T}(w)
+
+SOS1{T}(w::AbstractVector) where {T<:Real} = SOS1{T}(convert(Vector{T}, w))
 
 dimension(set::SOS1) = length(set.weights)
 
@@ -1889,7 +1900,18 @@ MathOptInterface.ConstraintIndex{MathOptInterface.VectorOfVariables, MathOptInte
 """
 struct SOS2{T<:Real} <: AbstractVectorSet
     weights::Vector{T}
+
+    function SOS2{T}(weights::Vector{T}) where {T<:Real}
+        if isempty(weights)
+            throw(DimensionMismatch("Dimension of SOS2 must be > 0."))
+        end
+        return new{T}(weights)
+    end
 end
+
+SOS2(w::AbstractVector{T}) where {T<:Real} = SOS2{T}(w)
+
+SOS2{T}(w::AbstractVector) where {T<:Real} = SOS2{T}(convert(Vector{T}, w))
 
 dimension(set::SOS2) = length(set.weights)
 

--- a/test/General/test_sets.jl
+++ b/test/General/test_sets.jl
@@ -503,6 +503,24 @@ function test_VectorNonlinearOracle()
     return
 end
 
+function test_SOS1_constructor()
+    @test_throws DimensionMismatch MOI.SOS1{Float64}(Float64[])
+    @test_throws DimensionMismatch MOI.SOS1(Float64[])
+    @test_throws DimensionMismatch MOI.SOS1(1:0)
+    @test MOI.SOS1(1:3) == MOI.SOS1{Int}(Int[1, 2, 3])
+    @test MOI.SOS1{Float64}(1:3) == MOI.SOS1{Float64}([1.0, 2.0, 3.0])
+    return
+end
+
+function test_SOS2_constructor()
+    @test_throws DimensionMismatch MOI.SOS2{Float64}(Float64[])
+    @test_throws DimensionMismatch MOI.SOS2(Float64[])
+    @test_throws DimensionMismatch MOI.SOS2(1:0)
+    @test MOI.SOS2(1:3) == MOI.SOS2{Int}(Int[1, 2, 3])
+    @test MOI.SOS2{Float64}(1:3) == MOI.SOS2{Float64}([1.0, 2.0, 3.0])
+    return
+end
+
 end  # module
 
 TestSets.runtests()


### PR DESCRIPTION
Closes #3074

I probably need to run solver tests because this could arguably be breaking. But equally. Why would anyone do this.

https://github.com/jump-dev/MathOptInterface.jl/actions/runs/34176516796